### PR TITLE
refactor(pp): clean up pretty printing

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -14,10 +14,12 @@ linters-settings:
           - (github.com/favonia/cloudflare-ddns/internal/pp.PP).Noticef
           - (github.com/favonia/cloudflare-ddns/internal/pp.PP).Warningf
           - (github.com/favonia/cloudflare-ddns/internal/pp.PP).Errorf
+          - (github.com/favonia/cloudflare-ddns/internal/pp.PP).Hintf
           - (*github.com/favonia/cloudflare-ddns/internal/mocks.MockPPMockRecorder).Infof
           - (*github.com/favonia/cloudflare-ddns/internal/mocks.MockPPMockRecorder).Noticef
           - (*github.com/favonia/cloudflare-ddns/internal/mocks.MockPPMockRecorder).Warningf
           - (*github.com/favonia/cloudflare-ddns/internal/mocks.MockPPMockRecorder).Errorf
+          - (*github.com/favonia/cloudflare-ddns/internal/mocks.MockPPMockRecorder).Hintf
   revive:
     rules:
       - name: exported

--- a/internal/api/cloudflare.go
+++ b/internal/api/cloudflare.go
@@ -143,8 +143,9 @@ func (h CloudflareHandle) SanityCheck(ctx context.Context, ppfmt pp.PP) bool {
 		ok = false
 		goto permanently
 	default:
-		ppfmt.Warningf(pp.EmojiImpossible, "The Cloudflare API token is in an undocumented state: %s", res.Status)
-		ppfmt.Warningf(pp.EmojiImpossible, "Please report the bug at https://github.com/favonia/cloudflare-ddns/issues/new") //nolint:lll
+		ppfmt.Warningf(pp.EmojiImpossible,
+			"The Cloudflare API token is in an undocumented state %q; please report this at %s",
+			res.Status, pp.IssueReportingURL)
 		goto permanently
 	}
 

--- a/internal/api/cloudflare_records.go
+++ b/internal/api/cloudflare_records.go
@@ -53,7 +53,8 @@ func (h CloudflareHandle) ListZones(ctx context.Context, ppfmt pp.PP, name strin
 			ppfmt.Infof(pp.EmojiWarning, "Zone %q is %q and thus skipped", name, zone.Status)
 			// skip these
 		default:
-			ppfmt.Warningf(pp.EmojiImpossible, "Zone %q is in an undocumented status %q; please report this at https://github.com/favonia/cloudflare-ddns/issues/new", name, zone.Status) //nolint:lll
+			ppfmt.Warningf(pp.EmojiImpossible, "Zone %q is in an undocumented status %q; please report this at %s",
+				name, zone.Status, pp.IssueReportingURL)
 			ids = append(ids, zone.ID)
 		}
 	}
@@ -89,8 +90,9 @@ zoneSearch:
 			h.cache.zoneOfDomain.Set(domain.DNSNameASCII(), zones[0], ttlcache.DefaultTTL)
 			return zones[0], true
 		default: // len(zones) > 1
-			ppfmt.Warningf(pp.EmojiImpossible, "Found multiple active zones named %q", zoneName)
-			ppfmt.Warningf(pp.EmojiImpossible, "Please report this rare situation at https://github.com/favonia/cloudflare-ddns/issues/new") //nolint:lll
+			ppfmt.Warningf(pp.EmojiImpossible,
+				"Found multiple active zones named %q (IDs: %s); please report this at %s",
+				zoneName, pp.EnglishJoin(zones), pp.IssueReportingURL)
 			return "", false
 		}
 	}

--- a/internal/api/cloudflare_records_test.go
+++ b/internal/api/cloudflare_records_test.go
@@ -214,12 +214,8 @@ func TestZoneOfDomain(t *testing.T) {
 				gomock.InOrder(
 					m.EXPECT().Warningf(
 						pp.EmojiImpossible,
-						"Found multiple active zones named %q",
-						"test.org",
-					),
-					m.EXPECT().Warningf(
-						pp.EmojiImpossible,
-						"Please report this rare situation at https://github.com/favonia/cloudflare-ddns/issues/new",
+						"Found multiple active zones named %q (IDs: %s); please report this at %s",
+						"test.org", pp.EnglishJoin(mockIDs("test.org", 0, 1)), pp.IssueReportingURL,
 					),
 				)
 			},
@@ -232,12 +228,8 @@ func TestZoneOfDomain(t *testing.T) {
 				gomock.InOrder(
 					m.EXPECT().Warningf(
 						pp.EmojiImpossible,
-						"Found multiple active zones named %q",
-						"test.org",
-					),
-					m.EXPECT().Warningf(
-						pp.EmojiImpossible,
-						"Please report this rare situation at https://github.com/favonia/cloudflare-ddns/issues/new",
+						"Found multiple active zones named %q (IDs: %s); please report this at %s",
+						"test.org", pp.EnglishJoin(mockIDs("test.org", 0, 1)), pp.IssueReportingURL,
 					),
 				)
 			},
@@ -281,7 +273,9 @@ func TestZoneOfDomain(t *testing.T) {
 			1, mockID("test.org", 0), true,
 			func(m *mocks.MockPP) {
 				gomock.InOrder(
-					m.EXPECT().Warningf(pp.EmojiWarning, "Zone %q is %q; your Cloudflare setup is incomplete; some features might not work as expected", "test.org", "initializing"), //nolint:lll
+					m.EXPECT().Warningf(pp.EmojiWarning,
+						"Zone %q is %q; your Cloudflare setup is incomplete; some features might not work as expected",
+						"test.org", "initializing"),
 				)
 			},
 		},
@@ -290,7 +284,9 @@ func TestZoneOfDomain(t *testing.T) {
 			map[string][]string{"test.org": {"some-undocumented-status"}},
 			1, mockID("test.org", 0), true,
 			func(m *mocks.MockPP) {
-				m.EXPECT().Warningf(pp.EmojiImpossible, "Zone %q is in an undocumented status %q; please report this at https://github.com/favonia/cloudflare-ddns/issues/new", "test.org", "some-undocumented-status") //nolint:lll
+				m.EXPECT().Warningf(pp.EmojiImpossible,
+					"Zone %q is in an undocumented status %q; please report this at %s",
+					"test.org", "some-undocumented-status", pp.IssueReportingURL)
 			},
 		},
 	} {

--- a/internal/api/cloudflare_test.go
+++ b/internal/api/cloudflare_test.go
@@ -265,8 +265,9 @@ func TestSanityCheckExpiring(t *testing.T) {
 			true,
 			func(p *mocks.MockPP) {
 				gomock.InOrder(
-					p.EXPECT().Warningf(pp.EmojiImpossible, "The Cloudflare API token is in an undocumented state: %s", "funny"),
-					p.EXPECT().Warningf(pp.EmojiImpossible, "Please report the bug at https://github.com/favonia/cloudflare-ddns/issues/new"), //nolint:lll
+					p.EXPECT().Warningf(pp.EmojiImpossible,
+						"The Cloudflare API token is in an undocumented state %q; please report this at %s",
+						"funny", pp.IssueReportingURL),
 				)
 			},
 		},

--- a/internal/api/cloudflare_waf.go
+++ b/internal/api/cloudflare_waf.go
@@ -43,9 +43,8 @@ func (h CloudflareHandle) ListWAFLists(ctx context.Context, ppfmt pp.PP) (map[st
 		if l.Kind == cloudflare.ListTypeIP {
 			if anotherListID, conflicting := lmap[l.Name]; conflicting {
 				ppfmt.Warningf(pp.EmojiImpossible,
-					"Found multiple lists named %q (IDs: %s and %s); please report this at "+
-						"https://github.com/favonia/cloudflare-ddns/issues/new",
-					l.Name, anotherListID, l.ID)
+					"Found multiple lists named %q (IDs: %s and %s); please report this at %s",
+					l.Name, anotherListID, l.ID, pp.IssueReportingURL)
 				return nil, false
 			}
 

--- a/internal/api/cloudflare_waf_test.go
+++ b/internal/api/cloudflare_waf_test.go
@@ -104,8 +104,8 @@ func TestListWAFLists(t *testing.T) {
 			false, nil,
 			func(ppfmt *mocks.MockPP) {
 				ppfmt.EXPECT().Warningf(pp.EmojiImpossible,
-					"Found multiple lists named %q (IDs: %s and %s); please report this at https://github.com/favonia/cloudflare-ddns/issues/new", //nolint:lll
-					"list", mockID("list", 0), mockID("list", 2),
+					"Found multiple lists named %q (IDs: %s and %s); please report this at %s",
+					"list", mockID("list", 0), mockID("list", 2), pp.IssueReportingURL,
 				)
 			},
 		},
@@ -228,8 +228,8 @@ func TestFindWAFList(t *testing.T) {
 			func(ppfmt *mocks.MockPP) {
 				gomock.InOrder(
 					ppfmt.EXPECT().Warningf(pp.EmojiImpossible,
-						"Found multiple lists named %q (IDs: %s and %s); please report this at https://github.com/favonia/cloudflare-ddns/issues/new", //nolint:lll
-						"list", mockID("list", 0), mockID("list", 2),
+						"Found multiple lists named %q (IDs: %s and %s); please report this at %s",
+						"list", mockID("list", 0), mockID("list", 2), pp.IssueReportingURL,
 					),
 					ppfmt.EXPECT().Warningf(pp.EmojiError,
 						"Failed to find the list %q",

--- a/internal/config/check_root.go
+++ b/internal/config/check_root.go
@@ -26,7 +26,6 @@ func CheckRoot(ppfmt pp.PP) {
 		useDeprecated = true
 	}
 	if useDeprecated {
-		ppfmt.Warningf(pp.EmojiHint,
-			"See https://github.com/favonia/cloudflare-ddns for the new Docker template")
+		ppfmt.Hintf(pp.HintUpdateDockerTemplate, "See %s for the new Docker template", pp.ManualURL)
 	}
 }

--- a/internal/config/check_root_test.go
+++ b/internal/config/check_root_test.go
@@ -37,7 +37,7 @@ func TestCheckRootWithOldConfigs(t *testing.T) {
 	calls = append(calls,
 		mockPP.EXPECT().Warningf(pp.EmojiUserError, "PUID=%s is ignored; use Docker's built-in mechanism to set user ID", "1000"),  //nolint:lll
 		mockPP.EXPECT().Warningf(pp.EmojiUserError, "PGID=%s is ignored; use Docker's built-in mechanism to set group ID", "1000"), //nolint:lll
-		mockPP.EXPECT().Warningf(pp.EmojiHint, "See https://github.com/favonia/cloudflare-ddns for the new Docker template"),
+		mockPP.EXPECT().Hintf(pp.HintUpdateDockerTemplate, "See %s for the new Docker template", pp.ManualURL),
 	)
 	gomock.InOrder(calls...)
 

--- a/internal/config/config_print.go
+++ b/internal/config/config_print.go
@@ -55,8 +55,8 @@ func (c *Config) Print(ppfmt pp.PP) {
 	}
 
 	ppfmt.Infof(pp.EmojiEnvVars, "Current settings:")
-	ppfmt = ppfmt.IncIndent()
-	inner := ppfmt.IncIndent()
+	ppfmt = ppfmt.Indent()
+	inner := ppfmt.Indent()
 
 	section := func(title string) { ppfmt.Infof(pp.EmojiConfig, title) }
 	item := func(title string, format string, values ...any) {

--- a/internal/config/config_print_test.go
+++ b/internal/config/config_print_test.go
@@ -30,8 +30,8 @@ func TestPrintDefault(t *testing.T) {
 	gomock.InOrder(
 		mockPP.EXPECT().IsEnabledFor(pp.Info).Return(true),
 		mockPP.EXPECT().Infof(pp.EmojiEnvVars, "Current settings:"),
-		mockPP.EXPECT().IncIndent().Return(mockPP),
-		mockPP.EXPECT().IncIndent().Return(innerMockPP),
+		mockPP.EXPECT().Indent().Return(mockPP),
+		mockPP.EXPECT().Indent().Return(innerMockPP),
 		mockPP.EXPECT().Infof(pp.EmojiConfig, "Domains, IP providers, and WAF lists:"),
 		printItem(t, innerMockPP, "IPv4-enabled domains:", "(none)"),
 		printItem(t, innerMockPP, "IPv4 provider:", "cloudflare.trace"),
@@ -68,8 +68,8 @@ func TestPrintValues(t *testing.T) {
 	gomock.InOrder(
 		mockPP.EXPECT().IsEnabledFor(pp.Info).Return(true),
 		mockPP.EXPECT().Infof(pp.EmojiEnvVars, "Current settings:"),
-		mockPP.EXPECT().IncIndent().Return(mockPP),
-		mockPP.EXPECT().IncIndent().Return(innerMockPP),
+		mockPP.EXPECT().Indent().Return(mockPP),
+		mockPP.EXPECT().Indent().Return(innerMockPP),
 		mockPP.EXPECT().Infof(pp.EmojiConfig, "Domains, IP providers, and WAF lists:"),
 		printItem(t, innerMockPP, "IPv4-enabled domains:", "test4.org, *.test4.org"),
 		printItem(t, innerMockPP, "IPv4 provider:", "cloudflare.trace"),
@@ -140,8 +140,8 @@ func TestPrintEmpty(t *testing.T) {
 	gomock.InOrder(
 		mockPP.EXPECT().IsEnabledFor(pp.Info).Return(true),
 		mockPP.EXPECT().Infof(pp.EmojiEnvVars, "Current settings:"),
-		mockPP.EXPECT().IncIndent().Return(mockPP),
-		mockPP.EXPECT().IncIndent().Return(innerMockPP),
+		mockPP.EXPECT().Indent().Return(mockPP),
+		mockPP.EXPECT().Indent().Return(innerMockPP),
 		mockPP.EXPECT().Infof(pp.EmojiConfig, "Domains, IP providers, and WAF lists:"),
 		printItem(t, innerMockPP, "WAF lists:", "(none)"),
 		mockPP.EXPECT().Infof(pp.EmojiConfig, "Scheduling:"),

--- a/internal/config/config_read.go
+++ b/internal/config/config_read.go
@@ -17,7 +17,7 @@ import (
 func (c *Config) ReadEnv(ppfmt pp.PP) bool {
 	if ppfmt.IsEnabledFor(pp.Info) {
 		ppfmt.Infof(pp.EmojiEnvVars, "Reading settings . . .")
-		ppfmt = ppfmt.IncIndent()
+		ppfmt = ppfmt.Indent()
 	}
 
 	if !ReadAuth(ppfmt, &c.Auth) ||
@@ -50,14 +50,15 @@ func (c *Config) ReadEnv(ppfmt pp.PP) bool {
 func (c *Config) Normalize(ppfmt pp.PP) bool {
 	if ppfmt.IsEnabledFor(pp.Info) {
 		ppfmt.Infof(pp.EmojiEnvVars, "Checking settings . . .")
-		ppfmt = ppfmt.IncIndent()
+		ppfmt = ppfmt.Indent()
 	}
 
 	// Step 1: is there something to do, and do wo have an auth?
 	if c.Auth == nil {
 		// if c.Auth == nil, the user should have been warned.
-		ppfmt.Errorf(pp.EmojiImpossible, "Authorization info is missing, but this should be impossible")
-		ppfmt.Errorf(pp.EmojiImpossible, "Please report the bug at https://github.com/favonia/cloudflare-ddns/issues/new")
+		ppfmt.Errorf(pp.EmojiImpossible,
+			"Authorization info is missing, but this should be impossible; please report this at %s",
+			pp.IssueReportingURL)
 		return false
 	}
 	if len(c.Domains[ipnet.IP4]) == 0 && len(c.Domains[ipnet.IP6]) == 0 && len(c.WAFLists) == 0 {
@@ -65,8 +66,8 @@ func (c *Config) Normalize(ppfmt pp.PP) bool {
 		return false
 	}
 	if (len(c.Domains[ipnet.IP4]) > 0 || len(c.Domains[ipnet.IP6]) > 0) && !c.Auth.SupportsRecords() {
-		ppfmt.Errorf(pp.EmojiImpossible, "CF_API_TOKEN is empty, but the updater should have stopped earlier")
-		ppfmt.Errorf(pp.EmojiImpossible, "Please report the bug at https://github.com/favonia/cloudflare-ddns/issues/new")
+		ppfmt.Errorf(pp.EmojiImpossible, "CF_API_TOKEN is empty, but this should be impossible; please report this at %s",
+			pp.IssueReportingURL)
 		return false
 	}
 	if len(c.WAFLists) > 0 && !c.Auth.SupportsWAFLists() {

--- a/internal/config/config_read_test.go
+++ b/internal/config/config_read_test.go
@@ -52,7 +52,7 @@ func TestReadEnvWithOnlyToken(t *testing.T) {
 	gomock.InOrder(
 		mockPP.EXPECT().IsEnabledFor(pp.Info).Return(true),
 		mockPP.EXPECT().Infof(pp.EmojiEnvVars, "Reading settings . . ."),
-		mockPP.EXPECT().IncIndent().Return(innerMockPP),
+		mockPP.EXPECT().Indent().Return(innerMockPP),
 		innerMockPP.EXPECT().Infof(pp.EmojiBullet, "Use default %s=%s", "IP4_PROVIDER", "none"),
 		innerMockPP.EXPECT().Infof(pp.EmojiBullet, "Use default %s=%s", "IP6_PROVIDER", "none"),
 		innerMockPP.EXPECT().Infof(pp.EmojiBullet, "Use default %s=%s", "UPDATE_CRON", "@once"),
@@ -79,7 +79,7 @@ func TestReadEnvEmpty(t *testing.T) {
 	gomock.InOrder(
 		mockPP.EXPECT().IsEnabledFor(pp.Info).Return(true),
 		mockPP.EXPECT().Infof(pp.EmojiEnvVars, "Reading settings . . ."),
-		mockPP.EXPECT().IncIndent().Return(innerMockPP),
+		mockPP.EXPECT().Indent().Return(innerMockPP),
 		innerMockPP.EXPECT().Errorf(pp.EmojiUserError, "Needs either CF_API_TOKEN or CF_API_TOKEN_FILE"),
 	)
 	ok := cfg.ReadEnv(mockPP)
@@ -117,9 +117,8 @@ func TestNormalize(t *testing.T) {
 				gomock.InOrder(
 					m.EXPECT().IsEnabledFor(pp.Info).Return(true),
 					m.EXPECT().Infof(pp.EmojiEnvVars, "Checking settings . . ."),
-					m.EXPECT().IncIndent().Return(m),
-					m.EXPECT().Errorf(pp.EmojiImpossible, "Authorization info is missing, but this should be impossible"),
-					m.EXPECT().Errorf(pp.EmojiImpossible, "Please report the bug at https://github.com/favonia/cloudflare-ddns/issues/new"), //nolint:lll
+					m.EXPECT().Indent().Return(m),
+					m.EXPECT().Errorf(pp.EmojiImpossible, "Authorization info is missing, but this should be impossible; please report this at %s", pp.IssueReportingURL), //nolint:lll
 				)
 			},
 		},
@@ -133,7 +132,7 @@ func TestNormalize(t *testing.T) {
 				gomock.InOrder(
 					m.EXPECT().IsEnabledFor(pp.Info).Return(true),
 					m.EXPECT().Infof(pp.EmojiEnvVars, "Checking settings . . ."),
-					m.EXPECT().IncIndent().Return(m),
+					m.EXPECT().Indent().Return(m),
 					m.EXPECT().Errorf(pp.EmojiUserError, "Nothing was specified in DOMAINS, IP4_DOMAINS, IP6_DOMAINS, or WAF_LISTS"),
 				)
 			},
@@ -151,9 +150,8 @@ func TestNormalize(t *testing.T) {
 				gomock.InOrder(
 					m.EXPECT().IsEnabledFor(pp.Info).Return(true),
 					m.EXPECT().Infof(pp.EmojiEnvVars, "Checking settings . . ."),
-					m.EXPECT().IncIndent().Return(m),
-					m.EXPECT().Errorf(pp.EmojiImpossible, "CF_API_TOKEN is empty, but the updater should have stopped earlier"),
-					m.EXPECT().Errorf(pp.EmojiImpossible, "Please report the bug at https://github.com/favonia/cloudflare-ddns/issues/new"), //nolint:lll
+					m.EXPECT().Indent().Return(m),
+					m.EXPECT().Errorf(pp.EmojiImpossible, "CF_API_TOKEN is empty, but this should be impossible; please report this at %s", pp.IssueReportingURL), //nolint:lll
 				)
 			},
 		},
@@ -168,7 +166,7 @@ func TestNormalize(t *testing.T) {
 				gomock.InOrder(
 					m.EXPECT().IsEnabledFor(pp.Info).Return(true),
 					m.EXPECT().Infof(pp.EmojiEnvVars, "Checking settings . . ."),
-					m.EXPECT().IncIndent().Return(m),
+					m.EXPECT().Indent().Return(m),
 					m.EXPECT().Errorf(pp.EmojiUserError, "Please give CF_ACCOUNT_ID to specify the WAF lists to update"),
 				)
 			},
@@ -187,7 +185,7 @@ func TestNormalize(t *testing.T) {
 				gomock.InOrder(
 					m.EXPECT().IsEnabledFor(pp.Info).Return(true),
 					m.EXPECT().Infof(pp.EmojiEnvVars, "Checking settings . . ."),
-					m.EXPECT().IncIndent().Return(m),
+					m.EXPECT().Indent().Return(m),
 					m.EXPECT().Errorf(pp.EmojiUserError, "UPDATE_ON_START=false is incompatible with UPDATE_CRON=@once"),
 				)
 			},
@@ -207,7 +205,7 @@ func TestNormalize(t *testing.T) {
 				gomock.InOrder(
 					m.EXPECT().IsEnabledFor(pp.Info).Return(true),
 					m.EXPECT().Infof(pp.EmojiEnvVars, "Checking settings . . ."),
-					m.EXPECT().IncIndent().Return(m),
+					m.EXPECT().Indent().Return(m),
 					m.EXPECT().Errorf(pp.EmojiUserError, "DELETE_ON_STOP=true will immediately delete all domains and WAF lists when UPDATE_CRON=@once"), //nolint:lll
 				)
 			},
@@ -231,7 +229,7 @@ func TestNormalize(t *testing.T) {
 				gomock.InOrder(
 					m.EXPECT().IsEnabledFor(pp.Info).Return(true),
 					m.EXPECT().Infof(pp.EmojiEnvVars, "Checking settings . . ."),
-					m.EXPECT().IncIndent().Return(m),
+					m.EXPECT().Indent().Return(m),
 					m.EXPECT().Errorf(pp.EmojiUserError,
 						"Nothing to update because both IP4_PROVIDER and IP6_PROVIDER are %q",
 						"none"),
@@ -270,7 +268,7 @@ func TestNormalize(t *testing.T) {
 				gomock.InOrder(
 					m.EXPECT().IsEnabledFor(pp.Info).Return(true),
 					m.EXPECT().Infof(pp.EmojiEnvVars, "Checking settings . . ."),
-					m.EXPECT().IncIndent().Return(m),
+					m.EXPECT().Indent().Return(m),
 					m.EXPECT().Warningf(pp.EmojiUserWarning,
 						"IP%d_PROVIDER was changed to %q because no domains or WAF lists use %s",
 						6, "none", "IPv6"),
@@ -294,7 +292,7 @@ func TestNormalize(t *testing.T) {
 				gomock.InOrder(
 					m.EXPECT().IsEnabledFor(pp.Info).Return(true),
 					m.EXPECT().Infof(pp.EmojiEnvVars, "Checking settings . . ."),
-					m.EXPECT().IncIndent().Return(m),
+					m.EXPECT().Indent().Return(m),
 					m.EXPECT().Warningf(pp.EmojiUserWarning,
 						"IP%d_PROVIDER was changed to %q because no domains or WAF lists use %s",
 						6, "none", "IPv6"),
@@ -338,7 +336,7 @@ func TestNormalize(t *testing.T) {
 				gomock.InOrder(
 					m.EXPECT().IsEnabledFor(pp.Info).Return(true),
 					m.EXPECT().Infof(pp.EmojiEnvVars, "Checking settings . . ."),
-					m.EXPECT().IncIndent().Return(m),
+					m.EXPECT().Indent().Return(m),
 					m.EXPECT().Warningf(pp.EmojiUserWarning,
 						"Domain %q is ignored because it is only for %s but %s is disabled",
 						"d.e.f", "IPv4", "IPv4"),
@@ -376,7 +374,7 @@ func TestNormalize(t *testing.T) {
 				gomock.InOrder(
 					m.EXPECT().IsEnabledFor(pp.Info).Return(true),
 					m.EXPECT().Infof(pp.EmojiEnvVars, "Checking settings . . ."),
-					m.EXPECT().IncIndent().Return(m),
+					m.EXPECT().Indent().Return(m),
 					m.EXPECT().Warningf(pp.EmojiUserWarning,
 						"TTL=%v is ignored because no domains will be updated",
 						api.TTL(10000)),
@@ -425,7 +423,7 @@ func TestNormalize(t *testing.T) {
 				gomock.InOrder(
 					m.EXPECT().IsEnabledFor(pp.Info).Return(true),
 					m.EXPECT().Infof(pp.EmojiEnvVars, "Checking settings . . ."),
-					m.EXPECT().IncIndent().Return(m),
+					m.EXPECT().Indent().Return(m),
 					m.EXPECT().Warningf(pp.EmojiUserWarning,
 						"WAF_LIST_DESCRIPTION=%s is ignored because no WAF lists will be updated",
 						"My list"),
@@ -465,7 +463,7 @@ func TestNormalize(t *testing.T) {
 				gomock.InOrder(
 					m.EXPECT().IsEnabledFor(pp.Info).Return(true),
 					m.EXPECT().Infof(pp.EmojiEnvVars, "Checking settings . . ."),
-					m.EXPECT().IncIndent().Return(m),
+					m.EXPECT().Indent().Return(m),
 				)
 			},
 		},
@@ -487,7 +485,7 @@ func TestNormalize(t *testing.T) {
 				gomock.InOrder(
 					m.EXPECT().IsEnabledFor(pp.Info).Return(true),
 					m.EXPECT().Infof(pp.EmojiEnvVars, "Checking settings . . ."),
-					m.EXPECT().IncIndent().Return(m),
+					m.EXPECT().Indent().Return(m),
 					m.EXPECT().Errorf(pp.EmojiUserError, "%s (%q) is not a boolean expression: got unexpected token %q", keyProxied, `range`, `range`), //nolint:lll
 				)
 			},
@@ -510,7 +508,7 @@ func TestNormalize(t *testing.T) {
 				gomock.InOrder(
 					m.EXPECT().IsEnabledFor(pp.Info).Return(true),
 					m.EXPECT().Infof(pp.EmojiEnvVars, "Checking settings . . ."),
-					m.EXPECT().IncIndent().Return(m),
+					m.EXPECT().Indent().Return(m),
 					m.EXPECT().Errorf(pp.EmojiUserError, "%s (%q) is not a boolean expression: got unexpected token %q", keyProxied, `999`, `999`), //nolint:lll
 				)
 			},
@@ -533,7 +531,7 @@ func TestNormalize(t *testing.T) {
 				gomock.InOrder(
 					m.EXPECT().IsEnabledFor(pp.Info).Return(true),
 					m.EXPECT().Infof(pp.EmojiEnvVars, "Checking settings . . ."),
-					m.EXPECT().IncIndent().Return(m),
+					m.EXPECT().Indent().Return(m),
 					m.EXPECT().Errorf(pp.EmojiUserError, `%s (%q) is missing %q at the end`, keyProxied, `is(12345`, ")"),
 				)
 			},

--- a/internal/config/network_probe.go
+++ b/internal/config/network_probe.go
@@ -40,7 +40,7 @@ func (c *Config) ShouldWeUse1001Now(ctx context.Context, ppfmt pp.PP) bool {
 
 	if ppfmt.IsEnabledFor(pp.Info) {
 		ppfmt.Infof(pp.EmojiEnvVars, "Probing 1.1.1.1 and 1.0.0.1 . . .")
-		ppfmt = ppfmt.IncIndent()
+		ppfmt = ppfmt.Indent()
 	}
 
 	if ProbeURL(ctx, "https://1.1.1.1") {

--- a/internal/config/network_probe_test.go
+++ b/internal/config/network_probe_test.go
@@ -43,7 +43,7 @@ func TestProbeCloudflareIPs(t *testing.T) {
 	gomock.InOrder(
 		mockPP.EXPECT().IsEnabledFor(pp.Info).Return(true),
 		mockPP.EXPECT().Infof(pp.EmojiEnvVars, "Probing 1.1.1.1 and 1.0.0.1 . . ."),
-		mockPP.EXPECT().IncIndent().Return(innerMockPP),
+		mockPP.EXPECT().Indent().Return(innerMockPP),
 		innerMockPP.EXPECT().Infof(pp.EmojiGood, "1.1.1.1 is working. Great!"),
 	)
 	c := config.Default()

--- a/internal/ipnet/ipnet_test.go
+++ b/internal/ipnet/ipnet_test.go
@@ -24,7 +24,7 @@ func TestDescribe(t *testing.T) {
 	}{
 		"4":   {ipnet.IP4, "IPv4"},
 		"6":   {ipnet.IP6, "IPv6"},
-		"100": {ipnet.Type(100), "<unrecognized IP network>"},
+		"100": {ipnet.Type(100), "<unrecognized IP version 100>"},
 	} {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -82,7 +82,7 @@ func TestNormalizeDetectedIP(t *testing.T) {
 			netip.Addr{},
 			false,
 			func(m *mocks.MockPP) {
-				m.EXPECT().Warningf(pp.EmojiError, "Detected IP address %s is not a valid %s address", "1::2", "IPv4")
+				m.EXPECT().Warningf(pp.EmojiError, "Detected IP address %s is not a valid IPv4 address", "1::2")
 			},
 		},
 		"4-::ffff:0a0a:0a0a": {ipnet.IP4, mustIP("::ffff:0a0a:0a0a"), mustIP("10.10.10.10"), true, nil},
@@ -102,10 +102,8 @@ func TestNormalizeDetectedIP(t *testing.T) {
 			netip.Addr{},
 			false,
 			func(m *mocks.MockPP) {
-				gomock.InOrder(
-					m.EXPECT().Warningf(pp.EmojiImpossible, "Detected IP address %s is not a valid %s address", "10.10.10.10", "<unrecognized IP network>"), //nolint:lll
-					m.EXPECT().Warningf(pp.EmojiImpossible, "Please report the bug at https://github.com/favonia/cloudflare-ddns/issues/new"),               //nolint:lll
-				)
+				m.EXPECT().Warningf(pp.EmojiImpossible,
+					"Unrecognized IP version %d was used; please report this at %s", 100, pp.IssueReportingURL)
 			},
 		},
 		"4-0.0.0.0": {
@@ -113,7 +111,8 @@ func TestNormalizeDetectedIP(t *testing.T) {
 			netip.Addr{},
 			false,
 			func(m *mocks.MockPP) {
-				m.EXPECT().Warningf(pp.EmojiImpossible, "Detected IP address %s is an unspecified %s address", "0.0.0.0", "IPv4") //nolint:lll
+				m.EXPECT().Warningf(pp.EmojiImpossible,
+					"Detected IP address %s is an unspecified %s address", "0.0.0.0", "IPv4")
 			},
 		},
 	} {

--- a/internal/mocks/mock_pp.go
+++ b/internal/mocks/mock_pp.go
@@ -79,40 +79,81 @@ func (c *PPErrorfCall) DoAndReturn(f func(pp.Emoji, string, ...any)) *PPErrorfCa
 	return c
 }
 
-// IncIndent mocks base method.
-func (m *MockPP) IncIndent() pp.PP {
+// Hintf mocks base method.
+func (m *MockPP) Hintf(arg0 pp.Hint, arg1 string, arg2 ...any) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "IncIndent")
-	ret0, _ := ret[0].(pp.PP)
-	return ret0
+	varargs := []any{arg0, arg1}
+	for _, a := range arg2 {
+		varargs = append(varargs, a)
+	}
+	m.ctrl.Call(m, "Hintf", varargs...)
 }
 
-// IncIndent indicates an expected call of IncIndent.
-func (mr *MockPPMockRecorder) IncIndent() *PPIncIndentCall {
+// Hintf indicates an expected call of Hintf.
+func (mr *MockPPMockRecorder) Hintf(arg0, arg1 any, arg2 ...any) *PPHintfCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IncIndent", reflect.TypeOf((*MockPP)(nil).IncIndent))
-	return &PPIncIndentCall{Call: call}
+	varargs := append([]any{arg0, arg1}, arg2...)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Hintf", reflect.TypeOf((*MockPP)(nil).Hintf), varargs...)
+	return &PPHintfCall{Call: call}
 }
 
-// PPIncIndentCall wrap *gomock.Call
-type PPIncIndentCall struct {
+// PPHintfCall wrap *gomock.Call
+type PPHintfCall struct {
 	*gomock.Call
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *PPIncIndentCall) Return(arg0 pp.PP) *PPIncIndentCall {
-	c.Call = c.Call.Return(arg0)
+func (c *PPHintfCall) Return() *PPHintfCall {
+	c.Call = c.Call.Return()
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *PPIncIndentCall) Do(f func() pp.PP) *PPIncIndentCall {
+func (c *PPHintfCall) Do(f func(pp.Hint, string, ...any)) *PPHintfCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *PPIncIndentCall) DoAndReturn(f func() pp.PP) *PPIncIndentCall {
+func (c *PPHintfCall) DoAndReturn(f func(pp.Hint, string, ...any)) *PPHintfCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// Indent mocks base method.
+func (m *MockPP) Indent() pp.PP {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Indent")
+	ret0, _ := ret[0].(pp.PP)
+	return ret0
+}
+
+// Indent indicates an expected call of Indent.
+func (mr *MockPPMockRecorder) Indent() *PPIndentCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Indent", reflect.TypeOf((*MockPP)(nil).Indent))
+	return &PPIndentCall{Call: call}
+}
+
+// PPIndentCall wrap *gomock.Call
+type PPIndentCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *PPIndentCall) Return(arg0 pp.PP) *PPIndentCall {
+	c.Call = c.Call.Return(arg0)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *PPIndentCall) Do(f func() pp.PP) *PPIndentCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *PPIndentCall) DoAndReturn(f func() pp.PP) *PPIndentCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -309,6 +350,42 @@ func (c *PPSetVerbosityCall) Do(f func(pp.Verbosity) pp.PP) *PPSetVerbosityCall 
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
 func (c *PPSetVerbosityCall) DoAndReturn(f func(pp.Verbosity) pp.PP) *PPSetVerbosityCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// SuppressHint mocks base method.
+func (m *MockPP) SuppressHint(arg0 pp.Hint) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SuppressHint", arg0)
+}
+
+// SuppressHint indicates an expected call of SuppressHint.
+func (mr *MockPPMockRecorder) SuppressHint(arg0 any) *PPSuppressHintCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SuppressHint", reflect.TypeOf((*MockPP)(nil).SuppressHint), arg0)
+	return &PPSuppressHintCall{Call: call}
+}
+
+// PPSuppressHintCall wrap *gomock.Call
+type PPSuppressHintCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *PPSuppressHintCall) Return() *PPSuppressHintCall {
+	c.Call = c.Call.Return()
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *PPSuppressHintCall) Do(f func(pp.Hint)) *PPSuppressHintCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *PPSuppressHintCall) DoAndReturn(f func(pp.Hint)) *PPSuppressHintCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/internal/pp/base.go
+++ b/internal/pp/base.go
@@ -14,8 +14,8 @@ type PP interface {
 	// IsEnabledFor checks whether a message of a certain level will be displayed.
 	IsEnabledFor(v Verbosity) bool
 
-	// IncIndent returns a new pretty-printer with more indentation.
-	IncIndent() PP
+	// Indent returns a new pretty-printer with more indentation.
+	Indent() PP
 
 	// Infof formats and prints a message at the info level.
 	Infof(emoji Emoji, format string, args ...any)
@@ -28,4 +28,10 @@ type PP interface {
 
 	// Errorf formats and prints a message at the error level.
 	Errorf(emoji Emoji, format string, args ...any)
+
+	// SuppressHint suppresses all future calls to [Hintf] with the same hint ID.
+	SuppressHint(hint Hint)
+
+	// Hintf formats and prints a hint.
+	Hintf(hint Hint, format string, args ...any)
 }

--- a/internal/pp/fmt.go
+++ b/internal/pp/fmt.go
@@ -10,6 +10,7 @@ type formatter struct {
 	writer    io.Writer
 	emoji     bool
 	indent    int
+	hintShown map[Hint]bool
 	verbosity Verbosity
 }
 
@@ -19,6 +20,7 @@ func New(writer io.Writer) PP {
 		writer:    writer,
 		emoji:     true,
 		indent:    0,
+		hintShown: map[Hint]bool{},
 		verbosity: DefaultVerbosity,
 	}
 }
@@ -40,8 +42,8 @@ func (f formatter) IsEnabledFor(v Verbosity) bool {
 	return v >= f.verbosity
 }
 
-// IncIndent returns a new printer that indents the messages more than the input printer.
-func (f formatter) IncIndent() PP {
+// Indent returns a new printer that indents the messages more than the input printer.
+func (f formatter) Indent() PP {
 	f.indent++
 	return f
 }
@@ -88,4 +90,17 @@ func (f formatter) Warningf(emoji Emoji, format string, args ...any) {
 // Errorf formats and sends a message at the level [Error].
 func (f formatter) Errorf(emoji Emoji, format string, args ...any) {
 	f.printf(Error, emoji, format, args...)
+}
+
+// SuppressHint sets the hint in the internal map to be "shown".
+func (f formatter) SuppressHint(hint Hint) {
+	f.hintShown[hint] = true
+}
+
+// Hintf called [Infof] with the emoji [EmojiHint].
+func (f formatter) Hintf(hint Hint, format string, args ...any) {
+	if !f.hintShown[hint] {
+		f.Infof(EmojiHint, format, args...)
+		f.hintShown[hint] = true
+	}
 }

--- a/internal/pp/fmt_test.go
+++ b/internal/pp/fmt_test.go
@@ -31,16 +31,16 @@ func TestIsEnabledFor(t *testing.T) {
 	}
 }
 
-func TestIncIndent(t *testing.T) {
+func TestIndent(t *testing.T) {
 	t.Parallel()
 
 	var buf strings.Builder
 	outer := pp.New(&buf)
 
 	outer.Errorf(pp.EmojiStar, "message1")
-	middle := outer.IncIndent()
+	middle := outer.Indent()
 	middle.Errorf(pp.EmojiStar, "message2")
-	inner := middle.IncIndent()
+	inner := middle.Indent()
 	outer.Errorf(pp.EmojiStar, "message3")
 	inner.Errorf(pp.EmojiStar, "message4")
 	middle.Errorf(pp.EmojiStar, "message5")
@@ -86,4 +86,18 @@ func TestPrint(t *testing.T) {
 			require.Equal(t, tc.expected, buf.String())
 		})
 	}
+}
+
+func TestSupressHint(t *testing.T) {
+	t.Parallel()
+
+	var buf strings.Builder
+	fmt := pp.New(&buf).SetEmoji(true).SetVerbosity(pp.Info)
+
+	fmt.SuppressHint(pp.Hint(0))
+	fmt.Hintf(pp.Hint(0), "hello %s", "world")
+	fmt.Hintf(pp.Hint(1), "hello %s", "galaxy")
+	fmt.Hintf(pp.Hint(1), "hello %s", "universe")
+
+	require.Equal(t, "💡 hello galaxy\n", buf.String())
 }

--- a/internal/pp/hint.go
+++ b/internal/pp/hint.go
@@ -1,0 +1,14 @@
+package pp
+
+// Hint is the identifier of a hint.
+type Hint int
+
+// All the registered hints.
+const (
+	HintUpdateDockerTemplate Hint = iota
+	HintIP4DetectionFails
+	HintIP6DetectionFails
+	HintDetectionTimeouts
+	HintUpdateTimeouts
+	Hint1111Blockage
+)

--- a/internal/pp/url.go
+++ b/internal/pp/url.go
@@ -1,0 +1,7 @@
+package pp
+
+// Fixed URLs in messages.
+const (
+	IssueReportingURL string = "https://github.com/favonia/cloudflare-ddns/issues/new"
+	ManualURL         string = "https://github.com/favonia/cloudflare-ddns/blob/main/README.markdown"
+)

--- a/internal/provider/protocol/doh_test.go
+++ b/internal/provider/protocol/doh_test.go
@@ -179,12 +179,7 @@ func TestDNSOverHTTPSGetIP(t *testing.T) {
 			},
 			invalidIP,
 			func(m *mocks.MockPP) {
-				m.EXPECT().Warningf(
-					pp.EmojiError,
-					"Detected IP address %s is not a valid %s address",
-					ip6.String(),
-					"IPv4",
-				)
+				m.EXPECT().Warningf(pp.EmojiError, "Detected IP address %s is not a valid IPv4 address", ip6.String())
 			},
 		},
 		"unmatched-id": {

--- a/internal/provider/protocol/field_test.go
+++ b/internal/provider/protocol/field_test.go
@@ -64,11 +64,7 @@ func TestFieldGetIP(t *testing.T) {
 			"6to4": {
 				ipnet.IP4, ip6Server.URL, "hello6", ipnet.IP4, invalidIP,
 				func(m *mocks.MockPP) {
-					m.EXPECT().Warningf(
-						pp.EmojiError, "Detected IP address %s is not a valid %s address",
-						ip6.String(),
-						"IPv4",
-					)
+					m.EXPECT().Warningf(pp.EmojiError, "Detected IP address %s is not a valid IPv4 address", ip6.String())
 				},
 			},
 			"4-nil1": {

--- a/internal/provider/protocol/http_test.go
+++ b/internal/provider/protocol/http_test.go
@@ -74,11 +74,7 @@ func TestHTTPGetIP(t *testing.T) {
 			"6to4": {
 				false, ipnet.IP4, ip6Server.URL, ipnet.IP4, invalidIP,
 				func(m *mocks.MockPP) {
-					m.EXPECT().Warningf(
-						pp.EmojiError, "Detected IP address %s is not a valid %s address",
-						ip6.String(),
-						"IPv4",
-					)
+					m.EXPECT().Warningf(pp.EmojiError, "Detected IP address %s is not a valid IPv4 address", ip6.String())
 				},
 			},
 			"4-nil1": {

--- a/internal/provider/protocol/local_test.go
+++ b/internal/provider/protocol/local_test.go
@@ -45,7 +45,8 @@ func TestLocalGetIP(t *testing.T) {
 		"4": {
 			ipnet.IP4, "127.0.0.1:80", ipnet.IP4, gomock.Eq(ip4Loopback), true,
 			func(m *mocks.MockPP) {
-				m.EXPECT().Warningf(pp.EmojiUserWarning, "Detected IP address %s does not look like a global unicast IP address. Please double-check.", "127.0.0.1") //nolint:lll
+				m.EXPECT().Warningf(pp.EmojiUserWarning,
+					"Detected IP address %s does not look like a global unicast IP address.", "127.0.0.1")
 			},
 		},
 		"6": {
@@ -62,7 +63,7 @@ func TestLocalGetIP(t *testing.T) {
 			true,
 			func(m *mocks.MockPP) {
 				m.EXPECT().Warningf(pp.EmojiUserWarning,
-					"Detected IP address %s does not look like a global unicast IP address. Please double-check.",
+					"Detected IP address %s does not look like a global unicast IP address.",
 					gomock.AnyOf(
 						"::1",
 						gomock.Cond(func(x any) bool {


### PR DESCRIPTION
Close #845.

- [x] All one-time hints should be managed by `pp/`
- [ ] EmojiError is a misnomer. It should probably be EmojiFailure
- [x] "Report URL" and "README URL" should be constants
- [x] "... please report" should be on the same line