### PR TITLE
refactor: remove unnecessary indirection

### DIFF
--- a/cmd/ddns/ddns.go
+++ b/cmd/ddns/ddns.go
@@ -32,7 +32,7 @@ func initConfig(ctx context.Context, ppfmt pp.PP) (*config.Config, setter.Setter
 	c := config.Default()
 
 	// Read the config
-	if !c.ReadEnv(ppfmt) || !c.NormalizeConfig(ppfmt) {
+	if !c.ReadEnv(ppfmt) || !c.Normalize(ppfmt) {
 		return c, nil, false
 	}
 

--- a/internal/config/config_read.go
+++ b/internal/config/config_read.go
@@ -12,7 +12,7 @@ import (
 // - timezone (TZ)
 // - privileges-related ones (PGID and PUID)
 // - output-related ones (QUIET and EMOJI)
-// One should subsequently call [Config.NormalizeConfig] to restore invariants across fields.
+// One should subsequently call [Config.Normalize] to restore invariants across fields.
 func (c *Config) ReadEnv(ppfmt pp.PP) bool {
 	if ppfmt.IsEnabledFor(pp.Info) {
 		ppfmt.Infof(pp.EmojiEnvVars, "Reading settings . . .")
@@ -40,11 +40,11 @@ func (c *Config) ReadEnv(ppfmt pp.PP) bool {
 	return true
 }
 
-// NormalizeConfig checks and normalizes the fields [Config.Provider], [Config.Proxied], and [Config.DeleteOnStop].
+// Normalize checks and normalizes the fields [Config.Provider], [Config.Proxied], and [Config.DeleteOnStop].
 // When any error is reported, the original configuration remain unchanged.
 //
 //nolint:funlen
-func (c *Config) NormalizeConfig(ppfmt pp.PP) bool {
+func (c *Config) Normalize(ppfmt pp.PP) bool {
 	if ppfmt.IsEnabledFor(pp.Info) {
 		ppfmt.Infof(pp.EmojiEnvVars, "Checking settings . . .")
 		ppfmt = ppfmt.IncIndent()

--- a/internal/config/config_read_test.go
+++ b/internal/config/config_read_test.go
@@ -86,7 +86,7 @@ func TestReadEnvEmpty(t *testing.T) {
 }
 
 //nolint:funlen
-func TestNormalizeConfig(t *testing.T) {
+func TestNormalize(t *testing.T) {
 	t.Parallel()
 
 	keyProxied := "PROXIED"
@@ -415,7 +415,7 @@ func TestNormalizeConfig(t *testing.T) {
 			if tc.prepareMockPP != nil {
 				tc.prepareMockPP(mockPP)
 			}
-			ok := cfg.NormalizeConfig(mockPP)
+			ok := cfg.Normalize(mockPP)
 			require.Equal(t, tc.ok, ok)
 			if tc.ok {
 				require.Equal(t, tc.expected, cfg)

--- a/internal/config/env_monitor_test.go
+++ b/internal/config/env_monitor_test.go
@@ -35,7 +35,7 @@ func TestReadAndAppendHealthchecksURL(t *testing.T) {
 		"example": {
 			true, "https://hi.org/1234",
 			nil,
-			[]mon{&monitor.Healthchecks{
+			[]mon{monitor.Healthchecks{
 				BaseURL: urlMustParse(t, "https://hi.org/1234"),
 				Timeout: monitor.HealthchecksDefaultTimeout,
 			}},
@@ -45,7 +45,7 @@ func TestReadAndAppendHealthchecksURL(t *testing.T) {
 		"password": {
 			true, "https://me:pass@hi.org/1234",
 			nil,
-			[]mon{&monitor.Healthchecks{
+			[]mon{monitor.Healthchecks{
 				BaseURL: urlMustParse(t, "https://me:pass@hi.org/1234"),
 				Timeout: monitor.HealthchecksDefaultTimeout,
 			}},
@@ -55,7 +55,7 @@ func TestReadAndAppendHealthchecksURL(t *testing.T) {
 		"fragment": {
 			true, "https://hi.org/1234#fragment",
 			nil,
-			[]mon{&monitor.Healthchecks{
+			[]mon{monitor.Healthchecks{
 				BaseURL: urlMustParse(t, "https://hi.org/1234#fragment"),
 				Timeout: monitor.HealthchecksDefaultTimeout,
 			}},
@@ -132,7 +132,7 @@ func TestReadAndAppendUptimeKumaURL(t *testing.T) {
 		"example": {
 			true, "https://hi.org/1234",
 			nil,
-			[]mon{&monitor.UptimeKuma{
+			[]mon{monitor.UptimeKuma{
 				BaseURL: urlMustParse(t, "https://hi.org/1234"),
 				Timeout: monitor.UptimeKumaDefaultTimeout,
 			}},
@@ -142,7 +142,7 @@ func TestReadAndAppendUptimeKumaURL(t *testing.T) {
 		"password": {
 			true, "https://me:pass@hi.org/1234",
 			nil,
-			[]mon{&monitor.UptimeKuma{
+			[]mon{monitor.UptimeKuma{
 				BaseURL: urlMustParse(t, "https://me:pass@hi.org/1234"),
 				Timeout: monitor.UptimeKumaDefaultTimeout,
 			}},
@@ -152,7 +152,7 @@ func TestReadAndAppendUptimeKumaURL(t *testing.T) {
 		"fragment": {
 			true, "https://hi.org/1234#fragment",
 			nil,
-			[]mon{&monitor.UptimeKuma{
+			[]mon{monitor.UptimeKuma{
 				BaseURL: urlMustParse(t, "https://hi.org/1234#fragment"),
 				Timeout: monitor.UptimeKumaDefaultTimeout,
 			}},
@@ -162,7 +162,7 @@ func TestReadAndAppendUptimeKumaURL(t *testing.T) {
 		"query": {
 			true, "https://hi.org/1234?hello=123",
 			nil,
-			[]mon{&monitor.UptimeKuma{
+			[]mon{monitor.UptimeKuma{
 				BaseURL: urlMustParse(t, "https://hi.org/1234"),
 				Timeout: monitor.UptimeKumaDefaultTimeout,
 			}},

--- a/internal/domain/base.go
+++ b/internal/domain/base.go
@@ -11,7 +11,7 @@ type Splitter interface {
 	ZoneNameASCII() string
 
 	// Next moves the cursor to the next possible splitting point, which might end up being invalid.
-	Next()
+	Next() Splitter
 }
 
 // A Domain represents a domain name to update.

--- a/internal/domain/fqdn.go
+++ b/internal/domain/fqdn.go
@@ -22,7 +22,7 @@ type FQDNSplitter struct {
 
 // Split constructs a [FQDNSplitter] for the FQDN.
 func (f FQDN) Split() Splitter {
-	return &FQDNSplitter{
+	return FQDNSplitter{
 		domain:    string(f),
 		cursor:    0,
 		exhausted: false,
@@ -30,22 +30,24 @@ func (f FQDN) Split() Splitter {
 }
 
 // IsValid checks whether the cursor is still valid.
-func (s *FQDNSplitter) IsValid() bool { return !s.exhausted }
+func (s FQDNSplitter) IsValid() bool { return !s.exhausted }
 
 // ZoneNameASCII gives the ASCII form of the current zone suffix.
-func (s *FQDNSplitter) ZoneNameASCII() string { return s.domain[s.cursor:] }
+func (s FQDNSplitter) ZoneNameASCII() string { return s.domain[s.cursor:] }
 
 // Next moves the cursor to the next spltting point.
 // Call [IsValid] to check whether the resulting cursor is valid.
-func (s *FQDNSplitter) Next() {
+func (s FQDNSplitter) Next() Splitter {
+	next := s
 	if s.cursor == len(s.domain) {
-		s.exhausted = true
+		next.exhausted = true
 	} else {
 		shift := strings.IndexRune(s.ZoneNameASCII(), '.')
 		if shift == -1 {
-			s.cursor = len(s.domain)
+			next.cursor = len(s.domain)
 		} else {
-			s.cursor += shift + 1
+			next.cursor += shift + 1
 		}
 	}
+	return next
 }

--- a/internal/domain/fqdn_test.go
+++ b/internal/domain/fqdn_test.go
@@ -83,7 +83,7 @@ func TestFQDNSplitter(t *testing.T) {
 		t.Run(tc.input, func(t *testing.T) {
 			t.Parallel()
 			var rs []r
-			for s := domain.FQDN(tc.input).Split(); s.IsValid(); s.Next() {
+			for s := domain.FQDN(tc.input).Split(); s.IsValid(); s = s.Next() {
 				rs = append(rs, s.ZoneNameASCII())
 			}
 			require.Equal(t, tc.expected, rs)

--- a/internal/domain/wildcard.go
+++ b/internal/domain/wildcard.go
@@ -33,7 +33,7 @@ type WildcardSplitter struct {
 
 // Split constructs a [Splitter] for a wildcard domain.
 func (w Wildcard) Split() Splitter {
-	return &WildcardSplitter{
+	return WildcardSplitter{
 		domain:    string(w),
 		cursor:    0,
 		exhausted: false,
@@ -41,22 +41,24 @@ func (w Wildcard) Split() Splitter {
 }
 
 // IsValid checks whether the cursor is still valid.
-func (s *WildcardSplitter) IsValid() bool { return !s.exhausted }
+func (s WildcardSplitter) IsValid() bool { return !s.exhausted }
 
 // ZoneNameASCII gives the ASCII form of the current zone suffix.
-func (s *WildcardSplitter) ZoneNameASCII() string { return s.domain[s.cursor:] }
+func (s WildcardSplitter) ZoneNameASCII() string { return s.domain[s.cursor:] }
 
 // Next moves the cursor to the next spltting point.
 // Call [WildcardSplitter.IsValid] to check whether the resulting cursor is valid.
-func (s *WildcardSplitter) Next() {
+func (s WildcardSplitter) Next() Splitter {
+	next := s
 	if s.cursor == len(s.domain) {
-		s.exhausted = true
+		next.exhausted = true
 	} else {
 		shift := strings.IndexRune(s.ZoneNameASCII(), '.')
 		if shift == -1 {
-			s.cursor = len(s.domain)
+			next.cursor = len(s.domain)
 		} else {
-			s.cursor += shift + 1
+			next.cursor += shift + 1
 		}
 	}
+	return next
 }

--- a/internal/domain/wildcard_test.go
+++ b/internal/domain/wildcard_test.go
@@ -87,7 +87,7 @@ func TestWildcardSplitter(t *testing.T) {
 		t.Run(tc.input, func(t *testing.T) {
 			t.Parallel()
 			var rs []r
-			for s := domain.Wildcard(tc.input).Split(); s.IsValid(); s.Next() {
+			for s := domain.Wildcard(tc.input).Split(); s.IsValid(); s = s.Next() {
 				rs = append(rs, s.ZoneNameASCII())
 			}
 			require.Equal(t, tc.expected, rs)

--- a/internal/monitor/healthchecks.go
+++ b/internal/monitor/healthchecks.go
@@ -25,7 +25,7 @@ type Healthchecks struct {
 	Timeout time.Duration
 }
 
-var _ Monitor = (*Healthchecks)(nil)
+var _ Monitor = Healthchecks{} //nolint:exhaustruct
 
 const (
 	// HealthchecksDefaultTimeout is the default timeout for a Healthchecks ping.
@@ -34,17 +34,17 @@ const (
 
 // NewHealthchecks creates a new Healthchecks monitor.
 // See https://healthchecks.io/docs/http_api/ for more information.
-func NewHealthchecks(ppfmt pp.PP, rawURL string) (*Healthchecks, bool) {
+func NewHealthchecks(ppfmt pp.PP, rawURL string) (Healthchecks, bool) {
 	u, err := url.Parse(rawURL)
 	if err != nil {
 		ppfmt.Errorf(pp.EmojiUserError, "Failed to parse the Healthchecks URL (redacted)")
-		return nil, false
+		return Healthchecks{}, false //nolint:exhaustruct
 	}
 
 	if !(u.IsAbs() && u.Opaque == "" && u.Host != "" && u.RawQuery == "") {
 		ppfmt.Errorf(pp.EmojiUserError, `The Healthchecks URL (redacted) does not look like a valid URL`)
 		ppfmt.Errorf(pp.EmojiUserError, `A valid example is "https://hc-ping.com/01234567-0123-0123-0123-0123456789abc"`)
-		return nil, false
+		return Healthchecks{}, false //nolint:exhaustruct
 	}
 
 	switch u.Scheme {
@@ -57,10 +57,10 @@ func NewHealthchecks(ppfmt pp.PP, rawURL string) (*Healthchecks, bool) {
 	default:
 		ppfmt.Errorf(pp.EmojiUserError, `The Healthchecks URL (redacted) does not look like a valid URL`)
 		ppfmt.Errorf(pp.EmojiUserError, `A valid example is "https://hc-ping.com/01234567-0123-0123-0123-0123456789abc"`)
-		return nil, false
+		return Healthchecks{}, false //nolint:exhaustruct
 	}
 
-	h := &Healthchecks{
+	h := Healthchecks{
 		BaseURL: u,
 		Timeout: HealthchecksDefaultTimeout,
 	}
@@ -69,7 +69,7 @@ func NewHealthchecks(ppfmt pp.PP, rawURL string) (*Healthchecks, bool) {
 }
 
 // Describe calls the callback with the service name "Healthchecks".
-func (h *Healthchecks) Describe(callback func(service, params string)) {
+func (h Healthchecks) Describe(callback func(service, params string)) {
 	callback("Healthchecks", "(URL redacted)")
 }
 
@@ -102,7 +102,7 @@ Code and body for the slug API:
 
 To support both APIs, we check both (1) whether the status code is 200 and (2) whether the body is "OK".
 */
-func (h *Healthchecks) ping(ctx context.Context, ppfmt pp.PP, endpoint string, message string) bool {
+func (h Healthchecks) ping(ctx context.Context, ppfmt pp.PP, endpoint string, message string) bool {
 	url := h.BaseURL.JoinPath(endpoint)
 
 	endpointDescription := "default (root)"
@@ -154,27 +154,27 @@ func (h *Healthchecks) ping(ctx context.Context, ppfmt pp.PP, endpoint string, m
 }
 
 // Success pings the root endpoint.
-func (h *Healthchecks) Success(ctx context.Context, ppfmt pp.PP, message string) bool {
+func (h Healthchecks) Success(ctx context.Context, ppfmt pp.PP, message string) bool {
 	return h.ping(ctx, ppfmt, "", message)
 }
 
 // Start pings the /start endpoint.
-func (h *Healthchecks) Start(ctx context.Context, ppfmt pp.PP, message string) bool {
+func (h Healthchecks) Start(ctx context.Context, ppfmt pp.PP, message string) bool {
 	return h.ping(ctx, ppfmt, "/start", message)
 }
 
 // Failure pings the /fail endpoint.
-func (h *Healthchecks) Failure(ctx context.Context, ppfmt pp.PP, message string) bool {
+func (h Healthchecks) Failure(ctx context.Context, ppfmt pp.PP, message string) bool {
 	return h.ping(ctx, ppfmt, "/fail", message)
 }
 
 // Log pings the /log endpoint.
-func (h *Healthchecks) Log(ctx context.Context, ppfmt pp.PP, message string) bool {
+func (h Healthchecks) Log(ctx context.Context, ppfmt pp.PP, message string) bool {
 	return h.ping(ctx, ppfmt, "/log", message)
 }
 
 // ExitStatus pings the /number endpoint where number is the exit status.
-func (h *Healthchecks) ExitStatus(ctx context.Context, ppfmt pp.PP, code int, message string) bool {
+func (h Healthchecks) ExitStatus(ctx context.Context, ppfmt pp.PP, code int, message string) bool {
 	if code < 0 || code > 255 {
 		ppfmt.Errorf(pp.EmojiImpossible, "Exit code (%d) not within the range 0-255", code)
 		return false

--- a/internal/monitor/healthchecks_test.go
+++ b/internal/monitor/healthchecks_test.go
@@ -27,7 +27,7 @@ func TestNewHealthchecks(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	mockPP := mocks.NewMockPP(mockCtrl)
 	m, ok := monitor.NewHealthchecks(mockPP, rawBaseURL)
-	require.Equal(t, &monitor.Healthchecks{
+	require.Equal(t, monitor.Healthchecks{
 		BaseURL: parsedBaseURL,
 		Timeout: monitor.HealthchecksDefaultTimeout,
 	}, m)

--- a/internal/monitor/uptimekuma_test.go
+++ b/internal/monitor/uptimekuma_test.go
@@ -63,12 +63,12 @@ func TestNewUptimeKuma(t *testing.T) {
 			m, ok := monitor.NewUptimeKuma(mockPP, tc.input)
 			require.Equal(t, tc.ok, ok)
 			if ok {
-				require.Equal(t, &monitor.UptimeKuma{
+				require.Equal(t, monitor.UptimeKuma{
 					BaseURL: parsedBaseURL,
 					Timeout: monitor.UptimeKumaDefaultTimeout,
 				}, m)
 			} else {
-				require.Nil(t, m)
+				require.Zero(t, m)
 			}
 		})
 	}

--- a/internal/provider/protocol/doh.go
+++ b/internal/provider/protocol/doh.go
@@ -178,12 +178,12 @@ type DNSOverHTTPS struct {
 }
 
 // Name of the detection protocol.
-func (p *DNSOverHTTPS) Name() string {
+func (p DNSOverHTTPS) Name() string {
 	return p.ProviderName
 }
 
 // GetIP detects the IP address by DNS over HTTPS.
-func (p *DNSOverHTTPS) GetIP(ctx context.Context, ppfmt pp.PP, ipNet ipnet.Type, use1001 bool) (netip.Addr, bool) {
+func (p DNSOverHTTPS) GetIP(ctx context.Context, ppfmt pp.PP, ipNet ipnet.Type, use1001 bool) (netip.Addr, bool) {
 	param, found := p.Param[ipNet]
 	if !found {
 		ppfmt.Warningf(pp.EmojiImpossible, "Unhandled IP network: %s", ipNet.Describe())
@@ -199,4 +199,4 @@ func (p *DNSOverHTTPS) GetIP(ctx context.Context, ppfmt pp.PP, ipNet ipnet.Type,
 }
 
 // ShouldWeCheck1111 returns whether we should check 1.1.1.1.
-func (p *DNSOverHTTPS) ShouldWeCheck1111() bool { return p.Is1111UsedForIP4 }
+func (p DNSOverHTTPS) ShouldWeCheck1111() bool { return p.Is1111UsedForIP4 }

--- a/internal/provider/protocol/doh_test.go
+++ b/internal/provider/protocol/doh_test.go
@@ -22,7 +22,7 @@ import (
 func TestDNSOverHTTPSName(t *testing.T) {
 	t.Parallel()
 
-	p := &protocol.DNSOverHTTPS{
+	p := protocol.DNSOverHTTPS{
 		ProviderName:     "very secret name",
 		Is1111UsedForIP4: false,
 		Param:            nil,

--- a/internal/provider/protocol/field.go
+++ b/internal/provider/protocol/field.go
@@ -49,12 +49,12 @@ type Field struct {
 }
 
 // Name of the detection protocol.
-func (p *Field) Name() string {
+func (p Field) Name() string {
 	return p.ProviderName
 }
 
 // GetIP detects the IP address by parsing the HTTP response.
-func (p *Field) GetIP(ctx context.Context, ppfmt pp.PP, ipNet ipnet.Type, use1001 bool) (netip.Addr, bool) {
+func (p Field) GetIP(ctx context.Context, ppfmt pp.PP, ipNet ipnet.Type, use1001 bool) (netip.Addr, bool) {
 	param, found := p.Param[ipNet]
 	if !found {
 		ppfmt.Warningf(pp.EmojiImpossible, "Unhandled IP network: %s", ipNet.Describe())
@@ -70,4 +70,4 @@ func (p *Field) GetIP(ctx context.Context, ppfmt pp.PP, ipNet ipnet.Type, use100
 }
 
 // ShouldWeCheck1111 returns whether we should check 1.1.1.1.
-func (p *Field) ShouldWeCheck1111() bool { return p.Is1111UsedforIP4 }
+func (p Field) ShouldWeCheck1111() bool { return p.Is1111UsedforIP4 }

--- a/internal/provider/protocol/http.go
+++ b/internal/provider/protocol/http.go
@@ -38,12 +38,12 @@ type HTTP struct {
 }
 
 // Name of the detection protocol.
-func (p *HTTP) Name() string {
+func (p HTTP) Name() string {
 	return p.ProviderName
 }
 
 // GetIP detects the IP address by using the HTTP response directly.
-func (p *HTTP) GetIP(ctx context.Context, ppfmt pp.PP, ipNet ipnet.Type, use1001 bool) (netip.Addr, bool) {
+func (p HTTP) GetIP(ctx context.Context, ppfmt pp.PP, ipNet ipnet.Type, use1001 bool) (netip.Addr, bool) {
 	url, found := p.URL[ipNet]
 	if !found {
 		ppfmt.Warningf(pp.EmojiImpossible, "Unhandled IP network: %s", ipNet.Describe())
@@ -59,4 +59,4 @@ func (p *HTTP) GetIP(ctx context.Context, ppfmt pp.PP, ipNet ipnet.Type, use1001
 }
 
 // ShouldWeCheck1111 returns whether we should check 1.1.1.1.
-func (p *HTTP) ShouldWeCheck1111() bool { return p.Is1111UsedForIP4 }
+func (p HTTP) ShouldWeCheck1111() bool { return p.Is1111UsedForIP4 }

--- a/internal/provider/protocol/httpcore.go
+++ b/internal/provider/protocol/httpcore.go
@@ -21,7 +21,7 @@ type httpCore struct {
 	extract           func(pp.PP, []byte) (netip.Addr, bool)
 }
 
-func (h *httpCore) getIP(ctx context.Context, ppfmt pp.PP) (netip.Addr, bool) {
+func (h httpCore) getIP(ctx context.Context, ppfmt pp.PP) (netip.Addr, bool) {
 	var invalidIP netip.Addr
 
 	req, err := retryablehttp.NewRequestWithContext(ctx, h.method, h.url, h.requestBody)

--- a/internal/provider/protocol/local.go
+++ b/internal/provider/protocol/local.go
@@ -25,13 +25,13 @@ type Local struct {
 }
 
 // Name of the detection protocol.
-func (p *Local) Name() string {
+func (p Local) Name() string {
 	return p.ProviderName
 }
 
 // GetIP detects the IP address by pretending to send an UDP packet.
 // (No actual UDP packets will be sent out.)
-func (p *Local) GetIP(_ctx context.Context, ppfmt pp.PP, ipNet ipnet.Type, use1001 bool) (netip.Addr, bool) {
+func (p Local) GetIP(_ctx context.Context, ppfmt pp.PP, ipNet ipnet.Type, use1001 bool) (netip.Addr, bool) {
 	var invalidIP netip.Addr
 
 	remoteUDPAddr, found := p.RemoteUDPAddr[ipNet]
@@ -53,4 +53,4 @@ func (p *Local) GetIP(_ctx context.Context, ppfmt pp.PP, ipNet ipnet.Type, use10
 }
 
 // ShouldWeCheck1111 returns whether we should check 1.1.1.1.
-func (p *Local) ShouldWeCheck1111() bool { return p.Is1111UsedForIP4 }
+func (p Local) ShouldWeCheck1111() bool { return p.Is1111UsedForIP4 }


### PR DESCRIPTION
It's also faster to pass structures directly except for really large ones.