### PR TITLE
ci: disable gha caching b/c GIT_DESCRIBE always invalidates it

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -35,5 +35,3 @@ jobs:
           platforms: linux/386,linux/arm/v6,linux/arm/v7,linux/arm64/v8,linux/amd64,linux/ppc64le,linux/s390x
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha


### PR DESCRIPTION
Disable gha when building Docker images because a changing GIT_DESCRIBE seems to (correctly) invalidate cache every time.