### PR TITLE
fix(monitor): distinguish success pinging from logging in SendResponse

### DIFF
--- a/cmd/ddns/ddns.go
+++ b/cmd/ddns/ddns.go
@@ -57,7 +57,7 @@ func initConfig(ctx context.Context, ppfmt pp.PP) (*config.Config, setter.Setter
 func stopUpdating(ctx context.Context, ppfmt pp.PP, c *config.Config, s setter.Setter) {
 	if c.DeleteOnStop {
 		resp := updater.DeleteIPs(ctx, ppfmt, c, s)
-		monitor.SendResponseAll(ctx, ppfmt, c.Monitors, resp)
+		monitor.SendResponseAll(ctx, ppfmt, c.Monitors, resp, false)
 		notifier.SendResponseAll(ctx, ppfmt, c.Notifiers, resp)
 	}
 }
@@ -123,7 +123,7 @@ func realMain() int { //nolint:funlen
 			monitor.SuccessAll(ctx, ppfmt, c.Monitors, "Started (no action)")
 		} else {
 			resp := updater.UpdateIPs(ctxWithSignals, ppfmt, c, s)
-			monitor.SendResponseAll(ctx, ppfmt, c.Monitors, resp)
+			monitor.SendResponseAll(ctx, ppfmt, c.Monitors, resp, true)
 			notifier.SendResponseAll(ctx, ppfmt, c.Notifiers, resp)
 		}
 

--- a/internal/monitor/base.go
+++ b/internal/monitor/base.go
@@ -36,11 +36,14 @@ type Monitor interface {
 	ExitStatus(ctx context.Context, ppfmt pp.PP, code int, message string) bool
 }
 
-func SendResponse(ctx context.Context, ppfmt pp.PP, m Monitor, r response.Response) bool {
+func SendResponse(ctx context.Context, ppfmt pp.PP, m Monitor, r response.Response, ping bool) bool {
 	msg := strings.Join(r.MonitorMessages, "\n")
-	if r.Ok {
+	switch {
+	case r.Ok && ping:
+		return m.Success(ctx, ppfmt, msg)
+	case r.Ok && !ping:
 		return m.Log(ctx, ppfmt, msg)
-	} else {
+	default:
 		return m.Failure(ctx, ppfmt, msg)
 	}
 }

--- a/internal/monitor/composite.go
+++ b/internal/monitor/composite.go
@@ -70,10 +70,10 @@ func ExitStatusAll(ctx context.Context, ppfmt pp.PP, ms []Monitor, code int, mes
 }
 
 // SendResponseAll calls [SendResponse] for each monitor in ms.
-func SendResponseAll(ctx context.Context, ppfmt pp.PP, ms []Monitor, resp response.Response) bool {
+func SendResponseAll(ctx context.Context, ppfmt pp.PP, ms []Monitor, resp response.Response, ping bool) bool {
 	ok := true
 	for _, m := range ms {
-		if !SendResponse(ctx, ppfmt, m, resp) {
+		if !SendResponse(ctx, ppfmt, m, resp, ping) {
 			ok = false
 		}
 	}


### PR DESCRIPTION
The bug was introduced in #762.