### PR TITLE
ci(docker): enable caching

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -20,6 +20,8 @@ jobs:
             type=edge
             type=semver,pattern={{version}}
       - uses: docker/setup-buildx-action@v1
+        with:
+          version: latest
       - uses: docker/login-action@v1
         if: ${{ github.event_name != 'pull_request' }}
         with:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -35,3 +35,5 @@ jobs:
           platforms: linux/386,linux/arm/v6,linux/arm/v7,linux/arm64/v8,linux/amd64,linux/ppc64le,linux/s390x
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -20,8 +20,6 @@ jobs:
             type=edge
             type=semver,pattern={{version}}
       - uses: docker/setup-buildx-action@v1
-        with:
-          version: latest
       - uses: docker/login-action@v1
         if: ${{ github.event_name != 'pull_request' }}
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,8 +7,11 @@ RUN \
   apk update && \
   apk add --no-cache git ca-certificates && \
   update-ca-certificates
-WORKDIR $GOPATH/src/github.com/favonia/cloudflare-ddns-go/
-COPY . .
+WORKDIR "/src/"
+COPY ["go.mod", "go.mod"]
+COPY ["go.sum", "go.sum"]
+COPY ["internal", "internal"]
+COPY ["cmd", "cmd"]
 RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} GOARM=${TARGETVARIANT#v} go build -tags timetzdata -o /bin/ddns -ldflags="-w -s -X main.Version=${GIT_DESCRIBE}" cmd/*.go
 
 FROM scratch


### PR DESCRIPTION
Needs Docker-Buildx 0.6.0. Blocked by actions/virtual-environments/pull/3792.