### PR TITLE
fix(api): keep leading dots after the beginning `*` is removed

### DIFF
--- a/internal/api/domain_test.go
+++ b/internal/api/domain_test.go
@@ -93,7 +93,7 @@ func TestNewDomain(t *testing.T) {
 		{"..｡..a.com", f("a.com"), true, ""},
 		{"*.xn--a.xn--a.xn--a.com", w("xn--a.xn--a.xn--a.com"), false, `idna: invalid label "\u0080"`},
 		{"*.a.com...｡", w("a.com"), true, ""},
-		{"*...｡..a.com", w("a.com"), true, ""},
+		{"*...｡..a.com", w(".....a.com"), true, ""},
 		{"*......", w(""), true, ""},
 		{"*｡｡｡｡｡｡", w(""), true, ""},
 	} {


### PR DESCRIPTION
This is to handle some obscure corner cases that probably never show up in reality. Previously, for the domain `*....a.com` the tool will immediately try `a.com` and `com` and so on. Now it would try `...a.com`, `..a.com`, and `.a.com` before `a.com` and `com`.