### PR TITLE
test: use testing/fstest from std lib instead of spf13/afero

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -44,10 +44,8 @@ By default, public IP addresses are obtained using [CloudFlare via DNS-over-HTTP
 The updater honors `PGID` and `PUID` and will drop Linux capabilities (divided superuser privileges).
 </details>
 
-<details><summary>🔌 The source code depends on six external libraries (outside the Go project).</summary>
+<details><summary>🔌 The source code depends on five external libraries (outside the Go project).</summary>
 
-- [afero](https://github.com/spf13/afero):\
-  A file system abstraction layer that enables testing.
 - [cap](https://sites.google.com/site/fullycapable):\
   Manipulation of Linux capabilities.
 - [cloudflare-go](https://github.com/cloudflare/cloudflare-go):\

--- a/internal/file/file.go
+++ b/internal/file/file.go
@@ -2,16 +2,16 @@ package file
 
 import (
 	"bytes"
-
-	"github.com/spf13/afero"
+	"io/fs"
+	"os"
 
 	"github.com/favonia/cloudflare-ddns-go/internal/pp"
 )
 
-var FS = afero.NewOsFs() //nolint:gochecknoglobals
+var FS = os.DirFS("/") //nolint:gochecknoglobals
 
 func ReadString(indent pp.Indent, path string) (string, bool) {
-	body, err := afero.ReadFile(FS, path)
+	body, err := fs.ReadFile(FS, path)
 	if err != nil {
 		pp.Printf(indent, pp.EmojiUserError, "Failed to read %q: %v", path, err)
 		return "", false


### PR DESCRIPTION
Go 1.16 introduced `io/fs` and `testing/fstest` which already satisfy our needs. No need to use any external libraries.