### PR TITLE
fix: updating was wrongly restricted by detection timeout

### DIFF
--- a/cmd/ip.go
+++ b/cmd/ip.go
@@ -30,29 +30,31 @@ func setIP(ctx context.Context, ppfmt pp.PP, c *config.Config, h api.Handle, ipN
 
 var ipv6MessageDisplayed = false //nolint:gochecknoglobals
 
-func updateIP(ctx context.Context, ppfmt pp.PP, c *config.Config, h api.Handle, ipNet ipnet.Type) {
+func detectIP(ctx context.Context, ppfmt pp.PP, c *config.Config, h api.Handle, ipNet ipnet.Type) netip.Addr {
 	ctx, cancel := context.WithTimeout(ctx, c.DetectionTimeout)
 	defer cancel()
 
 	ip := c.Policy[ipNet].GetIP(ctx, ppfmt, ipNet)
-	if !ip.IsValid() {
+	if ip.IsValid() {
+		ppfmt.Infof(pp.EmojiInternet, "Detected the %s address: %v", ipNet.Describe(), ip)
+	} else {
 		ppfmt.Errorf(pp.EmojiError, "Failed to detect the %s address", ipNet.Describe())
 		if !ipv6MessageDisplayed && ipNet == ipnet.IP6 {
 			ipv6MessageDisplayed = true
 			ppfmt.Infof(pp.EmojiConfig, "If you are using Docker, Kubernetes, or other frameworks, IPv6 networks often require additional setups.") //nolint:lll
 			ppfmt.Infof(pp.EmojiConfig, "Read more about IPv6 networks in the README at https://github.com/favonia/cloudflare-ddns")                //nolint:lll
 		}
-		return
 	}
-
-	ppfmt.Infof(pp.EmojiInternet, "Detected the %s address: %v", ipNet.Describe(), ip)
-	setIP(ctx, ppfmt, c, h, ipNet, ip)
+	return ip
 }
 
 func updateIPs(ctx context.Context, ppfmt pp.PP, c *config.Config, h api.Handle) {
 	for _, ipNet := range []ipnet.Type{ipnet.IP4, ipnet.IP6} {
 		if c.Policy[ipNet] != nil {
-			updateIP(ctx, ppfmt, c, h, ipNet)
+			ip := detectIP(ctx, ppfmt, c, h, ipNet)
+			if ip.IsValid() {
+				setIP(ctx, ppfmt, c, h, ipNet, ip)
+			}
 		}
 	}
 }


### PR DESCRIPTION
The context used in the old updateIP for setting IPs already has the timeout set for detection. The new code uses a fresh context for setting IPs. I believe this fixes #147.