### PR TITLE
docs(README): make sure `PROXIED` is disabled for non-web servers

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -128,6 +128,8 @@ services:
       - PROXIED=true
 ```
 
+⚠️ The setting `PROXIED=true` instructs Cloudflare to cache webpages on your machine and hide its actual IP addresses. If you wish to bypass that and expose your actual IP addresses, simply remove `PROXIED=true`. If your traffic is not HTTP(S), then Cloudflare cannot proxy it and you must turn off the proxying by removing `PROXIED=true`. (The default value of `PROXIED` is `false`.)
+
 _(Click to expand the following items.)_
 
 <details>
@@ -163,13 +165,6 @@ Docker’s default restart policies should prevent excessive logging when there 
 <summary>🛡️ Use <code>cap_drop</code>, <code>read_only</code>, <code>no-new-privileges</code>, <code>PUID</code>, and <code>PGID</code> to protect yourself.</summary>
 
 Change `1000` to the user or group IDs you wish to use to run the updater. The settings `cap_drop`, `read_only`, and `no-new-privileges` provide additional protection, especially when you run the container as a non-superuser. The updater itself will read <code>PUID</code> and <code>PGID</code> and attempt to drop all superuser privileges.
-
-</details>
-
-<details>
-<summary>🎭 Use <code>PROXIED=true</code> to hide your IP addresses.</summary>
-
-The setting `PROXIED=true` instructs Cloudflare to cache webpages on your machine and hide your actual IP addresses. If you wish to bypass that and expose your actual IP addresses, simply remove `PROXIED=true`. If your traffic is not HTTP(S), then Cloudflare cannot proxy it and you must turn off the proxying by removing `PROXIED=true`. (The default value of `PROXIED` is `false`.)
 
 </details>
 


### PR DESCRIPTION
This is to address the documentation issue I learned from #345. @truthsword