### PR TITLE
ci: use fetch-depth to streamline tag fetching

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -15,6 +15,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         name: Check out the repository
+        with:
+          fetch-depth: 0
       - uses: docker/setup-buildx-action@v1
         name: Set up Docker Buildx
       - uses: docker/login-action@v1
@@ -23,8 +25,6 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - run: "git fetch --force --prune --unshallow --tags"
-        name: Fetch git tags for `git describe`
       - run: echo '::set-output name=GIT_DESCRIBE::'`git describe --tags --always --long`
         name: Run `git describe` and save its output
         id: git-describe


### PR DESCRIPTION
This is to track whether https://github.com/actions/checkout/issues/290 is fixed so that we can drop the hack to fetch all tags. This PR _should not_ be merged until the issue has been resolved.
- [ ] https://github.com/actions/checkout/issues/290