### PR TITLE
Better printing of time durations.

### DIFF
--- a/cmd/ddns.go
+++ b/cmd/ddns.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/favonia/cloudflare-ddns-go/internal/api"
 	"github.com/favonia/cloudflare-ddns-go/internal/config"
+	"github.com/favonia/cloudflare-ddns-go/internal/cron"
 	"github.com/favonia/cloudflare-ddns-go/internal/quiet"
 )
 
@@ -281,9 +282,9 @@ mainLoop:
 
 		if !c.Quiet {
 			if first {
-				log.Printf("😴 Checking the IP addresses in %v . . .", interval)
+				log.Printf("😴 Checking the IP addresses in %v . . .", cron.PPDuration(interval))
 			} else {
-				log.Printf("😴 Checking the IP addresses again in %v . . .", interval)
+				log.Printf("😴 Checking the IP addresses again in %v . . .", cron.PPDuration(interval))
 			}
 		}
 		if sig := wait(chanSignal, interval); sig == nil {

--- a/internal/cron/printer.go
+++ b/internal/cron/printer.go
@@ -1,0 +1,14 @@
+package cron
+
+import (
+	"fmt"
+	"time"
+)
+
+func PPDuration(d time.Duration) string {
+	if d < time.Second {
+		return "less than 1s"
+	}
+
+	return fmt.Sprintf("about %v", d.Round(time.Second))
+}

--- a/internal/cron/schedule.go
+++ b/internal/cron/schedule.go
@@ -4,7 +4,7 @@ import (
 	"log"
 	"time"
 
-	c "github.com/robfig/cron/v3"
+	"github.com/robfig/cron/v3"
 )
 
 type Schedule = interface {
@@ -14,11 +14,11 @@ type Schedule = interface {
 
 type Cron struct {
 	spec     string
-	schedule c.Schedule
+	schedule cron.Schedule
 }
 
 func New(spec string) (*Cron, error) {
-	sche, err := c.ParseStandard(spec)
+	sche, err := cron.ParseStandard(spec)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Time durations such as  `1.938284s` would be printed as `about 2s`.