### PR TITLE
ci: relax network blocking until someone else makes a PR

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -28,6 +28,7 @@ jobs:
       - name: 🛡️ Harden Runner
         uses: step-security/harden-runner@1b05615854632b887b69ae1be8cbefe72d3ae423 # v2.6.0
         with:
+          egress-policy: audit
           disable-sudo: true
           policy: build
 

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -20,6 +20,7 @@ jobs:
       - name: Harden Runner
         uses: step-security/harden-runner@1b05615854632b887b69ae1be8cbefe72d3ae423 # v2.6.0
         with:
+          egress-policy: audit
           disable-sudo: true
           policy: dependency-review
 

--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -19,6 +19,7 @@ jobs:
       - name: 🛡️ Harden Runner
         uses: step-security/harden-runner@1b05615854632b887b69ae1be8cbefe72d3ae423 # v2.6.0
         with:
+          egress-policy: audit
           disable-sudo: true
           policy: golangci-lint
 

--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -34,6 +34,7 @@ jobs:
       - name: Harden Runner
         uses: step-security/harden-runner@1b05615854632b887b69ae1be8cbefe72d3ae423 # v2.6.0
         with:
+          egress-policy: audit
           disable-sudo: true
           policy: scorecards
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -19,6 +19,7 @@ jobs:
       - name: 🛡️ Harden Runner
         uses: step-security/harden-runner@1b05615854632b887b69ae1be8cbefe72d3ae423 # v2.6.0
         with:
+          egress-policy: audit
           disable-sudo: true
           policy: test
 
@@ -53,6 +54,7 @@ jobs:
       - name: 🛡️ Harden Runner
         uses: step-security/harden-runner@1b05615854632b887b69ae1be8cbefe72d3ae423 # v2.6.0
         with:
+          egress-policy: audit
           disable-sudo: true
           policy: test.fuzz
 
@@ -78,6 +80,7 @@ jobs:
       - name: 🛡️ Harden Runner
         uses: step-security/harden-runner@1b05615854632b887b69ae1be8cbefe72d3ae423 # v2.6.0
         with:
+          egress-policy: audit
           disable-sudo: true
           policy: test.regenerate
 


### PR DESCRIPTION
The current policy is too strict for a non-maintainer to run CI.