### PR TITLE
test: undo the hacks that made Go 1.22.{0,1} work

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -33,7 +33,7 @@ jobs:
           go-version: stable
       - name: 🧪 Run `go test`
         run: |
-          go test $(go list ./... | grep -v 'internal/mocks') -coverprofile=coverage.txt -race -v ./...
+          go test -coverpkg=$(go list ./... | grep -v 'internal/mocks' | tr '\n' ',') -coverprofile=coverage.txt -race -v ./...
       - name: ☂️ Report coverage rates to Codecov
         uses: codecov/codecov-action@e28ff129e5465c2c0dcc6f003fc735cb6ae0c673 # 4.5.0
         with:

--- a/cmd/ddns/ddns_test.go
+++ b/cmd/ddns/ddns_test.go
@@ -1,6 +1,0 @@
-// Package main_test is a dummy testing package to ensure that
-// the files in this directory are counted in the coverage report.
-//
-// Note: this was caused by a bug introduced in newer coverage
-// tool and can perhaps be removed in the future.
-package main_test

--- a/internal/droproot/drop_test.go
+++ b/internal/droproot/drop_test.go
@@ -1,6 +1,0 @@
-// Package droproot_test is a dummy testing package to ensure that
-// the files in this directory are counted in the coverage report.
-//
-// Note: this was caused by a bug introduced in newer coverage
-// tool and can perhaps be removed in the future.
-package droproot_test


### PR DESCRIPTION
Close #700. Related: #688.