### PR TITLE
ci: (hopefully) allow ClusterFuzzLite to upload artifact

### DIFF
--- a/.github/workflows/cflite_pr.yml
+++ b/.github/workflows/cflite_pr.yml
@@ -1,6 +1,8 @@
 name: ClusterFuzzLite
 on: pull_request
-permissions: read-all
+permissions:
+  contents: read
+  packages: write
 jobs:
   PR:
     runs-on: ubuntu-latest


### PR DESCRIPTION
ClusterFuzzLite was able to find some bugs (either in code or in the fuzzing test), but failed to upload artifacts. This PR is to fix that.