### PR TITLE
fix: put annotations only within the index manifest

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -66,7 +66,7 @@ jobs:
             io.artifacthub.package.readme-url=https://raw.githubusercontent.com/favonia/cloudflare-ddns/main/build/SUMMARY.markdown
             io.artifacthub.package.maintainers=[{"name":"favonia","email":"favonia@email.com"}]
         env:
-          DOCKER_METADATA_ANNOTATIONS_LEVELS: manifest,index
+          DOCKER_METADATA_ANNOTATIONS_LEVELS: index
       - name: 🚀 Build and deploy minimal Docker images
         uses: docker/build-push-action@4a13e500e55cf31b7a5d59a38ab2040ab0f42f56 # v5.1.0
         id: build


### PR DESCRIPTION
After digging into the source code of ArtifactHub, I believe it doesn't make much sense to add ArtifactHub-specific annotations within individual image manifests. What should be changed is ArtifactHub, not this tool.

Since GitHub registry also expects annotations at the index level. 'manifest' was removed. This is reverting the PR #652.