### PR TITLE
fix(cloudflare): revise the token verification message

### DIFF
--- a/internal/api/cloudflare.go
+++ b/internal/api/cloudflare.go
@@ -47,7 +47,7 @@ func (t *CloudflareAuth) New(ctx context.Context, ppfmt pp.PP, cacheExpiration t
 
 	// this is not needed, but is helpful for diagnosing the problem
 	if _, err := handle.VerifyAPIToken(ctx); err != nil {
-		ppfmt.Errorf(pp.EmojiUserError, "The Cloudflare API token is not valid: %v", err)
+		ppfmt.Errorf(pp.EmojiUserError, "The Cloudflare API token could not be verified: %v", err)
 		ppfmt.Errorf(pp.EmojiUserError, "Please double-check CF_API_TOKEN or CF_API_TOKEN_FILE")
 		return nil, false
 	}

--- a/internal/api/cloudflare_test.go
+++ b/internal/api/cloudflare_test.go
@@ -147,7 +147,7 @@ func TestNewInvalid(t *testing.T) {
 
 	mockPP := mocks.NewMockPP(mockCtrl)
 	gomock.InOrder(
-		mockPP.EXPECT().Errorf(pp.EmojiUserError, "The Cloudflare API token is not valid: %v", gomock.Any()),
+		mockPP.EXPECT().Errorf(pp.EmojiUserError, "The Cloudflare API token could not be verified: %v", gomock.Any()),
 		mockPP.EXPECT().Errorf(pp.EmojiUserError, "Please double-check CF_API_TOKEN or CF_API_TOKEN_FILE"),
 	)
 	h, ok := auth.New(context.Background(), mockPP, time.Second)


### PR DESCRIPTION
Token verification can fail even if the token is valid. For example, maybe the network is simply disconnected.