### PR TITLE
ci: remove Cosign from CI

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -83,9 +83,3 @@ jobs:
           platforms: ${{ env.platforms }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-      - name: ✍️ Install Cosign
-        uses: sigstore/cosign-installer@c3667d99424e7e6047999fb6246c0da843953c65 # 3.0.1
-      - name: ✍️ Sign the Docker images
-        if: ${{ github.event_name != 'pull_request' }}
-        run: |
-          cosign sign --recursive --yes "favonia/cloudflare-ddns@${{ steps.build.outputs.digest }}"


### PR DESCRIPTION
The device flow of Cosign is difficult to complete within GitHub Actions. (For example, if I open GitHub Actions logging too late, it is impossible for me to see the OIDC link before it fails.)