### PR TITLE
fix: trim the response of `url:URL` before parsing it

### DIFF
--- a/internal/provider/protocol/http.go
+++ b/internal/provider/protocol/http.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 	"net/netip"
+	"strings"
 
 	"github.com/favonia/cloudflare-ddns/internal/ipnet"
 	"github.com/favonia/cloudflare-ddns/internal/pp"
@@ -16,7 +17,7 @@ func getIPFromHTTP(ctx context.Context, ppfmt pp.PP, url string) (netip.Addr, bo
 		additionalHeaders: nil,
 		requestBody:       nil,
 		extract: func(_ pp.PP, body []byte) (netip.Addr, bool) {
-			ipString := string(body)
+			ipString := strings.TrimSpace(string(body))
 			ip, err := netip.ParseAddr(ipString)
 			if err != nil {
 				ppfmt.Errorf(pp.EmojiImpossible, `Failed to parse the IP address in the response of %q: %s`, url, ipString)


### PR DESCRIPTION
The idea was adapted from the following commit: https://github.com/gizmo-ds/cloudflare-ddns/commit/3a66d702eefe568d1da5c2f6ef2f2339d76551de

Thanks to @gizmo-ds