### PR TITLE
fix(api): optimize network traffic for UpdateRecord

### DIFF
--- a/internal/api/cloudflare.go
+++ b/internal/api/cloudflare.go
@@ -242,8 +242,6 @@ func (h *CloudflareHandle) UpdateRecord(ctx context.Context, ppfmt pp.PP,
 	//nolint:exhaustruct // Other fields are intentionally omitted
 	params := cloudflare.UpdateDNSRecordParams{
 		ID:      id,
-		Name:    domain.DNSNameASCII(),
-		Type:    ipNet.RecordType(),
 		Content: ip.String(),
 	}
 

--- a/internal/api/cloudflare_test.go
+++ b/internal/api/cloudflare_test.go
@@ -924,8 +924,6 @@ func TestUpdateRecordValid(t *testing.T) {
 			err := json.NewDecoder(r.Body).Decode(&record)
 			require.NoError(t, err)
 
-			require.Equal(t, "sub.test.org", record.Name)
-			require.Equal(t, ipnet.IP6.RecordType(), record.Type)
 			require.Equal(t, "::2", record.Content)
 
 			w.Header().Set("content-type", "application/json")


### PR DESCRIPTION
- [x] cloudflare/cloudflare-go#1170

The testing should automatically pass with a new release of `cloudflare-go` with the above PR merged. (The optimization is small, but why not! :laughing:)