### PR TITLE
feat(api): recheck tokens when the network is temporarily down

### DIFF
--- a/cmd/ddns/ddns.go
+++ b/cmd/ddns/ddns.go
@@ -129,6 +129,15 @@ func realMain() int { //nolint:funlen
 		if first && !c.UpdateOnStart {
 			monitor.SuccessAll(ctx, ppfmt, c.Monitors, "Started (no action)")
 		} else {
+			if c.UpdateCron != nil && !s.SanityCheck(ctx, ppfmt) {
+				monitor.SuccessAll(ctx, ppfmt, c.Monitors, "Invalid Cloudflare API token")
+				notifier.SendAll(ctx, ppfmt, c.Notifiers,
+					"The Cloudflare API token is invalid. "+
+						"Please check the value of CF_API_TOKEN or CF_API_TOKEN_FILE.",
+				)
+				return 1
+			}
+
 			msg := updater.UpdateIPs(ctxWithSignals, ppfmt, c, s)
 			monitor.PingMessageAll(ctx, ppfmt, c.Monitors, msg)
 			notifier.SendMessageAll(ctx, ppfmt, c.Notifiers, msg)

--- a/internal/api/base.go
+++ b/internal/api/base.go
@@ -15,9 +15,9 @@ import (
 
 // A Handle represents a generic API to update DNS records. Currently, the only implementation is Cloudflare.
 type Handle interface {
-	// The first return value means whether the sanity check is passed.
-	// The second return value means whether the result will not change.
-	SanityCheck(ctx context.Context, ppfmt pp.PP) (bool, bool)
+	// Perform basic checking. It returns false when we should give up
+	// all future operations.
+	SanityCheck(ctx context.Context, ppfmt pp.PP) bool
 
 	// ListRecords lists all matching DNS records.
 	//

--- a/internal/api/base.go
+++ b/internal/api/base.go
@@ -15,7 +15,13 @@ import (
 
 // A Handle represents a generic API to update DNS records. Currently, the only implementation is Cloudflare.
 type Handle interface {
+	// The first return value means whether the sanity check is passed.
+	// The second return value means whether the result will not change.
+	SanityCheck(ctx context.Context, ppfmt pp.PP) (bool, bool)
+
 	// ListRecords lists all matching DNS records.
+	//
+	// The second return value means whether the list is cached.
 	ListRecords(ctx context.Context, ppfmt pp.PP, domain domain.Domain, ipNet ipnet.Type) (map[string]netip.Addr, bool, bool) //nolint:lll
 
 	// DeleteRecord deletes one DNS record.

--- a/internal/api/cloudflare.go
+++ b/internal/api/cloudflare.go
@@ -128,7 +128,8 @@ func (h *CloudflareHandle) SanityCheck(ctx context.Context, ppfmt pp.PP) (bool, 
 	}
 
 	if !res.ExpiresOn.IsZero() {
-		ppfmt.Warningf(pp.EmojiAlarm, "The token will expire at %v", res.ExpiresOn.In(time.Local).Format(time.Stamp))
+		ppfmt.Warningf(pp.EmojiAlarm, "The token will expire at %s",
+			res.ExpiresOn.UTC().Format(time.RFC3339))
 	}
 
 permanently:

--- a/internal/api/cloudflare_test.go
+++ b/internal/api/cloudflare_test.go
@@ -119,8 +119,10 @@ func TestNewValid(t *testing.T) {
 
 	_, h := newHandle(t, false, mockPP)
 
-	ok := h.SanityCheck(context.Background(), mockPP)
-	require.True(t, ok)
+	require.True(t, h.SanityCheck(context.Background(), mockPP))
+
+	// Test again to test the caching
+	require.True(t, h.SanityCheck(context.Background(), mockPP))
 }
 
 func TestNewEmpty(t *testing.T) {
@@ -243,11 +245,7 @@ func TestSanityCheckExpiring(t *testing.T) {
 			h, ok := auth.New(context.Background(), mockPP, time.Second)
 			require.True(t, ok)
 			require.NotNil(t, h)
-			ok = h.SanityCheck(context.Background(), mockPP)
-			require.Equal(t, tc.ok, ok)
-			if tc.ok {
-				require.NotNil(t, h)
-			}
+			require.Equal(t, tc.ok, h.SanityCheck(context.Background(), mockPP))
 		})
 	}
 }
@@ -302,8 +300,7 @@ func TestNewInvalid(t *testing.T) {
 			h, ok := auth.New(context.Background(), mockPP, time.Second)
 			require.True(t, ok)
 			require.NotNil(t, h)
-			ok = h.SanityCheck(context.Background(), mockPP)
-			require.False(t, ok)
+			require.False(t, h.SanityCheck(context.Background(), mockPP))
 		})
 	}
 }
@@ -327,8 +324,7 @@ func TestSanityCheckTimeout(t *testing.T) {
 	h, ok := auth.New(context.Background(), mockPP, time.Second)
 	require.True(t, ok)
 	require.NotNil(t, h)
-	ok = h.SanityCheck(context.Background(), mockPP)
-	require.True(t, ok)
+	require.True(t, h.SanityCheck(context.Background(), mockPP))
 }
 
 func mockZone(name string, i int, status string) *cloudflare.Zone {

--- a/internal/api/cloudflare_test.go
+++ b/internal/api/cloudflare_test.go
@@ -138,6 +138,118 @@ func TestNewEmpty(t *testing.T) {
 	require.Nil(t, h)
 }
 
+func TestNewExpiring(t *testing.T) {
+	t.Parallel()
+
+	for name, tc := range map[string]struct {
+		resp          string
+		ok            bool
+		prepareMockPP func(*mocks.MockPP)
+	}{
+		"expiring": {
+			`{
+  "success": true,
+  "errors": [],
+  "messages": [],
+  "result": {
+    "id": "11111111111111111111111111111111",
+    "status": "active",
+    "expires_on": "3000-01-01T00:00:00Z"
+  }
+}`,
+			true,
+			func(p *mocks.MockPP) {
+				deadline, err := time.Parse(time.RFC3339, "3000-01-01T00:00:00Z")
+				require.NoError(t, err)
+				p.EXPECT().Warningf(pp.EmojiAlarm, "The token will expire at %s",
+					deadline.Format(time.RFC3339))
+			},
+		},
+		"expired": {
+			`{
+  "success": true,
+  "errors": [],
+  "messages": [],
+  "result": {
+    "id": "11111111111111111111111111111111",
+    "status": "expired"
+  }
+}`,
+			false,
+			func(p *mocks.MockPP) {
+				gomock.InOrder(
+					p.EXPECT().Errorf(pp.EmojiUserError, "The Cloudflare API token is %s", "expired"),
+					p.EXPECT().Errorf(pp.EmojiUserError, "Please double-check the value of CF_API_TOKEN or CF_API_TOKEN_FILE"),
+				)
+			},
+		},
+		"funny": {
+			`{
+  "success": true,
+  "errors": [],
+  "messages": [],
+  "result": {
+    "id": "11111111111111111111111111111111",
+    "status": "funny"
+  }
+}`,
+			false,
+			func(p *mocks.MockPP) {
+				gomock.InOrder(
+					p.EXPECT().Errorf(pp.EmojiImpossible, "The Cloudflare API token is in an undocumented state: %s", "funny"),
+					p.EXPECT().Errorf(pp.EmojiImpossible, "Please report the bug at https://github.com/favonia/cloudflare-ddns/issues/new"), //nolint:lll
+					p.EXPECT().Errorf(pp.EmojiUserError, "Please double-check the value of CF_API_TOKEN or CF_API_TOKEN_FILE"),
+				)
+			},
+		},
+		"disabled": {
+			`{
+  "success": true,
+  "errors": [],
+  "messages": [],
+  "result": {
+    "id": "11111111111111111111111111111111",
+    "status": "disabled"
+  }
+}`,
+			false,
+			func(p *mocks.MockPP) {
+				gomock.InOrder(
+					p.EXPECT().Errorf(pp.EmojiUserError, "The Cloudflare API token is %s", "disabled"),
+					p.EXPECT().Errorf(pp.EmojiUserError, "Please double-check the value of CF_API_TOKEN or CF_API_TOKEN_FILE"),
+				)
+			},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			mockCtrl := gomock.NewController(t)
+			mux, auth := newServerAuth(t, false)
+			mux.HandleFunc("/user/tokens/verify", func(w http.ResponseWriter, r *http.Request) {
+				if !assert.Equal(t, http.MethodGet, r.Method) ||
+					!assert.Equal(t, []string{mockAuthString}, r.Header["Authorization"]) ||
+					!assert.Empty(t, r.URL.Query()) {
+					panic(http.ErrAbortHandler)
+				}
+
+				w.Header().Set("Content-Type", "application/json")
+				fmt.Fprint(w, tc.resp)
+			})
+
+			mockPP := mocks.NewMockPP(mockCtrl)
+			if tc.prepareMockPP != nil {
+				tc.prepareMockPP(mockPP)
+			}
+			h, ok := auth.New(context.Background(), mockPP, time.Second)
+			require.Equal(t, tc.ok, ok)
+			if tc.ok {
+				require.NotNil(t, h)
+			}
+		})
+	}
+}
+
 func TestNewInvalid(t *testing.T) {
 	t.Parallel()
 

--- a/internal/mocks/mock_api.go
+++ b/internal/mocks/mock_api.go
@@ -197,12 +197,11 @@ func (c *HandleListRecordsCall) DoAndReturn(f func(context.Context, pp.PP, domai
 }
 
 // SanityCheck mocks base method.
-func (m *MockHandle) SanityCheck(arg0 context.Context, arg1 pp.PP) (bool, bool) {
+func (m *MockHandle) SanityCheck(arg0 context.Context, arg1 pp.PP) bool {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SanityCheck", arg0, arg1)
 	ret0, _ := ret[0].(bool)
-	ret1, _ := ret[1].(bool)
-	return ret0, ret1
+	return ret0
 }
 
 // SanityCheck indicates an expected call of SanityCheck.
@@ -218,19 +217,19 @@ type HandleSanityCheckCall struct {
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *HandleSanityCheckCall) Return(arg0, arg1 bool) *HandleSanityCheckCall {
-	c.Call = c.Call.Return(arg0, arg1)
+func (c *HandleSanityCheckCall) Return(arg0 bool) *HandleSanityCheckCall {
+	c.Call = c.Call.Return(arg0)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *HandleSanityCheckCall) Do(f func(context.Context, pp.PP) (bool, bool)) *HandleSanityCheckCall {
+func (c *HandleSanityCheckCall) Do(f func(context.Context, pp.PP) bool) *HandleSanityCheckCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *HandleSanityCheckCall) DoAndReturn(f func(context.Context, pp.PP) (bool, bool)) *HandleSanityCheckCall {
+func (c *HandleSanityCheckCall) DoAndReturn(f func(context.Context, pp.PP) bool) *HandleSanityCheckCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/internal/mocks/mock_api.go
+++ b/internal/mocks/mock_api.go
@@ -196,6 +196,45 @@ func (c *HandleListRecordsCall) DoAndReturn(f func(context.Context, pp.PP, domai
 	return c
 }
 
+// SanityCheck mocks base method.
+func (m *MockHandle) SanityCheck(arg0 context.Context, arg1 pp.PP) (bool, bool) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SanityCheck", arg0, arg1)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(bool)
+	return ret0, ret1
+}
+
+// SanityCheck indicates an expected call of SanityCheck.
+func (mr *MockHandleMockRecorder) SanityCheck(arg0, arg1 any) *HandleSanityCheckCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SanityCheck", reflect.TypeOf((*MockHandle)(nil).SanityCheck), arg0, arg1)
+	return &HandleSanityCheckCall{Call: call}
+}
+
+// HandleSanityCheckCall wrap *gomock.Call
+type HandleSanityCheckCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *HandleSanityCheckCall) Return(arg0, arg1 bool) *HandleSanityCheckCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *HandleSanityCheckCall) Do(f func(context.Context, pp.PP) (bool, bool)) *HandleSanityCheckCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *HandleSanityCheckCall) DoAndReturn(f func(context.Context, pp.PP) (bool, bool)) *HandleSanityCheckCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // UpdateRecord mocks base method.
 func (m *MockHandle) UpdateRecord(arg0 context.Context, arg1 pp.PP, arg2 domain.Domain, arg3 ipnet.Type, arg4 string, arg5 netip.Addr) bool {
 	m.ctrl.T.Helper()

--- a/internal/mocks/mock_setter.go
+++ b/internal/mocks/mock_setter.go
@@ -82,6 +82,44 @@ func (c *SetterDeleteCall) DoAndReturn(f func(context.Context, pp.PP, domain.Dom
 	return c
 }
 
+// SanityCheck mocks base method.
+func (m *MockSetter) SanityCheck(arg0 context.Context, arg1 pp.PP) bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SanityCheck", arg0, arg1)
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// SanityCheck indicates an expected call of SanityCheck.
+func (mr *MockSetterMockRecorder) SanityCheck(arg0, arg1 any) *SetterSanityCheckCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SanityCheck", reflect.TypeOf((*MockSetter)(nil).SanityCheck), arg0, arg1)
+	return &SetterSanityCheckCall{Call: call}
+}
+
+// SetterSanityCheckCall wrap *gomock.Call
+type SetterSanityCheckCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *SetterSanityCheckCall) Return(arg0 bool) *SetterSanityCheckCall {
+	c.Call = c.Call.Return(arg0)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *SetterSanityCheckCall) Do(f func(context.Context, pp.PP) bool) *SetterSanityCheckCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *SetterSanityCheckCall) DoAndReturn(f func(context.Context, pp.PP) bool) *SetterSanityCheckCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // Set mocks base method.
 func (m *MockSetter) Set(arg0 context.Context, arg1 pp.PP, arg2 domain.Domain, arg3 ipnet.Type, arg4 netip.Addr, arg5 api.TTL, arg6 bool, arg7 string) setter.ResponseCode {
 	m.ctrl.T.Helper()

--- a/internal/setter/base.go
+++ b/internal/setter/base.go
@@ -19,6 +19,12 @@ import (
 
 // Setter uses [api.Handle] to update DNS records.
 type Setter interface {
+	// SanityCheck determines whether one should continue trying
+	SanityCheck(
+		ctx context.Context,
+		ppfmt pp.PP,
+	) bool
+
 	// Set sets a particular domain to the given IP address.
 	Set(
 		ctx context.Context,

--- a/internal/setter/code.go
+++ b/internal/setter/code.go
@@ -17,4 +17,8 @@ const (
 	// but we failed to finish the updating, or that they
 	// should be deleted and we failed to finish the deletion.
 	ResponseFailed
+
+	// ResponseSanityFailed means sanity check failed and
+	// there is no point in performing actual operations.
+	ResponseSanityFailed
 )

--- a/internal/setter/code.go
+++ b/internal/setter/code.go
@@ -17,8 +17,4 @@ const (
 	// but we failed to finish the updating, or that they
 	// should be deleted and we failed to finish the deletion.
 	ResponseFailed
-
-	// ResponseSanityFailed means sanity check failed and
-	// there is no point in performing actual operations.
-	ResponseSanityFailed
 )

--- a/internal/setter/setter.go
+++ b/internal/setter/setter.go
@@ -52,6 +52,10 @@ func (s *setter) Set(ctx context.Context, ppfmt pp.PP,
 	recordType := ipnet.RecordType()
 	domainDescription := domain.Describe()
 
+	if ok, _ := s.Handle.SanityCheck(ctx, ppfmt); !ok {
+		return ResponseSanityFailed
+	}
+
 	rs, cached, ok := s.Handle.ListRecords(ctx, ppfmt, domain, ipnet)
 	if !ok {
 		ppfmt.Errorf(pp.EmojiError, "Failed to retrieve the current %s records of %q", recordType, domainDescription)

--- a/internal/setter/setter.go
+++ b/internal/setter/setter.go
@@ -43,6 +43,10 @@ func New(_ppfmt pp.PP, handle api.Handle) (Setter, bool) {
 	}, true
 }
 
+func (s *setter) SanityCheck(ctx context.Context, ppfmt pp.PP) bool {
+	return s.Handle.SanityCheck(ctx, ppfmt)
+}
+
 // Set updates the IP address of one domain to the given ip. The ip must be non-zero.
 //
 //nolint:funlen
@@ -51,10 +55,6 @@ func (s *setter) Set(ctx context.Context, ppfmt pp.PP,
 ) ResponseCode {
 	recordType := ipnet.RecordType()
 	domainDescription := domain.Describe()
-
-	if ok, _ := s.Handle.SanityCheck(ctx, ppfmt); !ok {
-		return ResponseSanityFailed
-	}
 
 	rs, cached, ok := s.Handle.ListRecords(ctx, ppfmt, domain, ipnet)
 	if !ok {

--- a/internal/setter/setter_test.go
+++ b/internal/setter/setter_test.go
@@ -63,7 +63,6 @@ func TestSet(t *testing.T) {
 			setter.ResponseUpdated,
 			func(ctx context.Context, _ func(), p *mocks.MockPP, h *mocks.MockHandle) {
 				gomock.InOrder(
-					h.EXPECT().SanityCheck(ctx, p).Return(true, true),
 					h.EXPECT().ListRecords(ctx, p, domain, ipNetwork).Return(map[string]netip.Addr{}, true, true),
 					h.EXPECT().CreateRecord(ctx, p, domain, ipNetwork, ip1, api.TTLAuto, false, "hello").Return(record1, true),
 					p.EXPECT().Noticef(pp.EmojiCreateRecord, "Added a new %s record of %q (ID: %q)", "AAAA", "sub.test.org", record1),
@@ -75,7 +74,6 @@ func TestSet(t *testing.T) {
 			setter.ResponseUpdated,
 			func(ctx context.Context, _ func(), p *mocks.MockPP, h *mocks.MockHandle) {
 				gomock.InOrder(
-					h.EXPECT().SanityCheck(ctx, p).Return(true, true),
 					h.EXPECT().ListRecords(ctx, p, domain, ipNetwork).Return(map[string]netip.Addr{record1: ip2}, true, true),
 					h.EXPECT().UpdateRecord(ctx, p, domain, ipNetwork, record1, ip1).Return(true),
 					p.EXPECT().Noticef(pp.EmojiUpdateRecord,
@@ -92,7 +90,6 @@ func TestSet(t *testing.T) {
 			setter.ResponseUpdated,
 			func(ctx context.Context, _ func(), p *mocks.MockPP, h *mocks.MockHandle) {
 				gomock.InOrder(
-					h.EXPECT().SanityCheck(ctx, p).Return(true, true),
 					h.EXPECT().ListRecords(ctx, p, domain, ipNetwork).Return(map[string]netip.Addr{record1: ip2}, true, true),
 					h.EXPECT().UpdateRecord(ctx, p, domain, ipNetwork, record1, ip1).Return(false),
 					h.EXPECT().DeleteRecord(ctx, p, domain, ipNetwork, record1).Return(true),
@@ -107,7 +104,6 @@ func TestSet(t *testing.T) {
 			setter.ResponseFailed,
 			func(ctx context.Context, cancel func(), p *mocks.MockPP, h *mocks.MockHandle) {
 				gomock.InOrder(
-					h.EXPECT().SanityCheck(ctx, p).Return(true, true),
 					h.EXPECT().ListRecords(ctx, p, domain, ipNetwork).
 						Return(map[string]netip.Addr{record1: ip2}, true, true),
 					h.EXPECT().UpdateRecord(ctx, p, domain, ipNetwork, record1, ip1).
@@ -121,7 +117,6 @@ func TestSet(t *testing.T) {
 			setter.ResponseFailed,
 			func(ctx context.Context, cancel func(), p *mocks.MockPP, h *mocks.MockHandle) {
 				gomock.InOrder(
-					h.EXPECT().SanityCheck(ctx, p).Return(true, true),
 					h.EXPECT().ListRecords(ctx, p, domain, ipNetwork).
 						Return(map[string]netip.Addr{record1: ip2}, true, true),
 					h.EXPECT().UpdateRecord(ctx, p, domain, ipNetwork, record1, ip1).
@@ -137,7 +132,6 @@ func TestSet(t *testing.T) {
 			setter.ResponseNoop,
 			func(ctx context.Context, _ func(), p *mocks.MockPP, h *mocks.MockHandle) {
 				gomock.InOrder(
-					h.EXPECT().SanityCheck(ctx, p).Return(true, true),
 					h.EXPECT().ListRecords(ctx, p, domain, ipNetwork).Return(map[string]netip.Addr{record1: ip1}, true, true),
 					p.EXPECT().Infof(pp.EmojiAlreadyDone,
 						"The %s records of %q are already up to date (cached)", "AAAA", "sub.test.org"),
@@ -149,7 +143,6 @@ func TestSet(t *testing.T) {
 			setter.ResponseNoop,
 			func(ctx context.Context, _ func(), p *mocks.MockPP, h *mocks.MockHandle) {
 				gomock.InOrder(
-					h.EXPECT().SanityCheck(ctx, p).Return(true, true),
 					h.EXPECT().ListRecords(ctx, p, domain, ipNetwork).Return(map[string]netip.Addr{record1: ip1}, false, true),
 					p.EXPECT().Infof(pp.EmojiAlreadyDone, "The %s records of %q are already up to date", "AAAA", "sub.test.org"),
 				)
@@ -160,7 +153,6 @@ func TestSet(t *testing.T) {
 			setter.ResponseUpdated,
 			func(ctx context.Context, _ func(), p *mocks.MockPP, h *mocks.MockHandle) {
 				gomock.InOrder(
-					h.EXPECT().SanityCheck(ctx, p).Return(true, true),
 					h.EXPECT().ListRecords(ctx, p, domain, ipNetwork).
 						Return(map[string]netip.Addr{record1: ip1, record2: ip1}, true, true),
 					h.EXPECT().DeleteRecord(ctx, p, domain, ipNetwork, record2).Return(true),
@@ -179,7 +171,6 @@ func TestSet(t *testing.T) {
 			setter.ResponseUpdated,
 			func(ctx context.Context, _ func(), p *mocks.MockPP, h *mocks.MockHandle) {
 				gomock.InOrder(
-					h.EXPECT().SanityCheck(ctx, p).Return(true, true),
 					h.EXPECT().ListRecords(ctx, p, domain, ipNetwork).
 						Return(map[string]netip.Addr{record1: ip1, record2: ip1}, true, true),
 					h.EXPECT().DeleteRecord(ctx, p, domain, ipNetwork, record2).Return(false),
@@ -191,7 +182,6 @@ func TestSet(t *testing.T) {
 			setter.ResponseFailed,
 			func(ctx context.Context, cancel func(), p *mocks.MockPP, h *mocks.MockHandle) {
 				gomock.InOrder(
-					h.EXPECT().SanityCheck(ctx, p).Return(true, true),
 					h.EXPECT().ListRecords(ctx, p, domain, ipNetwork).
 						Return(map[string]netip.Addr{record1: ip1, record2: ip1}, true, true),
 					h.EXPECT().DeleteRecord(ctx, p, domain, ipNetwork, record2).
@@ -205,7 +195,6 @@ func TestSet(t *testing.T) {
 			setter.ResponseUpdated,
 			func(ctx context.Context, _ func(), p *mocks.MockPP, h *mocks.MockHandle) {
 				gomock.InOrder(
-					h.EXPECT().SanityCheck(ctx, p).Return(true, true),
 					h.EXPECT().ListRecords(ctx, p, domain, ipNetwork).
 						Return(map[string]netip.Addr{record1: ip2, record2: ip2}, true, true),
 					h.EXPECT().UpdateRecord(ctx, p, domain, ipNetwork, record1, ip1).Return(true),
@@ -230,7 +219,6 @@ func TestSet(t *testing.T) {
 			setter.ResponseFailed,
 			func(ctx context.Context, cancel func(), p *mocks.MockPP, h *mocks.MockHandle) {
 				gomock.InOrder(
-					h.EXPECT().SanityCheck(ctx, p).Return(true, true),
 					h.EXPECT().ListRecords(ctx, p, domain, ipNetwork).
 						Return(map[string]netip.Addr{record1: ip2, record2: ip2}, true, true),
 					h.EXPECT().UpdateRecord(ctx, p, domain, ipNetwork, record1, ip1).Return(true),
@@ -252,7 +240,6 @@ func TestSet(t *testing.T) {
 			setter.ResponseUpdated,
 			func(ctx context.Context, _ func(), p *mocks.MockPP, h *mocks.MockHandle) {
 				gomock.InOrder(
-					h.EXPECT().SanityCheck(ctx, p).Return(true, true),
 					h.EXPECT().ListRecords(ctx, p, domain, ipNetwork).
 						Return(map[string]netip.Addr{record1: ip2, record2: ip2}, true, true),
 					h.EXPECT().UpdateRecord(ctx, p, domain, ipNetwork, record1, ip1).Return(false),
@@ -279,7 +266,6 @@ func TestSet(t *testing.T) {
 			setter.ResponseUpdated,
 			func(ctx context.Context, _ func(), p *mocks.MockPP, h *mocks.MockHandle) {
 				gomock.InOrder(
-					h.EXPECT().SanityCheck(ctx, p).Return(true, true),
 					h.EXPECT().ListRecords(ctx, p, domain, ipNetwork).
 						Return(map[string]netip.Addr{record1: ip2, record2: ip2}, true, true),
 					h.EXPECT().UpdateRecord(ctx, p, domain, ipNetwork, record1, ip1).Return(false),
@@ -298,7 +284,6 @@ func TestSet(t *testing.T) {
 			setter.ResponseFailed,
 			func(ctx context.Context, _ func(), p *mocks.MockPP, h *mocks.MockHandle) {
 				gomock.InOrder(
-					h.EXPECT().SanityCheck(ctx, p).Return(true, true),
 					h.EXPECT().ListRecords(ctx, p, domain, ipNetwork).Return(map[string]netip.Addr{record1: ip2, record2: ip2}, true, true), //nolint:lll
 					h.EXPECT().UpdateRecord(ctx, p, domain, ipNetwork, record1, ip1).Return(false),
 					h.EXPECT().DeleteRecord(ctx, p, domain, ipNetwork, record1).Return(false),
@@ -316,7 +301,6 @@ func TestSet(t *testing.T) {
 			setter.ResponseFailed,
 			func(ctx context.Context, _ func(), p *mocks.MockPP, h *mocks.MockHandle) {
 				gomock.InOrder(
-					h.EXPECT().SanityCheck(ctx, p).Return(true, true),
 					h.EXPECT().ListRecords(ctx, p, domain, ipNetwork).Return(map[string]netip.Addr{record1: ip2, record2: ip2}, true, true), //nolint:lll
 					h.EXPECT().UpdateRecord(ctx, p, domain, ipNetwork, record1, ip1).Return(false),
 					h.EXPECT().DeleteRecord(ctx, p, domain, ipNetwork, record1).Return(true),
@@ -334,7 +318,6 @@ func TestSet(t *testing.T) {
 			setter.ResponseFailed,
 			func(ctx context.Context, cancel func(), p *mocks.MockPP, h *mocks.MockHandle) {
 				gomock.InOrder(
-					h.EXPECT().SanityCheck(ctx, p).Return(true, true),
 					h.EXPECT().ListRecords(ctx, p, domain, ipNetwork).
 						Return(map[string]netip.Addr{record1: ip2, record2: ip2}, true, true),
 					h.EXPECT().UpdateRecord(ctx, p, domain, ipNetwork, record1, ip1).Return(false),
@@ -354,7 +337,6 @@ func TestSet(t *testing.T) {
 			setter.ResponseFailed,
 			func(ctx context.Context, _ func(), p *mocks.MockPP, h *mocks.MockHandle) {
 				gomock.InOrder(
-					h.EXPECT().SanityCheck(ctx, p).Return(true, true),
 					h.EXPECT().ListRecords(ctx, p, domain, ipNetwork).Return(nil, false, false),
 					p.EXPECT().Errorf(pp.EmojiError, "Failed to retrieve the current %s records of %q", "AAAA", "sub.test.org"),
 				)

--- a/internal/setter/setter_test.go
+++ b/internal/setter/setter_test.go
@@ -38,6 +38,35 @@ func wrapCancelAsDelete(cancel func()) func(context.Context, pp.PP, domain.Domai
 }
 
 //nolint:funlen
+func TestSanityCheck(t *testing.T) {
+	t.Parallel()
+
+	for name, tc := range map[string]struct {
+		answer bool
+	}{
+		"true":  {true},
+		"false": {false},
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			mockCtrl := gomock.NewController(t)
+
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			mockPP := mocks.NewMockPP(mockCtrl)
+			mockHandle := mocks.NewMockHandle(mockCtrl)
+
+			s, ok := setter.New(mockPP, mockHandle)
+			require.True(t, ok)
+
+			mockHandle.EXPECT().SanityCheck(ctx, mockPP).Return(tc.answer)
+			require.Equal(t, tc.answer, s.SanityCheck(ctx, mockPP))
+		})
+	}
+}
+
+//nolint:funlen
 func TestSet(t *testing.T) {
 	t.Parallel()
 

--- a/internal/setter/setter_test.go
+++ b/internal/setter/setter_test.go
@@ -63,6 +63,7 @@ func TestSet(t *testing.T) {
 			setter.ResponseUpdated,
 			func(ctx context.Context, _ func(), p *mocks.MockPP, h *mocks.MockHandle) {
 				gomock.InOrder(
+					h.EXPECT().SanityCheck(ctx, p).Return(true, true),
 					h.EXPECT().ListRecords(ctx, p, domain, ipNetwork).Return(map[string]netip.Addr{}, true, true),
 					h.EXPECT().CreateRecord(ctx, p, domain, ipNetwork, ip1, api.TTLAuto, false, "hello").Return(record1, true),
 					p.EXPECT().Noticef(pp.EmojiCreateRecord, "Added a new %s record of %q (ID: %q)", "AAAA", "sub.test.org", record1),
@@ -74,6 +75,7 @@ func TestSet(t *testing.T) {
 			setter.ResponseUpdated,
 			func(ctx context.Context, _ func(), p *mocks.MockPP, h *mocks.MockHandle) {
 				gomock.InOrder(
+					h.EXPECT().SanityCheck(ctx, p).Return(true, true),
 					h.EXPECT().ListRecords(ctx, p, domain, ipNetwork).Return(map[string]netip.Addr{record1: ip2}, true, true),
 					h.EXPECT().UpdateRecord(ctx, p, domain, ipNetwork, record1, ip1).Return(true),
 					p.EXPECT().Noticef(pp.EmojiUpdateRecord,
@@ -90,6 +92,7 @@ func TestSet(t *testing.T) {
 			setter.ResponseUpdated,
 			func(ctx context.Context, _ func(), p *mocks.MockPP, h *mocks.MockHandle) {
 				gomock.InOrder(
+					h.EXPECT().SanityCheck(ctx, p).Return(true, true),
 					h.EXPECT().ListRecords(ctx, p, domain, ipNetwork).Return(map[string]netip.Addr{record1: ip2}, true, true),
 					h.EXPECT().UpdateRecord(ctx, p, domain, ipNetwork, record1, ip1).Return(false),
 					h.EXPECT().DeleteRecord(ctx, p, domain, ipNetwork, record1).Return(true),
@@ -104,6 +107,7 @@ func TestSet(t *testing.T) {
 			setter.ResponseFailed,
 			func(ctx context.Context, cancel func(), p *mocks.MockPP, h *mocks.MockHandle) {
 				gomock.InOrder(
+					h.EXPECT().SanityCheck(ctx, p).Return(true, true),
 					h.EXPECT().ListRecords(ctx, p, domain, ipNetwork).
 						Return(map[string]netip.Addr{record1: ip2}, true, true),
 					h.EXPECT().UpdateRecord(ctx, p, domain, ipNetwork, record1, ip1).
@@ -117,6 +121,7 @@ func TestSet(t *testing.T) {
 			setter.ResponseFailed,
 			func(ctx context.Context, cancel func(), p *mocks.MockPP, h *mocks.MockHandle) {
 				gomock.InOrder(
+					h.EXPECT().SanityCheck(ctx, p).Return(true, true),
 					h.EXPECT().ListRecords(ctx, p, domain, ipNetwork).
 						Return(map[string]netip.Addr{record1: ip2}, true, true),
 					h.EXPECT().UpdateRecord(ctx, p, domain, ipNetwork, record1, ip1).
@@ -132,6 +137,7 @@ func TestSet(t *testing.T) {
 			setter.ResponseNoop,
 			func(ctx context.Context, _ func(), p *mocks.MockPP, h *mocks.MockHandle) {
 				gomock.InOrder(
+					h.EXPECT().SanityCheck(ctx, p).Return(true, true),
 					h.EXPECT().ListRecords(ctx, p, domain, ipNetwork).Return(map[string]netip.Addr{record1: ip1}, true, true),
 					p.EXPECT().Infof(pp.EmojiAlreadyDone,
 						"The %s records of %q are already up to date (cached)", "AAAA", "sub.test.org"),
@@ -143,6 +149,7 @@ func TestSet(t *testing.T) {
 			setter.ResponseNoop,
 			func(ctx context.Context, _ func(), p *mocks.MockPP, h *mocks.MockHandle) {
 				gomock.InOrder(
+					h.EXPECT().SanityCheck(ctx, p).Return(true, true),
 					h.EXPECT().ListRecords(ctx, p, domain, ipNetwork).Return(map[string]netip.Addr{record1: ip1}, false, true),
 					p.EXPECT().Infof(pp.EmojiAlreadyDone, "The %s records of %q are already up to date", "AAAA", "sub.test.org"),
 				)
@@ -153,6 +160,7 @@ func TestSet(t *testing.T) {
 			setter.ResponseUpdated,
 			func(ctx context.Context, _ func(), p *mocks.MockPP, h *mocks.MockHandle) {
 				gomock.InOrder(
+					h.EXPECT().SanityCheck(ctx, p).Return(true, true),
 					h.EXPECT().ListRecords(ctx, p, domain, ipNetwork).
 						Return(map[string]netip.Addr{record1: ip1, record2: ip1}, true, true),
 					h.EXPECT().DeleteRecord(ctx, p, domain, ipNetwork, record2).Return(true),
@@ -171,6 +179,7 @@ func TestSet(t *testing.T) {
 			setter.ResponseUpdated,
 			func(ctx context.Context, _ func(), p *mocks.MockPP, h *mocks.MockHandle) {
 				gomock.InOrder(
+					h.EXPECT().SanityCheck(ctx, p).Return(true, true),
 					h.EXPECT().ListRecords(ctx, p, domain, ipNetwork).
 						Return(map[string]netip.Addr{record1: ip1, record2: ip1}, true, true),
 					h.EXPECT().DeleteRecord(ctx, p, domain, ipNetwork, record2).Return(false),
@@ -182,6 +191,7 @@ func TestSet(t *testing.T) {
 			setter.ResponseFailed,
 			func(ctx context.Context, cancel func(), p *mocks.MockPP, h *mocks.MockHandle) {
 				gomock.InOrder(
+					h.EXPECT().SanityCheck(ctx, p).Return(true, true),
 					h.EXPECT().ListRecords(ctx, p, domain, ipNetwork).
 						Return(map[string]netip.Addr{record1: ip1, record2: ip1}, true, true),
 					h.EXPECT().DeleteRecord(ctx, p, domain, ipNetwork, record2).
@@ -195,6 +205,7 @@ func TestSet(t *testing.T) {
 			setter.ResponseUpdated,
 			func(ctx context.Context, _ func(), p *mocks.MockPP, h *mocks.MockHandle) {
 				gomock.InOrder(
+					h.EXPECT().SanityCheck(ctx, p).Return(true, true),
 					h.EXPECT().ListRecords(ctx, p, domain, ipNetwork).
 						Return(map[string]netip.Addr{record1: ip2, record2: ip2}, true, true),
 					h.EXPECT().UpdateRecord(ctx, p, domain, ipNetwork, record1, ip1).Return(true),
@@ -219,6 +230,7 @@ func TestSet(t *testing.T) {
 			setter.ResponseFailed,
 			func(ctx context.Context, cancel func(), p *mocks.MockPP, h *mocks.MockHandle) {
 				gomock.InOrder(
+					h.EXPECT().SanityCheck(ctx, p).Return(true, true),
 					h.EXPECT().ListRecords(ctx, p, domain, ipNetwork).
 						Return(map[string]netip.Addr{record1: ip2, record2: ip2}, true, true),
 					h.EXPECT().UpdateRecord(ctx, p, domain, ipNetwork, record1, ip1).Return(true),
@@ -240,6 +252,7 @@ func TestSet(t *testing.T) {
 			setter.ResponseUpdated,
 			func(ctx context.Context, _ func(), p *mocks.MockPP, h *mocks.MockHandle) {
 				gomock.InOrder(
+					h.EXPECT().SanityCheck(ctx, p).Return(true, true),
 					h.EXPECT().ListRecords(ctx, p, domain, ipNetwork).
 						Return(map[string]netip.Addr{record1: ip2, record2: ip2}, true, true),
 					h.EXPECT().UpdateRecord(ctx, p, domain, ipNetwork, record1, ip1).Return(false),
@@ -266,6 +279,7 @@ func TestSet(t *testing.T) {
 			setter.ResponseUpdated,
 			func(ctx context.Context, _ func(), p *mocks.MockPP, h *mocks.MockHandle) {
 				gomock.InOrder(
+					h.EXPECT().SanityCheck(ctx, p).Return(true, true),
 					h.EXPECT().ListRecords(ctx, p, domain, ipNetwork).
 						Return(map[string]netip.Addr{record1: ip2, record2: ip2}, true, true),
 					h.EXPECT().UpdateRecord(ctx, p, domain, ipNetwork, record1, ip1).Return(false),
@@ -284,6 +298,7 @@ func TestSet(t *testing.T) {
 			setter.ResponseFailed,
 			func(ctx context.Context, _ func(), p *mocks.MockPP, h *mocks.MockHandle) {
 				gomock.InOrder(
+					h.EXPECT().SanityCheck(ctx, p).Return(true, true),
 					h.EXPECT().ListRecords(ctx, p, domain, ipNetwork).Return(map[string]netip.Addr{record1: ip2, record2: ip2}, true, true), //nolint:lll
 					h.EXPECT().UpdateRecord(ctx, p, domain, ipNetwork, record1, ip1).Return(false),
 					h.EXPECT().DeleteRecord(ctx, p, domain, ipNetwork, record1).Return(false),
@@ -301,6 +316,7 @@ func TestSet(t *testing.T) {
 			setter.ResponseFailed,
 			func(ctx context.Context, _ func(), p *mocks.MockPP, h *mocks.MockHandle) {
 				gomock.InOrder(
+					h.EXPECT().SanityCheck(ctx, p).Return(true, true),
 					h.EXPECT().ListRecords(ctx, p, domain, ipNetwork).Return(map[string]netip.Addr{record1: ip2, record2: ip2}, true, true), //nolint:lll
 					h.EXPECT().UpdateRecord(ctx, p, domain, ipNetwork, record1, ip1).Return(false),
 					h.EXPECT().DeleteRecord(ctx, p, domain, ipNetwork, record1).Return(true),
@@ -318,6 +334,7 @@ func TestSet(t *testing.T) {
 			setter.ResponseFailed,
 			func(ctx context.Context, cancel func(), p *mocks.MockPP, h *mocks.MockHandle) {
 				gomock.InOrder(
+					h.EXPECT().SanityCheck(ctx, p).Return(true, true),
 					h.EXPECT().ListRecords(ctx, p, domain, ipNetwork).
 						Return(map[string]netip.Addr{record1: ip2, record2: ip2}, true, true),
 					h.EXPECT().UpdateRecord(ctx, p, domain, ipNetwork, record1, ip1).Return(false),
@@ -337,6 +354,7 @@ func TestSet(t *testing.T) {
 			setter.ResponseFailed,
 			func(ctx context.Context, _ func(), p *mocks.MockPP, h *mocks.MockHandle) {
 				gomock.InOrder(
+					h.EXPECT().SanityCheck(ctx, p).Return(true, true),
 					h.EXPECT().ListRecords(ctx, p, domain, ipNetwork).Return(nil, false, false),
 					p.EXPECT().Errorf(pp.EmojiError, "Failed to retrieve the current %s records of %q", "AAAA", "sub.test.org"),
 				)


### PR DESCRIPTION
Close #722.

- [x] Test calling SanityCheck when it's already checked
- [x] Test expired API tokens
- [x] Test disabled API tokens
- [x] Test API tokens in unknown states