### PR TITLE
feat(monitor): improve Healthchecks integration

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -45,7 +45,7 @@ By default, public IP addresses are obtained using the [Cloudflare debugging pag
 
 - 🛑 The superuser privileges are immediately dropped after the updater starts. This minimizes the impact of undiscovered security bugs in the updater.
 - 🛡️ The updater uses HTTPS (or [DNS over HTTPS](https://en.wikipedia.org/wiki/DNS_over_HTTPS)) to detect public IP addresses, making it harder to tamper with the detection process. _(Due to the nature of address detection, it is impossible to protect the updater from an adversary who can modify the source IP address of the IP packets coming from your machine.)_
-- 🖥️ Optionally, you can [monitor the updater via Healthchecks.io](https://healthchecks.io), which will notify you when the updating fails.
+- 🖥️ Optionally, you can [monitor the updater via Healthchecks](https://healthchecks.io), which will notify you when the updating fails.
 - 📚 The updater uses only established open-source Go libraries.
   <details><summary>🔌 Full list of external Go libraries <em>(click to expand)</em></summary>
 
@@ -433,12 +433,12 @@ In most cases, `CF_ACCOUNT_ID` is not needed.
 <details>
 <summary>👁️ Monitoring the updater</summary>
 
-| Name           | Valid Values                                                                                                                                                         | Meaning                                                                         | Required? | Default Value |
-| -------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------- | --------- | ------------- |
-| `QUIET`        | Boolean values, such as `true`, `false`, `0` and `1`. See [strconv.ParseBool](https://pkg.go.dev/strconv#ParseBool)                                                  | Whether the updater should reduce the logging to the standard output            | No        | `false`       |
-| `HEALTHCHECKS` | [Healthchecks.io ping URLs](https://healthchecks.io/docs/), such as `https://hc-ping.com/<uuid>` or `https://hc-ping.com/<project-ping-key>/<name-slug>` (see below) | If set, the updater will ping the URL when it successfully updates IP addresses | No        | (unset)       |
+| Name           | Valid Values                                                                                                                                                      | Meaning                                                                         | Required? | Default Value |
+| -------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------- | --------- | ------------- |
+| `QUIET`        | Boolean values, such as `true`, `false`, `0` and `1`. See [strconv.ParseBool](https://pkg.go.dev/strconv#ParseBool)                                               | Whether the updater should reduce the logging to the standard output            | No        | `false`       |
+| `HEALTHCHECKS` | [Healthchecks ping URLs](https://healthchecks.io/docs/), such as `https://hc-ping.com/<uuid>` or `https://hc-ping.com/<project-ping-key>/<name-slug>` (see below) | If set, the updater will ping the URL when it successfully updates IP addresses | No        | (unset)       |
 
-For `HEALTHCHECKS`, the updater accepts any URL that follows the [same notification protocol](https://healthchecks.io/docs/http_api/).
+For `HEALTHCHECKS`, the updater can work with any server following the [same notification protocol](https://healthchecks.io/docs/http_api/), including but not limited to self-hosted instances of [Healthchecks](https://github.com/healthchecks/healthchecks). Both UUID and Slug URLs are supported, and the updater is compatible with POST-only mode.
 
 </details>
 

--- a/internal/README.markdown
+++ b/internal/README.markdown
@@ -4,10 +4,10 @@
 - `config`: read configuration settings from environment variables
 - `cron`: parse Cron expressions
 - `domain`: handle domain names and split them into possible subdomains and zones
-- `domainexp`: handle domain lists and parse boolean expressions on domains (for `PROXIED`)
-- `file`: virtualize file system (to enable testing)
+- `domainexp`: parse domain lists and parse boolean expressions on domains (for `PROXIED`)
+- `file`: virtualize file systems (to enable testing)
 - `ipnet`: define a type for labelling IPv4 and IPv6
-- `monitor`: ping the monitoring API, currently only supporting Healthchecks.io
+- `monitor`: ping the monitoring API, currently only supporting Healthchecks
 - `pp`: pretty print messages with emojis
 - `provider`: find out the public IP
 - `setter`: set the IP of one domain using a DNS service API

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -264,7 +264,7 @@ func (c *Config) ReadEnv(ppfmt pp.PP) bool {
 		!ReadString(ppfmt, "PROXIED", &c.ProxiedTemplate) ||
 		!ReadNonnegDuration(ppfmt, "DETECTION_TIMEOUT", &c.DetectionTimeout) ||
 		!ReadNonnegDuration(ppfmt, "UPDATE_TIMEOUT", &c.UpdateTimeout) ||
-		!ReadHealthChecksURL(ppfmt, "HEALTHCHECKS", &c.Monitors) {
+		!ReadHealthchecksURL(ppfmt, "HEALTHCHECKS", &c.Monitors) {
 		return false
 	}
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -402,7 +402,7 @@ func TestPrintMaps(t *testing.T) {
 		innerMockPP.EXPECT().Infof(pp.EmojiBullet, "%-*s %s", 24, "IP detection:", "5s"),
 		innerMockPP.EXPECT().Infof(pp.EmojiBullet, "%-*s %s", 24, "Record updating:", "30s"),
 		mockPP.EXPECT().Infof(pp.EmojiConfig, "Monitors:"),
-		innerMockPP.EXPECT().Infof(pp.EmojiBullet, "%-*s %s", 24, "Healthchecks.io:", "(URL redacted)"),
+		innerMockPP.EXPECT().Infof(pp.EmojiBullet, "%-*s %s", 24, "Healthchecks:", "(URL redacted)"),
 	)
 
 	c := config.Default()
@@ -418,7 +418,7 @@ func TestPrintMaps(t *testing.T) {
 	c.Proxied[domain.FQDN("c")] = false
 	c.Proxied[domain.FQDN("d")] = false
 
-	m, ok := monitor.NewHealthChecks(mockPP, "http://user:pass@host/path")
+	m, ok := monitor.NewHealthchecks(mockPP, "https://user:pass@host/path")
 	require.True(t, ok)
 	c.Monitors = []monitor.Monitor{m}
 

--- a/internal/config/env.go
+++ b/internal/config/env.go
@@ -282,15 +282,15 @@ func ReadCron(ppfmt pp.PP, key string, field *cron.Schedule) bool {
 	return true
 }
 
-// ReadHealthChecksURL reads the base URL of the healthcheck.io endpoint.
-func ReadHealthChecksURL(ppfmt pp.PP, key string, field *[]monitor.Monitor) bool {
+// ReadHealthchecksURL reads the base URL of the healthcheck.io endpoint.
+func ReadHealthchecksURL(ppfmt pp.PP, key string, field *[]monitor.Monitor) bool {
 	val := Getenv(key)
 
 	if val == "" {
 		return true
 	}
 
-	h, ok := monitor.NewHealthChecks(ppfmt, val)
+	h, ok := monitor.NewHealthchecks(ppfmt, val)
 	if !ok {
 		return false
 	}

--- a/internal/config/env_test.go
+++ b/internal/config/env_test.go
@@ -720,7 +720,7 @@ func urlMustParse(t *testing.T, u string) *url.URL {
 }
 
 //nolint:paralleltest,funlen // paralleltest should not be used because environment vars are global
-func TestReadHealthChecksURL(t *testing.T) {
+func TestReadHealthchecksURL(t *testing.T) {
 	key := keyPrefix + "HEALTHCHECKS"
 
 	type mon = monitor.Monitor
@@ -742,10 +742,10 @@ func TestReadHealthChecksURL(t *testing.T) {
 		"example": {
 			true, "https://hi.org/1234",
 			[]mon{},
-			[]mon{&monitor.HealthChecks{
+			[]mon{&monitor.Healthchecks{
 				BaseURL:    urlMustParse(t, "https://hi.org/1234"),
-				Timeout:    monitor.HealthChecksDefaultTimeout,
-				MaxRetries: monitor.HealthChecksDefaultMaxRetries,
+				Timeout:    monitor.HealthchecksDefaultTimeout,
+				MaxRetries: monitor.HealthchecksDefaultMaxRetries,
 			}},
 			true,
 			nil,
@@ -753,10 +753,10 @@ func TestReadHealthChecksURL(t *testing.T) {
 		"password": {
 			true, "https://me:pass@hi.org/1234",
 			[]mon{},
-			[]mon{&monitor.HealthChecks{
+			[]mon{&monitor.Healthchecks{
 				BaseURL:    urlMustParse(t, "https://me:pass@hi.org/1234"),
-				Timeout:    monitor.HealthChecksDefaultTimeout,
-				MaxRetries: monitor.HealthChecksDefaultMaxRetries,
+				Timeout:    monitor.HealthchecksDefaultTimeout,
+				MaxRetries: monitor.HealthchecksDefaultMaxRetries,
 			}},
 			true,
 			nil,
@@ -764,10 +764,10 @@ func TestReadHealthChecksURL(t *testing.T) {
 		"fragment": {
 			true, "https://hi.org/1234#fragment",
 			[]mon{},
-			[]mon{&monitor.HealthChecks{
+			[]mon{&monitor.Healthchecks{
 				BaseURL:    urlMustParse(t, "https://hi.org/1234#fragment"),
-				Timeout:    monitor.HealthChecksDefaultTimeout,
-				MaxRetries: monitor.HealthChecksDefaultMaxRetries,
+				Timeout:    monitor.HealthchecksDefaultTimeout,
+				MaxRetries: monitor.HealthchecksDefaultMaxRetries,
 			}},
 			true,
 			nil,
@@ -775,10 +775,10 @@ func TestReadHealthChecksURL(t *testing.T) {
 		"query": {
 			true, "https://hi.org/1234?hello=123",
 			[]mon{},
-			[]mon{&monitor.HealthChecks{
+			[]mon{&monitor.Healthchecks{
 				BaseURL:    urlMustParse(t, "https://hi.org/1234?hello=123"),
-				Timeout:    monitor.HealthChecksDefaultTimeout,
-				MaxRetries: monitor.HealthChecksDefaultMaxRetries,
+				Timeout:    monitor.HealthchecksDefaultTimeout,
+				MaxRetries: monitor.HealthchecksDefaultMaxRetries,
 			}},
 			true,
 			nil,
@@ -793,7 +793,7 @@ func TestReadHealthChecksURL(t *testing.T) {
 			if tc.prepareMockPP != nil {
 				tc.prepareMockPP(mockPP)
 			}
-			ok := config.ReadHealthChecksURL(mockPP, key, &field)
+			ok := config.ReadHealthchecksURL(mockPP, key, &field)
 			require.Equal(t, tc.ok, ok)
 			require.Equal(t, tc.newField, field)
 		})

--- a/internal/mocks/mock_monitor.go
+++ b/internal/mocks/mock_monitor.go
@@ -50,57 +50,71 @@ func (mr *MockMonitorMockRecorder) DescribeService() *gomock.Call {
 }
 
 // ExitStatus mocks base method.
-func (m *MockMonitor) ExitStatus(arg0 context.Context, arg1 pp.PP, arg2 int) bool {
+func (m *MockMonitor) ExitStatus(arg0 context.Context, arg1 pp.PP, arg2 int, arg3 string) bool {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ExitStatus", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "ExitStatus", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(bool)
 	return ret0
 }
 
 // ExitStatus indicates an expected call of ExitStatus.
-func (mr *MockMonitorMockRecorder) ExitStatus(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockMonitorMockRecorder) ExitStatus(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExitStatus", reflect.TypeOf((*MockMonitor)(nil).ExitStatus), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExitStatus", reflect.TypeOf((*MockMonitor)(nil).ExitStatus), arg0, arg1, arg2, arg3)
 }
 
 // Failure mocks base method.
-func (m *MockMonitor) Failure(arg0 context.Context, arg1 pp.PP) bool {
+func (m *MockMonitor) Failure(arg0 context.Context, arg1 pp.PP, arg2 string) bool {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Failure", arg0, arg1)
+	ret := m.ctrl.Call(m, "Failure", arg0, arg1, arg2)
 	ret0, _ := ret[0].(bool)
 	return ret0
 }
 
 // Failure indicates an expected call of Failure.
-func (mr *MockMonitorMockRecorder) Failure(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockMonitorMockRecorder) Failure(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Failure", reflect.TypeOf((*MockMonitor)(nil).Failure), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Failure", reflect.TypeOf((*MockMonitor)(nil).Failure), arg0, arg1, arg2)
+}
+
+// Log mocks base method.
+func (m *MockMonitor) Log(arg0 context.Context, arg1 pp.PP, arg2 string) bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Log", arg0, arg1, arg2)
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// Log indicates an expected call of Log.
+func (mr *MockMonitorMockRecorder) Log(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Log", reflect.TypeOf((*MockMonitor)(nil).Log), arg0, arg1, arg2)
 }
 
 // Start mocks base method.
-func (m *MockMonitor) Start(arg0 context.Context, arg1 pp.PP) bool {
+func (m *MockMonitor) Start(arg0 context.Context, arg1 pp.PP, arg2 string) bool {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Start", arg0, arg1)
+	ret := m.ctrl.Call(m, "Start", arg0, arg1, arg2)
 	ret0, _ := ret[0].(bool)
 	return ret0
 }
 
 // Start indicates an expected call of Start.
-func (mr *MockMonitorMockRecorder) Start(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockMonitorMockRecorder) Start(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Start", reflect.TypeOf((*MockMonitor)(nil).Start), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Start", reflect.TypeOf((*MockMonitor)(nil).Start), arg0, arg1, arg2)
 }
 
 // Success mocks base method.
-func (m *MockMonitor) Success(arg0 context.Context, arg1 pp.PP) bool {
+func (m *MockMonitor) Success(arg0 context.Context, arg1 pp.PP, arg2 string) bool {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Success", arg0, arg1)
+	ret := m.ctrl.Call(m, "Success", arg0, arg1, arg2)
 	ret0, _ := ret[0].(bool)
 	return ret0
 }
 
 // Success indicates an expected call of Success.
-func (mr *MockMonitorMockRecorder) Success(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockMonitorMockRecorder) Success(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Success", reflect.TypeOf((*MockMonitor)(nil).Success), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Success", reflect.TypeOf((*MockMonitor)(nil).Success), arg0, arg1, arg2)
 }

--- a/internal/mocks/mock_setter.go
+++ b/internal/mocks/mock_setter.go
@@ -40,11 +40,12 @@ func (m *MockSetter) EXPECT() *MockSetterMockRecorder {
 }
 
 // Set mocks base method.
-func (m *MockSetter) Set(arg0 context.Context, arg1 pp.PP, arg2 domain.Domain, arg3 ipnet.Type, arg4 netip.Addr, arg5 api.TTL, arg6 bool) bool {
+func (m *MockSetter) Set(arg0 context.Context, arg1 pp.PP, arg2 domain.Domain, arg3 ipnet.Type, arg4 netip.Addr, arg5 api.TTL, arg6 bool) (bool, string) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Set", arg0, arg1, arg2, arg3, arg4, arg5, arg6)
 	ret0, _ := ret[0].(bool)
-	return ret0
+	ret1, _ := ret[1].(string)
+	return ret0, ret1
 }
 
 // Set indicates an expected call of Set.

--- a/internal/monitor/base.go
+++ b/internal/monitor/base.go
@@ -10,8 +10,9 @@ import (
 
 type Monitor interface {
 	DescribeService() string
-	Success(context.Context, pp.PP) bool
-	Start(context.Context, pp.PP) bool
-	Failure(context.Context, pp.PP) bool
-	ExitStatus(context.Context, pp.PP, int) bool
+	Success(context.Context, pp.PP, string) bool
+	Start(context.Context, pp.PP, string) bool
+	Failure(context.Context, pp.PP, string) bool
+	Log(context.Context, pp.PP, string) bool
+	ExitStatus(context.Context, pp.PP, int, string) bool
 }

--- a/internal/monitor/healthchecks.go
+++ b/internal/monitor/healthchecks.go
@@ -56,7 +56,8 @@ func NewHealthchecks(ppfmt pp.PP, rawURL string, os ...HealthchecksOption) (Moni
 		// HTTPS is good!
 
 	default:
-		ppfmt.Errorf(pp.EmojiUserError, "The Healthchecks URL (redacted) does not use HTTP(S) and is not supported")
+		ppfmt.Errorf(pp.EmojiUserError, `The Healthchecks URL (redacted) does not look like a valid URL.`)
+		ppfmt.Errorf(pp.EmojiUserError, `A valid example is "https://hc-ping.com/01234567-0123-0123-0123-0123456789abc".`)
 		return nil, false
 	}
 

--- a/internal/monitor/healthchecks_test.go
+++ b/internal/monitor/healthchecks_test.go
@@ -77,6 +77,19 @@ func TestNewHealthchecksFail2(t *testing.T) {
 
 	mockCtrl := gomock.NewController(t)
 	mockPP := mocks.NewMockPP(mockCtrl)
+	gomock.InOrder(
+		mockPP.EXPECT().Errorf(pp.EmojiUserError, `The Healthchecks URL (redacted) does not look like a valid URL.`),
+		mockPP.EXPECT().Errorf(pp.EmojiUserError, `A valid example is "https://hc-ping.com/01234567-0123-0123-0123-0123456789abc".`), //nolint:lll
+	)
+	_, ok := monitor.NewHealthchecks(mockPP, "ftp://example.org")
+	require.False(t, ok)
+}
+
+func TestNewHealthchecksFail3(t *testing.T) {
+	t.Parallel()
+
+	mockCtrl := gomock.NewController(t)
+	mockPP := mocks.NewMockPP(mockCtrl)
 	mockPP.EXPECT().Errorf(pp.EmojiUserError, "Failed to parse the Healthchecks URL (redacted)")
 	_, ok := monitor.NewHealthchecks(mockPP, "://#?")
 	require.False(t, ok)

--- a/internal/monitor/healthchecks_test.go
+++ b/internal/monitor/healthchecks_test.go
@@ -16,32 +16,32 @@ import (
 	"github.com/favonia/cloudflare-ddns/internal/pp"
 )
 
-func TestSetHealthChecksMaxRetries(t *testing.T) {
+func TestSetHealthchecksMaxRetries(t *testing.T) {
 	t.Parallel()
 
-	m := &monitor.HealthChecks{} //nolint:exhaustruct
+	m := &monitor.Healthchecks{} //nolint:exhaustruct
 
-	monitor.SetHealthChecksMaxRetries(42)(m)
+	monitor.SetHealthchecksMaxRetries(42)(m)
 
-	require.Equal(t, &monitor.HealthChecks{MaxRetries: 42}, m) //nolint:exhaustruct
+	require.Equal(t, &monitor.Healthchecks{MaxRetries: 42}, m) //nolint:exhaustruct
 }
 
-func TestSetHealthChecksMaxRetriesPanic(t *testing.T) {
+func TestSetHealthchecksMaxRetriesPanic(t *testing.T) {
 	t.Parallel()
 
 	require.Panics(t,
 		func() {
-			monitor.SetHealthChecksMaxRetries(0)
+			monitor.SetHealthchecksMaxRetries(0)
 		},
 	)
 	require.Panics(t,
 		func() {
-			monitor.SetHealthChecksMaxRetries(-1)
+			monitor.SetHealthchecksMaxRetries(-1)
 		},
 	)
 }
 
-func TestNewHealthChecks(t *testing.T) {
+func TestNewHealthchecks(t *testing.T) {
 	t.Parallel()
 
 	rawURL := "https://user:pass@host/path"
@@ -50,35 +50,35 @@ func TestNewHealthChecks(t *testing.T) {
 
 	mockCtrl := gomock.NewController(t)
 	mockPP := mocks.NewMockPP(mockCtrl)
-	m, ok := monitor.NewHealthChecks(mockPP, rawURL, monitor.SetHealthChecksMaxRetries(100))
-	require.Equal(t, &monitor.HealthChecks{
+	m, ok := monitor.NewHealthchecks(mockPP, rawURL, monitor.SetHealthchecksMaxRetries(100))
+	require.Equal(t, &monitor.Healthchecks{
 		BaseURL:    parsedURL,
-		Timeout:    monitor.HealthChecksDefaultTimeout,
+		Timeout:    monitor.HealthchecksDefaultTimeout,
 		MaxRetries: 100,
 	}, m)
 	require.True(t, ok)
 }
 
-func TestNewHealthChecksFail1(t *testing.T) {
+func TestNewHealthchecksFail1(t *testing.T) {
 	t.Parallel()
 
 	mockCtrl := gomock.NewController(t)
 	mockPP := mocks.NewMockPP(mockCtrl)
 	gomock.InOrder(
-		mockPP.EXPECT().Errorf(pp.EmojiUserError, `The Healthchecks.io URL (redacted) does not look like a valid URL.`),
+		mockPP.EXPECT().Errorf(pp.EmojiUserError, `The Healthchecks URL (redacted) does not look like a valid URL.`),
 		mockPP.EXPECT().Errorf(pp.EmojiUserError, `A valid example is "https://hc-ping.com/01234567-0123-0123-0123-0123456789abc".`), //nolint:lll
 	)
-	_, ok := monitor.NewHealthChecks(mockPP, "this is not a valid URL")
+	_, ok := monitor.NewHealthchecks(mockPP, "this is not a valid URL")
 	require.False(t, ok)
 }
 
-func TestNewHealthChecksFail2(t *testing.T) {
+func TestNewHealthchecksFail2(t *testing.T) {
 	t.Parallel()
 
 	mockCtrl := gomock.NewController(t)
 	mockPP := mocks.NewMockPP(mockCtrl)
-	mockPP.EXPECT().Errorf(pp.EmojiUserError, "Failed to parse the Healthchecks.io URL (redacted)")
-	_, ok := monitor.NewHealthChecks(mockPP, "://#?")
+	mockPP.EXPECT().Errorf(pp.EmojiUserError, "Failed to parse the Healthchecks URL (redacted)")
+	_, ok := monitor.NewHealthchecks(mockPP, "://#?")
 	require.False(t, ok)
 }
 
@@ -87,9 +87,9 @@ func TestDescripbeService(t *testing.T) {
 
 	mockCtrl := gomock.NewController(t)
 	mockPP := mocks.NewMockPP(mockCtrl)
-	m, ok := monitor.NewHealthChecks(mockPP, "https://user:pass@host/path")
+	m, ok := monitor.NewHealthchecks(mockPP, "https://user:pass@host/path")
 	require.True(t, ok)
-	require.Equal(t, "Healthchecks.io", m.DescribeService())
+	require.Equal(t, "Healthchecks", m.DescribeService())
 }
 
 //nolint:funlen
@@ -107,6 +107,7 @@ func TestEndPoints(t *testing.T) {
 	for name, tc := range map[string]struct {
 		endpoint      func(pp.PP, monitor.Monitor) bool
 		url           string
+		message       string
 		actions       []action
 		pinged        bool
 		ok            bool
@@ -114,134 +115,144 @@ func TestEndPoints(t *testing.T) {
 	}{
 		"success": {
 			func(ppfmt pp.PP, m monitor.Monitor) bool {
-				return m.Success(context.Background(), ppfmt)
+				return m.Success(context.Background(), ppfmt, "hello")
 			},
-			"/",
+			"/", "hello",
 			[]action{ActionAbort, ActionAbort, ActionOk},
 			true, true,
 			func(m *mocks.MockPP) {
 				gomock.InOrder(
-					m.EXPECT().Warningf(pp.EmojiError, "Failed to send HTTP(S) request to the %s endpoint of Healthchecks.io: %v", `default (root)`, gomock.Any()), //nolint:lll
-					m.EXPECT().Infof(pp.EmojiRepeatOnce, "Trying again . . ."),                                                                                     //nolint:lll
-					m.EXPECT().Warningf(pp.EmojiError, "Failed to send HTTP(S) request to the %s endpoint of Healthchecks.io: %v", `default (root)`, gomock.Any()), //nolint:lll
-					m.EXPECT().Infof(pp.EmojiRepeatOnce, "Trying again . . ."),                                                                                     //nolint:lll
-					m.EXPECT().Infof(pp.EmojiNotification, "Successfully pinged the %s endpoint of Healthchecks.io", `default (root)`),                             //nolint:lll
+					m.EXPECT().Warningf(pp.EmojiUserWarning, "The Healthchecks URL (redacted) uses HTTP; please consider using HTTPS"),
+					m.EXPECT().Warningf(pp.EmojiError, "Failed to send HTTP(S) request to the %s endpoint of Healthchecks: %v", `default (root)`, gomock.Any()), //nolint:lll
+					m.EXPECT().Infof(pp.EmojiRepeatOnce, "Trying again . . ."),
+					m.EXPECT().Warningf(pp.EmojiError, "Failed to send HTTP(S) request to the %s endpoint of Healthchecks: %v", `default (root)`, gomock.Any()), //nolint:lll
+					m.EXPECT().Infof(pp.EmojiRepeatOnce, "Trying again . . ."),
+					m.EXPECT().Infof(pp.EmojiNotification, "Successfully pinged the %s endpoint of Healthchecks", `default (root)`), //nolint:lll
 				)
 			},
 		},
 		"success/notok": {
 			func(ppfmt pp.PP, m monitor.Monitor) bool {
-				return m.Success(context.Background(), ppfmt)
+				return m.Success(context.Background(), ppfmt, "aloha")
 			},
-			"/",
+			"/", "aloha",
 			[]action{ActionAbort, ActionAbort, ActionNotOk},
 			false, false,
 			func(m *mocks.MockPP) {
 				gomock.InOrder(
-					m.EXPECT().Warningf(pp.EmojiError, "Failed to send HTTP(S) request to the %s endpoint of Healthchecks.io: %v", `default (root)`, gomock.Any()),                 //nolint:lll
-					m.EXPECT().Infof(pp.EmojiRepeatOnce, "Trying again . . ."),                                                                                                     //nolint:lll
-					m.EXPECT().Warningf(pp.EmojiError, "Failed to send HTTP(S) request to the %s endpoint of Healthchecks.io: %v", `default (root)`, gomock.Any()),                 //nolint:lll
-					m.EXPECT().Infof(pp.EmojiRepeatOnce, "Trying again . . ."),                                                                                                     //nolint:lll
-					m.EXPECT().Warningf(pp.EmojiError, "Failed to ping the %s endpoint of Healthchecks.io; got response code: %d %s", `default (root)`, 400, "invalid url format"), //nolint:lll
+					m.EXPECT().Warningf(pp.EmojiUserWarning, "The Healthchecks URL (redacted) uses HTTP; please consider using HTTPS"),
+					m.EXPECT().Warningf(pp.EmojiError, "Failed to send HTTP(S) request to the %s endpoint of Healthchecks: %v", `default (root)`, gomock.Any()), //nolint:lll
+					m.EXPECT().Infof(pp.EmojiRepeatOnce, "Trying again . . ."),
+					m.EXPECT().Warningf(pp.EmojiError, "Failed to send HTTP(S) request to the %s endpoint of Healthchecks: %v", `default (root)`, gomock.Any()), //nolint:lll
+					m.EXPECT().Infof(pp.EmojiRepeatOnce, "Trying again . . ."),
+					m.EXPECT().Warningf(pp.EmojiError, "Failed to ping the %s endpoint of Healthchecks; got response code: %d %s", `default (root)`, 400, "invalid url format"), //nolint:lll
 				)
 			},
 		},
 		"success/abort/all": {
 			func(ppfmt pp.PP, m monitor.Monitor) bool {
-				return m.Success(context.Background(), ppfmt)
+				return m.Success(context.Background(), ppfmt, "stop now")
 			},
-			"/",
+			"/", "stop now",
 			[]action{ActionAbort, ActionAbort, ActionAbort},
 			false, false,
 			func(m *mocks.MockPP) {
 				gomock.InOrder(
-					m.EXPECT().Warningf(pp.EmojiError, "Failed to send HTTP(S) request to the %s endpoint of Healthchecks.io: %v", `default (root)`, gomock.Any()), //nolint:lll
-					m.EXPECT().Infof(pp.EmojiRepeatOnce, "Trying again . . ."),                                                                                     //nolint:lll
-					m.EXPECT().Warningf(pp.EmojiError, "Failed to send HTTP(S) request to the %s endpoint of Healthchecks.io: %v", `default (root)`, gomock.Any()), //nolint:lll
-					m.EXPECT().Infof(pp.EmojiRepeatOnce, "Trying again . . ."),                                                                                     //nolint:lll
-					m.EXPECT().Warningf(pp.EmojiError, "Failed to send HTTP(S) request to the %s endpoint of Healthchecks.io: %v", `default (root)`, gomock.Any()), //nolint:lll
-					m.EXPECT().Infof(pp.EmojiRepeatOnce, "Trying again . . ."),                                                                                     //nolint:lll
-					m.EXPECT().Warningf(pp.EmojiError, "Failed to send HTTP(S) request to the %s endpoint of Healthchecks.io in %d time(s)", `default (root)`, 3),  //nolint:lll
+					m.EXPECT().Warningf(pp.EmojiUserWarning, "The Healthchecks URL (redacted) uses HTTP; please consider using HTTPS"),
+					m.EXPECT().Warningf(pp.EmojiError, "Failed to send HTTP(S) request to the %s endpoint of Healthchecks: %v", `default (root)`, gomock.Any()), //nolint:lll
+					m.EXPECT().Infof(pp.EmojiRepeatOnce, "Trying again . . ."),
+					m.EXPECT().Warningf(pp.EmojiError, "Failed to send HTTP(S) request to the %s endpoint of Healthchecks: %v", `default (root)`, gomock.Any()), //nolint:lll
+					m.EXPECT().Infof(pp.EmojiRepeatOnce, "Trying again . . ."),
+					m.EXPECT().Warningf(pp.EmojiError, "Failed to send HTTP(S) request to the %s endpoint of Healthchecks: %v", `default (root)`, gomock.Any()), //nolint:lll
+					m.EXPECT().Infof(pp.EmojiRepeatOnce, "Trying again . . ."),
+					m.EXPECT().Warningf(pp.EmojiError, "Failed to send HTTP(S) request to the %s endpoint of Healthchecks in %d time(s)", `default (root)`, 3), //nolint:lll
 				)
 			},
 		},
 		"start": {
 			func(ppfmt pp.PP, m monitor.Monitor) bool {
-				return m.Start(context.Background(), ppfmt)
+				return m.Start(context.Background(), ppfmt, "starting now!")
 			},
-			"/start",
+			"/start", "starting now!",
 			[]action{ActionAbort, ActionAbort, ActionOk},
 			true, true,
 			func(m *mocks.MockPP) {
 				gomock.InOrder(
-					m.EXPECT().Warningf(pp.EmojiError, "Failed to send HTTP(S) request to the %s endpoint of Healthchecks.io: %v", `"/start"`, gomock.Any()), //nolint:lll
-					m.EXPECT().Infof(pp.EmojiRepeatOnce, "Trying again . . ."),                                                                               //nolint:lll
-					m.EXPECT().Warningf(pp.EmojiError, "Failed to send HTTP(S) request to the %s endpoint of Healthchecks.io: %v", `"/start"`, gomock.Any()), //nolint:lll
-					m.EXPECT().Infof(pp.EmojiRepeatOnce, "Trying again . . ."),                                                                               //nolint:lll
-					m.EXPECT().Infof(pp.EmojiNotification, "Successfully pinged the %s endpoint of Healthchecks.io", `"/start"`),                             //nolint:lll
+					m.EXPECT().Warningf(pp.EmojiUserWarning, "The Healthchecks URL (redacted) uses HTTP; please consider using HTTPS"),
+					m.EXPECT().Warningf(pp.EmojiError, "Failed to send HTTP(S) request to the %s endpoint of Healthchecks: %v", `"/start"`, gomock.Any()), //nolint:lll
+					m.EXPECT().Infof(pp.EmojiRepeatOnce, "Trying again . . ."),
+					m.EXPECT().Warningf(pp.EmojiError, "Failed to send HTTP(S) request to the %s endpoint of Healthchecks: %v", `"/start"`, gomock.Any()), //nolint:lll
+					m.EXPECT().Infof(pp.EmojiRepeatOnce, "Trying again . . ."),
+					m.EXPECT().Infof(pp.EmojiNotification, "Successfully pinged the %s endpoint of Healthchecks", `"/start"`), //nolint:lll
 				)
 			},
 		},
 		"failure": {
 			func(ppfmt pp.PP, m monitor.Monitor) bool {
-				return m.Failure(context.Background(), ppfmt)
+				return m.Failure(context.Background(), ppfmt, "something's wrong")
 			},
-			"/fail",
+			"/fail", "something's wrong",
 			[]action{ActionAbort, ActionAbort, ActionOk},
 			true, true,
 			func(m *mocks.MockPP) {
 				gomock.InOrder(
-					m.EXPECT().Warningf(pp.EmojiError, "Failed to send HTTP(S) request to the %s endpoint of Healthchecks.io: %v", `"/fail"`, gomock.Any()), //nolint:lll
-					m.EXPECT().Infof(pp.EmojiRepeatOnce, "Trying again . . ."),                                                                              //nolint:lll
-					m.EXPECT().Warningf(pp.EmojiError, "Failed to send HTTP(S) request to the %s endpoint of Healthchecks.io: %v", `"/fail"`, gomock.Any()), //nolint:lll
-					m.EXPECT().Infof(pp.EmojiRepeatOnce, "Trying again . . ."),                                                                              //nolint:lll
-					m.EXPECT().Infof(pp.EmojiNotification, "Successfully pinged the %s endpoint of Healthchecks.io", `"/fail"`),                             //nolint:lll
+					m.EXPECT().Warningf(pp.EmojiUserWarning, "The Healthchecks URL (redacted) uses HTTP; please consider using HTTPS"),
+					m.EXPECT().Warningf(pp.EmojiError, "Failed to send HTTP(S) request to the %s endpoint of Healthchecks: %v", `"/fail"`, gomock.Any()), //nolint:lll
+					m.EXPECT().Infof(pp.EmojiRepeatOnce, "Trying again . . ."),
+					m.EXPECT().Warningf(pp.EmojiError, "Failed to send HTTP(S) request to the %s endpoint of Healthchecks: %v", `"/fail"`, gomock.Any()), //nolint:lll
+					m.EXPECT().Infof(pp.EmojiRepeatOnce, "Trying again . . ."),
+					m.EXPECT().Infof(pp.EmojiNotification, "Successfully pinged the %s endpoint of Healthchecks", `"/fail"`), //nolint:lll
 				)
 			},
 		},
 		"exitstatus/0": {
 			func(ppfmt pp.PP, m monitor.Monitor) bool {
-				return m.ExitStatus(context.Background(), ppfmt, 0)
+				return m.ExitStatus(context.Background(), ppfmt, 0, "bye!")
 			},
-			"/0",
+			"/0", "bye!",
 			[]action{ActionAbort, ActionAbort, ActionOk},
 			true, true,
 			func(m *mocks.MockPP) {
 				gomock.InOrder(
-					m.EXPECT().Warningf(pp.EmojiError, "Failed to send HTTP(S) request to the %s endpoint of Healthchecks.io: %v", `"/0"`, gomock.Any()), //nolint:lll
-					m.EXPECT().Infof(pp.EmojiRepeatOnce, "Trying again . . ."),                                                                           //nolint:lll
-					m.EXPECT().Warningf(pp.EmojiError, "Failed to send HTTP(S) request to the %s endpoint of Healthchecks.io: %v", `"/0"`, gomock.Any()), //nolint:lll
-					m.EXPECT().Infof(pp.EmojiRepeatOnce, "Trying again . . ."),                                                                           //nolint:lll
-					m.EXPECT().Infof(pp.EmojiNotification, "Successfully pinged the %s endpoint of Healthchecks.io", `"/0"`),                             //nolint:lll
+					m.EXPECT().Warningf(pp.EmojiUserWarning, "The Healthchecks URL (redacted) uses HTTP; please consider using HTTPS"),
+					m.EXPECT().Warningf(pp.EmojiError, "Failed to send HTTP(S) request to the %s endpoint of Healthchecks: %v", `"/0"`, gomock.Any()), //nolint:lll
+					m.EXPECT().Infof(pp.EmojiRepeatOnce, "Trying again . . ."),
+					m.EXPECT().Warningf(pp.EmojiError, "Failed to send HTTP(S) request to the %s endpoint of Healthchecks: %v", `"/0"`, gomock.Any()), //nolint:lll
+					m.EXPECT().Infof(pp.EmojiRepeatOnce, "Trying again . . ."),
+					m.EXPECT().Infof(pp.EmojiNotification, "Successfully pinged the %s endpoint of Healthchecks", `"/0"`),
 				)
 			},
 		},
 		"exitstatus/1": {
 			func(ppfmt pp.PP, m monitor.Monitor) bool {
-				return m.ExitStatus(context.Background(), ppfmt, 1)
+				return m.ExitStatus(context.Background(), ppfmt, 1, "did exit(1)")
 			},
-			"/1",
+			"/1", "did exit(1)",
 			[]action{ActionAbort, ActionAbort, ActionOk},
 			true, true,
 			func(m *mocks.MockPP) {
 				gomock.InOrder(
-					m.EXPECT().Warningf(pp.EmojiError, "Failed to send HTTP(S) request to the %s endpoint of Healthchecks.io: %v", `"/1"`, gomock.Any()), //nolint:lll
-					m.EXPECT().Infof(pp.EmojiRepeatOnce, "Trying again . . ."),                                                                           //nolint:lll
-					m.EXPECT().Warningf(pp.EmojiError, "Failed to send HTTP(S) request to the %s endpoint of Healthchecks.io: %v", `"/1"`, gomock.Any()), //nolint:lll
-					m.EXPECT().Infof(pp.EmojiRepeatOnce, "Trying again . . ."),                                                                           //nolint:lll
-					m.EXPECT().Infof(pp.EmojiNotification, "Successfully pinged the %s endpoint of Healthchecks.io", `"/1"`),                             //nolint:lll
+					m.EXPECT().Warningf(pp.EmojiUserWarning, "The Healthchecks URL (redacted) uses HTTP; please consider using HTTPS"),
+					m.EXPECT().Warningf(pp.EmojiError, "Failed to send HTTP(S) request to the %s endpoint of Healthchecks: %v", `"/1"`, gomock.Any()), //nolint:lll
+					m.EXPECT().Infof(pp.EmojiRepeatOnce, "Trying again . . ."),
+					m.EXPECT().Warningf(pp.EmojiError, "Failed to send HTTP(S) request to the %s endpoint of Healthchecks: %v", `"/1"`, gomock.Any()), //nolint:lll
+					m.EXPECT().Infof(pp.EmojiRepeatOnce, "Trying again . . ."),
+					m.EXPECT().Infof(pp.EmojiNotification, "Successfully pinged the %s endpoint of Healthchecks", `"/1"`),
 				)
 			},
 		},
 		"exitstatus/-1": {
 			func(ppfmt pp.PP, m monitor.Monitor) bool {
-				return m.ExitStatus(context.Background(), ppfmt, -1)
+				return m.ExitStatus(context.Background(), ppfmt, -1, "feeling negative")
 			},
-			"",
+			"", "feeling negative",
 			nil,
 			false, false,
 			func(m *mocks.MockPP) {
-				m.EXPECT().Errorf(pp.EmojiImpossible, "Exit code (%d) not within the range 0-255", -1)
+				gomock.InOrder(
+					m.EXPECT().Warningf(pp.EmojiUserWarning, "The Healthchecks URL (redacted) uses HTTP; please consider using HTTPS"),
+					m.EXPECT().Errorf(pp.EmojiImpossible, "Exit code (%d) not within the range 0-255", -1),
+				)
 			},
 		},
 	} {
@@ -257,8 +268,12 @@ func TestEndPoints(t *testing.T) {
 			visited := 0
 			pinged := false
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				require.Equal(t, http.MethodGet, r.Method)
+				require.Equal(t, http.MethodPost, r.Method)
 				require.Equal(t, tc.url, r.URL.EscapedPath())
+
+				reqBody, err := io.ReadAll(r.Body)
+				require.Nil(t, err)
+				require.Equal(t, tc.message, string(reqBody))
 
 				visited++
 				require.LessOrEqual(t, visited, len(tc.actions))
@@ -280,7 +295,7 @@ func TestEndPoints(t *testing.T) {
 				}
 			}))
 
-			m, ok := monitor.NewHealthChecks(mockPP, server.URL, monitor.SetHealthChecksMaxRetries(3))
+			m, ok := monitor.NewHealthchecks(mockPP, server.URL, monitor.SetHealthchecksMaxRetries(3))
 			require.True(t, ok)
 			ok = tc.endpoint(mockPP, m)
 			require.Equal(t, tc.ok, ok)

--- a/internal/monitor/healthchecks_test.go
+++ b/internal/monitor/healthchecks_test.go
@@ -218,6 +218,24 @@ func TestEndPoints(t *testing.T) {
 				)
 			},
 		},
+		"log": {
+			func(ppfmt pp.PP, m monitor.Monitor) bool {
+				return m.Log(context.Background(), ppfmt, "message")
+			},
+			"/log", "message",
+			[]action{ActionAbort, ActionAbort, ActionOk},
+			true, true,
+			func(m *mocks.MockPP) {
+				gomock.InOrder(
+					m.EXPECT().Warningf(pp.EmojiUserWarning, "The Healthchecks URL (redacted) uses HTTP; please consider using HTTPS"),
+					m.EXPECT().Warningf(pp.EmojiError, "Failed to send HTTP(S) request to the %s endpoint of Healthchecks: %v", `"/log"`, gomock.Any()), //nolint:lll
+					m.EXPECT().Infof(pp.EmojiRepeatOnce, "Trying again . . ."),
+					m.EXPECT().Warningf(pp.EmojiError, "Failed to send HTTP(S) request to the %s endpoint of Healthchecks: %v", `"/log"`, gomock.Any()), //nolint:lll
+					m.EXPECT().Infof(pp.EmojiRepeatOnce, "Trying again . . ."),
+					m.EXPECT().Infof(pp.EmojiNotification, "Successfully pinged the %s endpoint of Healthchecks", `"/log"`), //nolint:lll
+				)
+			},
+		},
 		"exitstatus/0": {
 			func(ppfmt pp.PP, m monitor.Monitor) bool {
 				return m.ExitStatus(context.Background(), ppfmt, 0, "bye!")

--- a/internal/monitor/util.go
+++ b/internal/monitor/util.go
@@ -6,40 +6,50 @@ import (
 	"github.com/favonia/cloudflare-ddns/internal/pp"
 )
 
-func SuccessAll(ctx context.Context, ppfmt pp.PP, ms []Monitor) bool {
+func SuccessAll(ctx context.Context, ppfmt pp.PP, ms []Monitor, message string) bool {
 	ok := true
 	for _, m := range ms {
-		if !m.Success(ctx, ppfmt) {
+		if !m.Success(ctx, ppfmt, message) {
 			ok = false
 		}
 	}
 	return ok
 }
 
-func StartAll(ctx context.Context, ppfmt pp.PP, ms []Monitor) bool {
+func StartAll(ctx context.Context, ppfmt pp.PP, ms []Monitor, message string) bool {
 	ok := true
 	for _, m := range ms {
-		if !m.Start(ctx, ppfmt) {
+		if !m.Start(ctx, ppfmt, message) {
 			ok = false
 		}
 	}
 	return ok
 }
 
-func FailureAll(ctx context.Context, ppfmt pp.PP, ms []Monitor) bool {
+func FailureAll(ctx context.Context, ppfmt pp.PP, ms []Monitor, message string) bool {
 	ok := true
 	for _, m := range ms {
-		if !m.Failure(ctx, ppfmt) {
+		if !m.Failure(ctx, ppfmt, message) {
 			ok = false
 		}
 	}
 	return ok
 }
 
-func ExitStatusAll(ctx context.Context, ppfmt pp.PP, ms []Monitor, code int) bool {
+func LogAll(ctx context.Context, ppfmt pp.PP, ms []Monitor, message string) bool {
 	ok := true
 	for _, m := range ms {
-		if !m.ExitStatus(ctx, ppfmt, code) {
+		if !m.Log(ctx, ppfmt, message) {
+			ok = false
+		}
+	}
+	return ok
+}
+
+func ExitStatusAll(ctx context.Context, ppfmt pp.PP, ms []Monitor, code int, message string) bool {
+	ok := true
+	for _, m := range ms {
+		if !m.ExitStatus(ctx, ppfmt, code, message) {
 			ok = false
 		}
 	}

--- a/internal/monitor/util_test.go
+++ b/internal/monitor/util_test.go
@@ -56,7 +56,7 @@ func TestFailureAll(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	mockPP := mocks.NewMockPP(mockCtrl)
 
-	message := "hello!"
+	message := "secret"
 
 	for i := 0; i < 5; i++ {
 		m := mocks.NewMockMonitor(mockCtrl)
@@ -67,6 +67,25 @@ func TestFailureAll(t *testing.T) {
 	monitor.FailureAll(context.Background(), mockPP, ms, message)
 }
 
+func TestLogAll(t *testing.T) {
+	t.Parallel()
+
+	var ms []monitor.Monitor
+
+	mockCtrl := gomock.NewController(t)
+	mockPP := mocks.NewMockPP(mockCtrl)
+
+	message := "forest"
+
+	for i := 0; i < 5; i++ {
+		m := mocks.NewMockMonitor(mockCtrl)
+		m.EXPECT().Log(context.Background(), mockPP, message)
+		ms = append(ms, m)
+	}
+
+	monitor.LogAll(context.Background(), mockPP, ms, message)
+}
+
 func TestExitStatus(t *testing.T) {
 	t.Parallel()
 
@@ -75,7 +94,7 @@ func TestExitStatus(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	mockPP := mocks.NewMockPP(mockCtrl)
 
-	message := "hello!"
+	message := "bye!"
 
 	for i := 0; i < 5; i++ {
 		m := mocks.NewMockMonitor(mockCtrl)

--- a/internal/monitor/util_test.go
+++ b/internal/monitor/util_test.go
@@ -18,13 +18,15 @@ func TestSuccessAll(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	mockPP := mocks.NewMockPP(mockCtrl)
 
+	message := "aloha"
+
 	for i := 0; i < 5; i++ {
 		m := mocks.NewMockMonitor(mockCtrl)
-		m.EXPECT().Success(context.Background(), mockPP)
+		m.EXPECT().Success(context.Background(), mockPP, message)
 		ms = append(ms, m)
 	}
 
-	monitor.SuccessAll(context.Background(), mockPP, ms)
+	monitor.SuccessAll(context.Background(), mockPP, ms, message)
 }
 
 func TestStartAll(t *testing.T) {
@@ -35,13 +37,15 @@ func TestStartAll(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	mockPP := mocks.NewMockPP(mockCtrl)
 
+	message := "你好"
+
 	for i := 0; i < 5; i++ {
 		m := mocks.NewMockMonitor(mockCtrl)
-		m.EXPECT().Start(context.Background(), mockPP)
+		m.EXPECT().Start(context.Background(), mockPP, message)
 		ms = append(ms, m)
 	}
 
-	monitor.StartAll(context.Background(), mockPP, ms)
+	monitor.StartAll(context.Background(), mockPP, ms, message)
 }
 
 func TestFailureAll(t *testing.T) {
@@ -52,13 +56,15 @@ func TestFailureAll(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	mockPP := mocks.NewMockPP(mockCtrl)
 
+	message := "hello!"
+
 	for i := 0; i < 5; i++ {
 		m := mocks.NewMockMonitor(mockCtrl)
-		m.EXPECT().Failure(context.Background(), mockPP)
+		m.EXPECT().Failure(context.Background(), mockPP, message)
 		ms = append(ms, m)
 	}
 
-	monitor.FailureAll(context.Background(), mockPP, ms)
+	monitor.FailureAll(context.Background(), mockPP, ms, message)
 }
 
 func TestExitStatus(t *testing.T) {
@@ -69,11 +75,13 @@ func TestExitStatus(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	mockPP := mocks.NewMockPP(mockCtrl)
 
+	message := "hello!"
+
 	for i := 0; i < 5; i++ {
 		m := mocks.NewMockMonitor(mockCtrl)
-		m.EXPECT().ExitStatus(context.Background(), mockPP, 42)
+		m.EXPECT().ExitStatus(context.Background(), mockPP, 42, message)
 		ms = append(ms, m)
 	}
 
-	monitor.ExitStatusAll(context.Background(), mockPP, ms, 42)
+	monitor.ExitStatusAll(context.Background(), mockPP, ms, 42, message)
 }

--- a/internal/pp/emoji.go
+++ b/internal/pp/emoji.go
@@ -13,9 +13,10 @@ const (
 	EmojiMute         Emoji = "🔇" // quiet mode
 	EmojiExperimental Emoji = "🧪" // experimental features
 
-	EmojiAddRecord    Emoji = "🐣" // adding new DNS records
-	EmojiDelRecord    Emoji = "💀" // deleting DNS records
+	EmojiCreateRecord Emoji = "🐣" // adding new DNS records
+	EmojiDeleteRecord Emoji = "💀" // deleting DNS records
 	EmojiUpdateRecord Emoji = "📡" // updating DNS records
+	EmojiClearRecord  Emoji = "🧹" // clearing DNS records
 
 	EmojiNotification Emoji = "🔔" // sending out notifications, pinging, health checks
 	EmojiRepeatOnce   Emoji = "🔂" // repeating things once

--- a/internal/setter/base.go
+++ b/internal/setter/base.go
@@ -21,5 +21,5 @@ type Setter interface {
 		IP netip.Addr,
 		ttl api.TTL,
 		proxied bool,
-	) bool
+	) (bool, string)
 }

--- a/internal/updater/updater_test.go
+++ b/internal/updater/updater_test.go
@@ -50,69 +50,75 @@ func TestUpdateIPs(t *testing.T) {
 		ttl                  api.TTL
 		proxied              mockproxied
 		ok                   bool
+		msg                  string
 		MessageShouldDisplay map[ipnet.Type]bool
 		prepareMockPP        func(m *mocks.MockPP)
 		prepareMockProvider  mockproviders
 		prepareMockSetter    func(ppfmt pp.PP, m *mocks.MockSetter)
 	}{
 		"none": {
-			api.TTLAuto, proxiedBoth, true, map[ipnet.Type]bool{ipnet.IP4: true, ipnet.IP6: true}, nil, mockproviders{}, nil,
+			api.TTLAuto, proxiedBoth, true, ``, map[ipnet.Type]bool{ipnet.IP4: true, ipnet.IP6: true}, nil, mockproviders{}, nil,
 		},
 		"ip4only": {
 			api.TTLAuto,
 			proxiedNone,
 			true,
+			"",
 			map[ipnet.Type]bool{ipnet.IP4: true, ipnet.IP6: true},
 			pp4only,
 			mockproviders{ipnet.IP4: provider4},
 			func(ppfmt pp.PP, m *mocks.MockSetter) {
-				m.EXPECT().Set(gomock.Any(), ppfmt, domain.FQDN("ip4.hello"), ipnet.IP4, ip4, api.TTL(1), false).Return(true)
+				m.EXPECT().Set(gomock.Any(), ppfmt, domain.FQDN("ip4.hello"), ipnet.IP4, ip4, api.TTL(1), false).Return(true, "")
 			},
 		},
 		"ip4only/setfail": {
 			api.TTLAuto,
 			proxiedBoth,
 			false,
+			"error",
 			map[ipnet.Type]bool{ipnet.IP4: true, ipnet.IP6: true},
 			pp4only,
 			mockproviders{ipnet.IP4: provider4},
 			func(ppfmt pp.PP, m *mocks.MockSetter) {
-				m.EXPECT().Set(gomock.Any(), ppfmt, domain.FQDN("ip4.hello"), ipnet.IP4, ip4, api.TTL(1), true).Return(false)
+				m.EXPECT().Set(gomock.Any(), ppfmt, domain.FQDN("ip4.hello"), ipnet.IP4, ip4, api.TTL(1), true).Return(false, "error") //nolint:lll
 			},
 		},
 		"ip6only": {
 			api.TTLAuto,
 			proxiedNone,
 			true,
+			"ok",
 			map[ipnet.Type]bool{ipnet.IP4: true, ipnet.IP6: true},
 			pp6only,
 			mockproviders{ipnet.IP6: provider6},
 			func(ppfmt pp.PP, m *mocks.MockSetter) {
-				m.EXPECT().Set(gomock.Any(), ppfmt, domain.FQDN("ip6.hello"), ipnet.IP6, ip6, api.TTL(1), false).Return(true)
+				m.EXPECT().Set(gomock.Any(), ppfmt, domain.FQDN("ip6.hello"), ipnet.IP6, ip6, api.TTL(1), false).Return(true, "ok")
 			},
 		},
 		"ip6only/setfail": {
 			api.TTLAuto,
 			proxiedBoth,
 			false,
+			"bad",
 			map[ipnet.Type]bool{ipnet.IP4: true, ipnet.IP6: true},
 			pp6only,
 			mockproviders{ipnet.IP6: provider6},
 			func(ppfmt pp.PP, m *mocks.MockSetter) {
-				m.EXPECT().Set(gomock.Any(), ppfmt, domain.FQDN("ip6.hello"), ipnet.IP6, ip6, api.TTL(1), true).Return(false)
+				m.EXPECT().Set(gomock.Any(), ppfmt, domain.FQDN("ip6.hello"), ipnet.IP6, ip6, api.TTL(1), true).Return(false, "bad")
 			},
 		},
 		"both": {
 			api.TTLAuto,
 			proxiedNone,
 			true,
+			"",
 			map[ipnet.Type]bool{ipnet.IP4: true, ipnet.IP6: true},
 			ppBoth,
 			mockproviders{ipnet.IP4: provider4, ipnet.IP6: provider6},
 			func(ppfmt pp.PP, m *mocks.MockSetter) {
 				gomock.InOrder(
-					m.EXPECT().Set(gomock.Any(), ppfmt, domain.FQDN("ip4.hello"), ipnet.IP4, ip4, api.TTL(1), false).Return(true),
-					m.EXPECT().Set(gomock.Any(), ppfmt, domain.FQDN("ip6.hello"), ipnet.IP6, ip6, api.TTL(1), false).Return(true),
+					m.EXPECT().Set(gomock.Any(), ppfmt, domain.FQDN("ip4.hello"), ipnet.IP4, ip4, api.TTL(1), false).Return(true, ""),
+					m.EXPECT().Set(gomock.Any(), ppfmt, domain.FQDN("ip6.hello"), ipnet.IP6, ip6, api.TTL(1), false).Return(true, ""),
 				)
 			},
 		},
@@ -120,13 +126,14 @@ func TestUpdateIPs(t *testing.T) {
 			api.TTLAuto,
 			proxiedBoth,
 			false,
+			"hey!",
 			map[ipnet.Type]bool{ipnet.IP4: true, ipnet.IP6: true},
 			ppBoth,
 			mockproviders{ipnet.IP4: provider4, ipnet.IP6: provider6},
 			func(ppfmt pp.PP, m *mocks.MockSetter) {
 				gomock.InOrder(
-					m.EXPECT().Set(gomock.Any(), ppfmt, domain.FQDN("ip4.hello"), ipnet.IP4, ip4, api.TTL(1), true).Return(false),
-					m.EXPECT().Set(gomock.Any(), ppfmt, domain.FQDN("ip6.hello"), ipnet.IP6, ip6, api.TTL(1), true).Return(true),
+					m.EXPECT().Set(gomock.Any(), ppfmt, domain.FQDN("ip4.hello"), ipnet.IP4, ip4, api.TTL(1), true).Return(false, "hey!"), //nolint:lll
+					m.EXPECT().Set(gomock.Any(), ppfmt, domain.FQDN("ip6.hello"), ipnet.IP6, ip6, api.TTL(1), true).Return(true, ""),
 				)
 			},
 		},
@@ -134,13 +141,14 @@ func TestUpdateIPs(t *testing.T) {
 			api.TTLAuto,
 			proxiedNone,
 			false,
+			"wrong",
 			map[ipnet.Type]bool{ipnet.IP4: true, ipnet.IP6: true},
 			ppBoth,
 			mockproviders{ipnet.IP4: provider4, ipnet.IP6: provider6},
 			func(ppfmt pp.PP, m *mocks.MockSetter) {
 				gomock.InOrder(
-					m.EXPECT().Set(gomock.Any(), ppfmt, domain.FQDN("ip4.hello"), ipnet.IP4, ip4, api.TTL(1), false).Return(true),
-					m.EXPECT().Set(gomock.Any(), ppfmt, domain.FQDN("ip6.hello"), ipnet.IP6, ip6, api.TTL(1), false).Return(false),
+					m.EXPECT().Set(gomock.Any(), ppfmt, domain.FQDN("ip4.hello"), ipnet.IP4, ip4, api.TTL(1), false).Return(true, ""),
+					m.EXPECT().Set(gomock.Any(), ppfmt, domain.FQDN("ip6.hello"), ipnet.IP6, ip6, api.TTL(1), false).Return(false, "wrong"), //nolint:lll
 				)
 			},
 		},
@@ -148,6 +156,7 @@ func TestUpdateIPs(t *testing.T) {
 			api.TTLAuto,
 			proxiedBoth,
 			false,
+			"looking good",
 			map[ipnet.Type]bool{ipnet.IP4: true, ipnet.IP6: true},
 			func(m *mocks.MockPP) {
 				gomock.InOrder(
@@ -163,13 +172,14 @@ func TestUpdateIPs(t *testing.T) {
 				ipnet.IP6: provider6,
 			},
 			func(ppfmt pp.PP, m *mocks.MockSetter) {
-				m.EXPECT().Set(gomock.Any(), ppfmt, domain.FQDN("ip6.hello"), ipnet.IP6, ip6, api.TTL(1), true).Return(true)
+				m.EXPECT().Set(gomock.Any(), ppfmt, domain.FQDN("ip6.hello"), ipnet.IP6, ip6, api.TTL(1), true).Return(true, "looking good") //nolint:lll
 			},
 		},
 		"ip6fails": {
 			api.TTLAuto,
 			proxiedNone,
 			false,
+			"good",
 			map[ipnet.Type]bool{ipnet.IP4: true, ipnet.IP6: true},
 			func(m *mocks.MockPP) {
 				gomock.InOrder(
@@ -187,13 +197,14 @@ func TestUpdateIPs(t *testing.T) {
 				},
 			},
 			func(ppfmt pp.PP, m *mocks.MockSetter) {
-				m.EXPECT().Set(gomock.Any(), ppfmt, domain.FQDN("ip4.hello"), ipnet.IP4, ip4, api.TTL(1), false).Return(true)
+				m.EXPECT().Set(gomock.Any(), ppfmt, domain.FQDN("ip4.hello"), ipnet.IP4, ip4, api.TTL(1), false).Return(true, "good") //nolint:lll
 			},
 		},
 		"ip6fails/again": {
 			api.TTLAuto,
 			proxiedBoth,
 			false,
+			"",
 			map[ipnet.Type]bool{ipnet.IP4: true, ipnet.IP6: false},
 			func(m *mocks.MockPP) {
 				gomock.InOrder(
@@ -208,13 +219,14 @@ func TestUpdateIPs(t *testing.T) {
 				},
 			},
 			func(ppfmt pp.PP, m *mocks.MockSetter) {
-				m.EXPECT().Set(gomock.Any(), ppfmt, domain.FQDN("ip4.hello"), ipnet.IP4, ip4, api.TTL(1), true).Return(true)
+				m.EXPECT().Set(gomock.Any(), ppfmt, domain.FQDN("ip4.hello"), ipnet.IP4, ip4, api.TTL(1), true).Return(true, "")
 			},
 		},
 		"bothfail": {
 			api.TTLAuto,
 			proxiedNone,
 			false,
+			"",
 			map[ipnet.Type]bool{ipnet.IP4: true, ipnet.IP6: true},
 			func(m *mocks.MockPP) {
 				gomock.InOrder(
@@ -240,19 +252,20 @@ func TestUpdateIPs(t *testing.T) {
 			api.TTLAuto,
 			mockproxied{},
 			true,
+			"response",
 			map[ipnet.Type]bool{ipnet.IP4: true, ipnet.IP6: true},
 			func(m *mocks.MockPP) {
 				gomock.InOrder(
 					m.EXPECT().Infof(pp.EmojiInternet, "Detected the %s address: %v", "IPv4", ip4),
 					m.EXPECT().Warningf(pp.EmojiImpossible,
-						"Proxied[%s] not initialized; please report the bug at https://github.com/favonia/cloudflare-ddns/issues/new",
+						"Proxied[%s] not initialized; this should not happen; please report the bug at https://github.com/favonia/cloudflare-ddns/issues/new", //nolint:lll
 						"ip4.hello",
 					),
 				)
 			},
 			mockproviders{ipnet.IP4: provider4},
 			func(ppfmt pp.PP, m *mocks.MockSetter) {
-				m.EXPECT().Set(gomock.Any(), ppfmt, domain.FQDN("ip4.hello"), ipnet.IP4, ip4, api.TTL(1), false).Return(true)
+				m.EXPECT().Set(gomock.Any(), ppfmt, domain.FQDN("ip4.hello"), ipnet.IP4, ip4, api.TTL(1), false).Return(true, "response") //nolint:lll
 			},
 		},
 	} {
@@ -282,8 +295,9 @@ func TestUpdateIPs(t *testing.T) {
 			if tc.prepareMockSetter != nil {
 				tc.prepareMockSetter(mockPP, mockSetter)
 			}
-			ok := updater.UpdateIPs(ctx, mockPP, conf, mockSetter)
+			ok, msg := updater.UpdateIPs(ctx, mockPP, conf, mockSetter)
 			require.Equal(t, tc.ok, ok)
+			require.Equal(t, tc.msg, msg)
 		})
 	}
 }
@@ -306,6 +320,7 @@ func TestClearIPs(t *testing.T) {
 		ttl                  api.TTL
 		proxied              mockproxied
 		ok                   bool
+		msg                  string
 		MessageShouldDisplay map[ipnet.Type]bool
 		prepareMockPP        func(m *mocks.MockPP)
 		prepareMockProvider  mockproviders
@@ -315,6 +330,7 @@ func TestClearIPs(t *testing.T) {
 			api.TTLAuto,
 			proxiedNone,
 			true,
+			``,
 			map[ipnet.Type]bool{ipnet.IP4: true, ipnet.IP6: true},
 			nil,
 			mockproviders{},
@@ -324,57 +340,62 @@ func TestClearIPs(t *testing.T) {
 			api.TTLAuto,
 			proxiedNone,
 			true,
+			"hello",
 			map[ipnet.Type]bool{ipnet.IP4: true, ipnet.IP6: true},
 			nil,
 			mockproviders{ipnet.IP4: true},
 			func(ppfmt pp.PP, m *mocks.MockSetter) {
-				m.EXPECT().Set(gomock.Any(), ppfmt, domain4, ipnet.IP4, netip.Addr{}, api.TTL(1), false).Return(true)
+				m.EXPECT().Set(gomock.Any(), ppfmt, domain4, ipnet.IP4, netip.Addr{}, api.TTL(1), false).Return(true, "hello")
 			},
 		},
 		"ip4only/setfail": {
 			api.TTLAuto,
 			proxiedNone,
 			false,
+			"err",
 			map[ipnet.Type]bool{ipnet.IP4: true, ipnet.IP6: true},
 			nil,
 			mockproviders{ipnet.IP4: true},
 			func(ppfmt pp.PP, m *mocks.MockSetter) {
-				m.EXPECT().Set(gomock.Any(), ppfmt, domain4, ipnet.IP4, netip.Addr{}, api.TTL(1), false).Return(false)
+				m.EXPECT().Set(gomock.Any(), ppfmt, domain4, ipnet.IP4, netip.Addr{}, api.TTL(1), false).Return(false, "err")
 			},
 		},
 		"ip6only": {
 			api.TTLAuto,
 			proxiedNone,
 			true,
+			"",
 			map[ipnet.Type]bool{ipnet.IP4: true, ipnet.IP6: true},
 			nil,
 			mockproviders{ipnet.IP6: true},
 			func(ppfmt pp.PP, m *mocks.MockSetter) {
-				m.EXPECT().Set(gomock.Any(), ppfmt, domain6, ipnet.IP6, netip.Addr{}, api.TTL(1), false).Return(true)
+				m.EXPECT().Set(gomock.Any(), ppfmt, domain6, ipnet.IP6, netip.Addr{}, api.TTL(1), false).Return(true, "")
 			},
 		},
 		"ip6only/setfail": {
 			api.TTLAuto,
 			proxiedNone,
 			false,
+			"test",
 			map[ipnet.Type]bool{ipnet.IP4: true, ipnet.IP6: true},
 			nil,
 			mockproviders{ipnet.IP6: true},
 			func(ppfmt pp.PP, m *mocks.MockSetter) {
-				m.EXPECT().Set(gomock.Any(), ppfmt, domain6, ipnet.IP6, netip.Addr{}, api.TTL(1), false).Return(false)
+				m.EXPECT().Set(gomock.Any(), ppfmt, domain6, ipnet.IP6, netip.Addr{}, api.TTL(1), false).Return(false, "test")
 			},
 		},
 		"both": {
 			api.TTLAuto,
 			proxiedNone,
 			true,
+			"both\nneither",
 			map[ipnet.Type]bool{ipnet.IP4: true, ipnet.IP6: true},
 			nil,
 			mockproviders{ipnet.IP4: true, ipnet.IP6: true},
 			func(ppfmt pp.PP, m *mocks.MockSetter) {
 				gomock.InOrder(
-					m.EXPECT().Set(gomock.Any(), ppfmt, domain4, ipnet.IP4, netip.Addr{}, api.TTL(1), false).Return(true),
-					m.EXPECT().Set(gomock.Any(), ppfmt, domain6, ipnet.IP6, netip.Addr{}, api.TTL(1), false).Return(true),
+					m.EXPECT().Set(gomock.Any(), ppfmt, domain4, ipnet.IP4, netip.Addr{}, api.TTL(1), false).Return(true, "both"),
+					m.EXPECT().Set(gomock.Any(), ppfmt, domain6, ipnet.IP6, netip.Addr{}, api.TTL(1), false).Return(true, "neither"),
 				)
 			},
 		},
@@ -382,13 +403,14 @@ func TestClearIPs(t *testing.T) {
 			api.TTLAuto,
 			proxiedNone,
 			false,
+			"999",
 			map[ipnet.Type]bool{ipnet.IP4: true, ipnet.IP6: true},
 			nil,
 			mockproviders{ipnet.IP4: true, ipnet.IP6: true},
 			func(ppfmt pp.PP, m *mocks.MockSetter) {
 				gomock.InOrder(
-					m.EXPECT().Set(gomock.Any(), ppfmt, domain4, ipnet.IP4, netip.Addr{}, api.TTL(1), false).Return(false),
-					m.EXPECT().Set(gomock.Any(), ppfmt, domain6, ipnet.IP6, netip.Addr{}, api.TTL(1), false).Return(true),
+					m.EXPECT().Set(gomock.Any(), ppfmt, domain4, ipnet.IP4, netip.Addr{}, api.TTL(1), false).Return(false, ""),
+					m.EXPECT().Set(gomock.Any(), ppfmt, domain6, ipnet.IP6, netip.Addr{}, api.TTL(1), false).Return(true, "999"),
 				)
 			},
 		},
@@ -396,13 +418,14 @@ func TestClearIPs(t *testing.T) {
 			api.TTLAuto,
 			proxiedNone,
 			false,
+			"1\n2",
 			map[ipnet.Type]bool{ipnet.IP4: true, ipnet.IP6: true},
 			nil,
 			mockproviders{ipnet.IP4: true, ipnet.IP6: true},
 			func(ppfmt pp.PP, m *mocks.MockSetter) {
 				gomock.InOrder(
-					m.EXPECT().Set(gomock.Any(), ppfmt, domain4, ipnet.IP4, netip.Addr{}, api.TTL(1), false).Return(true),
-					m.EXPECT().Set(gomock.Any(), ppfmt, domain6, ipnet.IP6, netip.Addr{}, api.TTL(1), false).Return(false),
+					m.EXPECT().Set(gomock.Any(), ppfmt, domain4, ipnet.IP4, netip.Addr{}, api.TTL(1), false).Return(true, "1"),
+					m.EXPECT().Set(gomock.Any(), ppfmt, domain6, ipnet.IP6, netip.Addr{}, api.TTL(1), false).Return(false, "2"),
 				)
 			},
 		},
@@ -432,8 +455,9 @@ func TestClearIPs(t *testing.T) {
 			if tc.prepareMockSetter != nil {
 				tc.prepareMockSetter(mockPP, mockSetter)
 			}
-			ok := updater.ClearIPs(ctx, mockPP, conf, mockSetter)
+			ok, msg := updater.ClearIPs(ctx, mockPP, conf, mockSetter)
 			require.Equal(t, tc.ok, ok)
+			require.Equal(t, tc.msg, msg)
 		})
 	}
 }


### PR DESCRIPTION
1. Explicitly document that any instance of Healthchecks is supported
2. Warn about HTTP connections
3. Use POST method to work with the POST-only mode
4. Send summary for IP updating, record cleaning, and failures