### PR TITLE
ci: lint the linters

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,11 +1,14 @@
 linters-settings:
+  exhaustive:
+    default-signifies-exhaustive: true
   gci:
     sections:
       - standard
       - default
       - prefix(github.com/favonia/cloudflare-ddns)
-  exhaustive:
-    default-signifies-exhaustive: true
+  gosec:
+    excludes:
+      - G101
   govet:
     settings:
       printf:
@@ -28,6 +31,12 @@ linters-settings:
           - allowRegex: "^_"
 
 issues:
+  exclude-rules:
+    - path: "_test.go"
+      linters:
+        - lll
+        - dupl
+        - goconst
   include:
     - EXC0002
     - EXC0011
@@ -43,8 +52,6 @@ linters:
     - gomnd # deprecated
     - exportloopref # deprecated
 
-    - dupl # somewhat unpredictable, and never leads to actual code changes
-    - goconst # never leads to actual code changes
     - mnd # never leads to actual code changes
 
     - cyclop # can detect complicated code, but never leads to actual code changes

--- a/docs/DESIGN.markdown
+++ b/docs/DESIGN.markdown
@@ -34,6 +34,7 @@ Here is some arbitrary coding convention that I chose to follow. It may change i
    - Domain names
    - Full WAF list references (`account/name`)
 2. A variable of type `map[..]...` should not be named in a plural form just because it is of type `map[...]...`. For example, a mapping from IP networks to detected IPs should be named `detectedIP` not `detectedIPs`.
+3. For testing, an expected call to a mocked interface should be specified in one line in most cases, even if the line becomes very long.
 
 ## Network Security Threat Model
 

--- a/internal/api/cloudflare_records_test.go
+++ b/internal/api/cloudflare_records_test.go
@@ -1,3 +1,4 @@
+// vim: nowrap
 package api_test
 
 import (
@@ -134,12 +135,7 @@ func TestListZonesTwo(t *testing.T) {
 				h.(api.CloudflareHandle).FlushCache() //nolint:forcetypeassert
 
 				mockPP = mocks.NewMockPP(mockCtrl)
-				mockPP.EXPECT().Noticef(
-					pp.EmojiError,
-					"Failed to check the existence of a zone named %s: %v",
-					"test.org",
-					gomock.Any(),
-				)
+				mockPP.EXPECT().Noticef(pp.EmojiError, "Failed to check the existence of a zone named %s: %v", "test.org", gomock.Any())
 				output, ok = h.(api.CloudflareHandle).ListZones(context.Background(), mockPP, tc.input)
 				require.False(t, ok)
 				require.Zero(t, output)
@@ -161,9 +157,9 @@ func TestZoneIDOfDomain(t *testing.T) {
 		ok            bool
 		prepareMockPP func(*mocks.MockPP)
 	}{
-		"root":     {"test.org", domain.FQDN("test.org"), map[string][]string{"test.org": {"active"}}, 1, mockID("test.org", 0), true, nil},     //nolint:lll
-		"wildcard": {"test.org", domain.Wildcard("test.org"), map[string][]string{"test.org": {"active"}}, 1, mockID("test.org", 0), true, nil}, //nolint:lll
-		"one":      {"test.org", domain.FQDN("sub.test.org"), map[string][]string{"test.org": {"active"}}, 2, mockID("test.org", 0), true, nil}, //nolint:lll
+		"root":     {"test.org", domain.FQDN("test.org"), map[string][]string{"test.org": {"active"}}, 1, mockID("test.org", 0), true, nil},
+		"wildcard": {"test.org", domain.Wildcard("test.org"), map[string][]string{"test.org": {"active"}}, 1, mockID("test.org", 0), true, nil},
+		"one":      {"test.org", domain.FQDN("sub.test.org"), map[string][]string{"test.org": {"active"}}, 2, mockID("test.org", 0), true, nil},
 		"none": {
 			"test.org", domain.FQDN("sub.test.org"),
 			map[string][]string{},
@@ -186,11 +182,7 @@ func TestZoneIDOfDomain(t *testing.T) {
 			2, "", false,
 			func(m *mocks.MockPP) {
 				gomock.InOrder(
-					m.EXPECT().Noticef(
-						pp.EmojiImpossible,
-						"Found multiple active zones named %s (IDs: %s); please report this at %s",
-						"test.org", pp.EnglishJoin(mockIDsAsStrings("test.org", 0, 1)), pp.IssueReportingURL,
-					),
+					m.EXPECT().Noticef(pp.EmojiImpossible, "Found multiple active zones named %s (IDs: %s); please report this at %s", "test.org", pp.EnglishJoin(mockIDsAsStrings("test.org", 0, 1)), pp.IssueReportingURL),
 				)
 			},
 		},
@@ -200,11 +192,7 @@ func TestZoneIDOfDomain(t *testing.T) {
 			1, "", false,
 			func(m *mocks.MockPP) {
 				gomock.InOrder(
-					m.EXPECT().Noticef(
-						pp.EmojiImpossible,
-						"Found multiple active zones named %s (IDs: %s); please report this at %s",
-						"test.org", pp.EnglishJoin(mockIDsAsStrings("test.org", 0, 1)), pp.IssueReportingURL,
-					),
+					m.EXPECT().Noticef(pp.EmojiImpossible, "Found multiple active zones named %s (IDs: %s); please report this at %s", "test.org", pp.EnglishJoin(mockIDsAsStrings("test.org", 0, 1)), pp.IssueReportingURL),
 				)
 			},
 		},
@@ -214,7 +202,7 @@ func TestZoneIDOfDomain(t *testing.T) {
 			2, "", false,
 			func(m *mocks.MockPP) {
 				gomock.InOrder(
-					m.EXPECT().Infof(pp.EmojiWarning, "DNS zone %s is %q in your Cloudflare account and thus skipped", "test.org", "deleted"), //nolint:lll
+					m.EXPECT().Infof(pp.EmojiWarning, "DNS zone %s is %q in your Cloudflare account and thus skipped", "test.org", "deleted"),
 					m.EXPECT().Noticef(pp.EmojiError, "Failed to find the zone of %s", "test.org"),
 				)
 			},
@@ -225,7 +213,7 @@ func TestZoneIDOfDomain(t *testing.T) {
 			1, mockID("test.org", 0), true,
 			func(m *mocks.MockPP) {
 				gomock.InOrder(
-					m.EXPECT().Noticef(pp.EmojiWarning, "DNS zone %s is %q in your Cloudflare account; some features (e.g., proxying) might not work as expected", "test.org", "pending"), //nolint:lll
+					m.EXPECT().Noticef(pp.EmojiWarning, "DNS zone %s is %q in your Cloudflare account; some features (e.g., proxying) might not work as expected", "test.org", "pending"),
 				)
 			},
 		},
@@ -235,9 +223,7 @@ func TestZoneIDOfDomain(t *testing.T) {
 			1, mockID("test.org", 0), true,
 			func(m *mocks.MockPP) {
 				gomock.InOrder(
-					m.EXPECT().Noticef(pp.EmojiWarning,
-						"DNS zone %s is %q in your Cloudflare account; some features (e.g., proxying) might not work as expected",
-						"test.org", "initializing"),
+					m.EXPECT().Noticef(pp.EmojiWarning, "DNS zone %s is %q in your Cloudflare account; some features (e.g., proxying) might not work as expected", "test.org", "initializing"),
 				)
 			},
 		},
@@ -246,9 +232,7 @@ func TestZoneIDOfDomain(t *testing.T) {
 			map[string][]string{"test.org": {"some-undocumented-status"}},
 			1, mockID("test.org", 0), true,
 			func(m *mocks.MockPP) {
-				m.EXPECT().Noticef(pp.EmojiImpossible,
-					"DNS zone %s is in an undocumented status %q in your Cloudflare account; please report this at %s",
-					"test.org", "some-undocumented-status", pp.IssueReportingURL)
+				m.EXPECT().Noticef(pp.EmojiImpossible, "DNS zone %s is in an undocumented status %q in your Cloudflare account; please report this at %s", "test.org", "some-undocumented-status", pp.IssueReportingURL)
 			},
 		},
 	} {
@@ -290,12 +274,7 @@ func TestZoneIDOfDomainInvalid(t *testing.T) {
 	_, h, ok := newHandle(t, mockPP)
 	require.True(t, ok)
 
-	mockPP.EXPECT().Noticef(
-		pp.EmojiError,
-		"Failed to check the existence of a zone named %s: %v",
-		"sub.test.org",
-		gomock.Any(),
-	)
+	mockPP.EXPECT().Noticef(pp.EmojiError, "Failed to check the existence of a zone named %s: %v", "sub.test.org", gomock.Any())
 	zoneID, ok := h.(api.CloudflareHandle).ZoneIDOfDomain(context.Background(), mockPP, domain.FQDN("sub.test.org"))
 	require.False(t, ok)
 	require.Zero(t, zoneID)
@@ -344,7 +323,7 @@ func newListRecordsHandler(t *testing.T, mux *http.ServeMux,
 		func(w http.ResponseWriter, r *http.Request) {
 			if !checkRequestLimit(t, &requestLimit) || !checkToken(t, r) {
 				w.WriteHeader(http.StatusUnauthorized)
-				_, err := w.Write([]byte(`{"success":false,"errors":[{"code":9109,"message":"Invalid access token"}],"messages":[],"result":null}`)) //nolint:lll
+				_, err := w.Write([]byte(`{"success":false,"errors":[{"code":9109,"message":"Invalid access token"}],"messages":[],"result":null}`))
 				assert.NoError(t, err)
 				return
 			}
@@ -413,23 +392,13 @@ func TestListRecords(t *testing.T) {
 			nil,
 			false,
 			func(ppfmt *mocks.MockPP) {
-				ppfmt.EXPECT().Noticef(
-					pp.EmojiError,
-					"Failed to retrieve %s records of %s: %v", "AAAA", "sub.test.org", gomock.Any(),
-				)
-				ppfmt.EXPECT().Hintf(pp.HintRecordPermission,
-					"Double check your API token. "+
-						`Make sure you granted the "Edit" permission of "Zone - DNS"`)
+				ppfmt.EXPECT().Noticef(pp.EmojiError, "Failed to retrieve %s records of %s: %v", "AAAA", "sub.test.org", gomock.Any())
+				ppfmt.EXPECT().Hintf(pp.HintRecordPermission, `Double check your API token. Make sure you granted the "Edit" permission of "Zone - DNS"`)
 			},
 			false,
 			func(ppfmt *mocks.MockPP) {
-				ppfmt.EXPECT().Noticef(
-					pp.EmojiError,
-					"Failed to retrieve %s records of %s: %v", "AAAA", "sub.test.org", gomock.Any(),
-				)
-				ppfmt.EXPECT().Hintf(pp.HintRecordPermission,
-					"Double check your API token. "+
-						`Make sure you granted the "Edit" permission of "Zone - DNS"`)
+				ppfmt.EXPECT().Noticef(pp.EmojiError, "Failed to retrieve %s records of %s: %v", "AAAA", "sub.test.org", gomock.Any())
+				ppfmt.EXPECT().Hintf(pp.HintRecordPermission, `Double check your API token. Make sure you granted the "Edit" permission of "Zone - DNS"`)
 			},
 		},
 		"no-zone": {
@@ -439,19 +408,11 @@ func TestListRecords(t *testing.T) {
 			nil,
 			false,
 			func(ppfmt *mocks.MockPP) {
-				ppfmt.EXPECT().Noticef(
-					pp.EmojiError,
-					"Failed to check the existence of a zone named %s: %v",
-					"sub.test.org", gomock.Any(),
-				)
+				ppfmt.EXPECT().Noticef(pp.EmojiError, "Failed to check the existence of a zone named %s: %v", "sub.test.org", gomock.Any())
 			},
 			false,
 			func(ppfmt *mocks.MockPP) {
-				ppfmt.EXPECT().Noticef(
-					pp.EmojiError,
-					"Failed to check the existence of a zone named %s: %v",
-					"sub.test.org", gomock.Any(),
-				)
+				ppfmt.EXPECT().Noticef(pp.EmojiError, "Failed to check the existence of a zone named %s: %v", "sub.test.org", gomock.Any())
 			},
 		},
 		"invalid-ip": {
@@ -464,22 +425,12 @@ func TestListRecords(t *testing.T) {
 			nil,
 			false,
 			func(ppfmt *mocks.MockPP) {
-				ppfmt.EXPECT().Noticef(
-					pp.EmojiImpossible,
-					"Failed to parse the IP address in an %s record of %s (ID: %s): %v",
-					"AAAA", "sub.test.org", "record2", gomock.Any(),
-				)
+				ppfmt.EXPECT().Noticef(pp.EmojiImpossible, "Failed to parse the IP address in an %s record of %s (ID: %s): %v", "AAAA", "sub.test.org", "record2", gomock.Any())
 			},
 			false,
 			func(ppfmt *mocks.MockPP) {
-				ppfmt.EXPECT().Noticef(
-					pp.EmojiError,
-					"Failed to retrieve %s records of %s: %v",
-					"AAAA", "sub.test.org", gomock.Any(),
-				)
-				ppfmt.EXPECT().Hintf(pp.HintRecordPermission,
-					"Double check your API token. "+
-						`Make sure you granted the "Edit" permission of "Zone - DNS"`)
+				ppfmt.EXPECT().Noticef(pp.EmojiError, "Failed to retrieve %s records of %s: %v", "AAAA", "sub.test.org", gomock.Any())
+				ppfmt.EXPECT().Hintf(pp.HintRecordPermission, `Double check your API token. Make sure you granted the "Edit" permission of "Zone - DNS"`)
 			},
 		},
 	} {
@@ -533,8 +484,7 @@ func mockDNSRecordResponse(id string, ipNet ipnet.Type, domain string, ip string
 	return envelopDNSRecordResponse(mockDNSRecord(id, ipNet, domain, ip))
 }
 
-func newDeleteRecordHandler(t *testing.T, mux *http.ServeMux, id string, ipNet ipnet.Type, domain string, ip string,
-) httpHandler {
+func newDeleteRecordHandler(t *testing.T, mux *http.ServeMux, id string, ipNet ipnet.Type, domain string, ip string) httpHandler {
 	t.Helper()
 
 	var requestLimit int
@@ -578,20 +528,14 @@ func TestDeleteRecord(t *testing.T) {
 			0, 0, 0,
 			false,
 			func(ppfmt *mocks.MockPP) {
-				ppfmt.EXPECT().Noticef(pp.EmojiError,
-					"Failed to check the existence of a zone named %s: %v",
-					"sub.test.org", gomock.Any(),
-				)
+				ppfmt.EXPECT().Noticef(pp.EmojiError, "Failed to check the existence of a zone named %s: %v", "sub.test.org", gomock.Any())
 			},
 		},
 		"delete-fails": {
 			2, 0, 0,
 			false,
 			func(ppfmt *mocks.MockPP) {
-				ppfmt.EXPECT().Noticef(pp.EmojiError,
-					"Failed to delete a stale %s record of %s (ID: %s): %v",
-					"AAAA", "sub.test.org", api.ID("record1"), gomock.Any(),
-				)
+				ppfmt.EXPECT().Noticef(pp.EmojiError, "Failed to delete a stale %s record of %s (ID: %s): %v", "AAAA", "sub.test.org", api.ID("record1"), gomock.Any())
 			},
 		},
 	} {
@@ -702,10 +646,7 @@ func TestUpdateRecord(t *testing.T) {
 			100, false, "",
 			false,
 			func(ppfmt *mocks.MockPP) {
-				ppfmt.EXPECT().Noticef(pp.EmojiError,
-					"Failed to check the existence of a zone named %s: %v",
-					"sub.test.org", gomock.Any(),
-				)
+				ppfmt.EXPECT().Noticef(pp.EmojiError, "Failed to check the existence of a zone named %s: %v", "sub.test.org", gomock.Any())
 			},
 		},
 		"update-fails": {
@@ -713,10 +654,7 @@ func TestUpdateRecord(t *testing.T) {
 			100, false, "",
 			false,
 			func(ppfmt *mocks.MockPP) {
-				ppfmt.EXPECT().Noticef(pp.EmojiError,
-					"Failed to update a stale %s record of %s (ID: %s): %v",
-					"AAAA", "sub.test.org", api.ID("record1"), gomock.Any(),
-				)
+				ppfmt.EXPECT().Noticef(pp.EmojiError, "Failed to update a stale %s record of %s (ID: %s): %v", "AAAA", "sub.test.org", api.ID("record1"), gomock.Any())
 			},
 		},
 		"mismatch-attribute": {
@@ -728,20 +666,11 @@ func TestUpdateRecord(t *testing.T) {
 					"you can change them in your Cloudflare dashboard at https://dash.cloudflare.com"
 
 				gomock.InOrder(
-					ppfmt.EXPECT().Infof(pp.EmojiUserWarning,
-						"The TTL of the %s record of %s (ID: %s) to be updated differs from the value of TTL (%s) and will be kept", //nolint:lll
-						"AAAA", "sub.test.org", api.ID("record1"), "1 (auto)",
-					),
+					ppfmt.EXPECT().Infof(pp.EmojiUserWarning, "The TTL of the %s record of %s (ID: %s) to be updated differs from the value of TTL (%s) and will be kept", "AAAA", "sub.test.org", api.ID("record1"), "1 (auto)"),
 					ppfmt.EXPECT().Hintf(pp.HintMismatchedRecordAttributes, hintText),
-					ppfmt.EXPECT().Infof(pp.EmojiUserWarning,
-						"The proxy status of the %s record of %s (ID: %s) to be updated differs from the value of PROXIED (%v for this domain) and will be kept", //nolint:lll
-						"AAAA", "sub.test.org", api.ID("record1"), true,
-					),
+					ppfmt.EXPECT().Infof(pp.EmojiUserWarning, "The proxy status of the %s record of %s (ID: %s) to be updated differs from the value of PROXIED (%v for this domain) and will be kept", "AAAA", "sub.test.org", api.ID("record1"), true),
 					ppfmt.EXPECT().Hintf(pp.HintMismatchedRecordAttributes, hintText),
-					ppfmt.EXPECT().Infof(pp.EmojiUserWarning,
-						"The comment of the %s record of %s (ID: %s) to be updated differs from the value of RECORD_COMMENT (%q) and will be kept", //nolint:lll
-						"AAAA", "sub.test.org", api.ID("record1"), "hello",
-					),
+					ppfmt.EXPECT().Infof(pp.EmojiUserWarning, "The comment of the %s record of %s (ID: %s) to be updated differs from the value of RECORD_COMMENT (%q) and will be kept", "AAAA", "sub.test.org", api.ID("record1"), "hello"),
 					ppfmt.EXPECT().Hintf(pp.HintMismatchedRecordAttributes, hintText),
 				)
 			},
@@ -767,8 +696,7 @@ func TestUpdateRecord(t *testing.T) {
 			urh := newUpdateRecordHandler(t, mux, "record1", "::2")
 			urh.setRequestLimit(tc.updateRequestLimit)
 
-			ok = h.UpdateRecord(context.Background(), mockPP, ipnet.IP6, domain.FQDN("sub.test.org"), "record1", mustIP("::2"),
-				tc.expectedTTL, tc.expectedProxied, tc.expectedComment)
+			ok = h.UpdateRecord(context.Background(), mockPP, ipnet.IP6, domain.FQDN("sub.test.org"), "record1", mustIP("::2"), tc.expectedTTL, tc.expectedProxied, tc.expectedComment)
 			require.Equal(t, tc.ok, ok)
 			require.True(t, zh.isExhausted())
 			require.True(t, lrh.isExhausted())
@@ -796,8 +724,7 @@ func TestUpdateRecord(t *testing.T) {
 	}
 }
 
-func newCreateRecordHandler(t *testing.T, mux *http.ServeMux, id string, ipNet ipnet.Type, domain string, ip string,
-) httpHandler {
+func newCreateRecordHandler(t *testing.T, mux *http.ServeMux, id string, ipNet ipnet.Type, domain string, ip string) httpHandler {
 	t.Helper()
 
 	var requestLimit int
@@ -858,20 +785,14 @@ func TestCreateRecord(t *testing.T) {
 			0, 0, 0,
 			false,
 			func(ppfmt *mocks.MockPP) {
-				ppfmt.EXPECT().Noticef(pp.EmojiError,
-					"Failed to check the existence of a zone named %s: %v",
-					"sub.test.org", gomock.Any(),
-				).Times(2)
+				ppfmt.EXPECT().Noticef(pp.EmojiError, "Failed to check the existence of a zone named %s: %v", "sub.test.org", gomock.Any()).Times(2)
 			},
 		},
 		"create-fails": {
 			2, 1, 0,
 			false,
 			func(ppfmt *mocks.MockPP) {
-				ppfmt.EXPECT().Noticef(pp.EmojiError,
-					"Failed to add a new %s record of %s: %v",
-					"AAAA", "sub.test.org", gomock.Any(),
-				)
+				ppfmt.EXPECT().Noticef(pp.EmojiError, "Failed to add a new %s record of %s: %v", "AAAA", "sub.test.org", gomock.Any())
 			},
 		},
 	} {
@@ -896,7 +817,7 @@ func TestCreateRecord(t *testing.T) {
 			crh.setRequestLimit(tc.createRequestLimit)
 
 			h.ListRecords(context.Background(), mockPP, ipnet.IP6, domain.FQDN("sub.test.org"))
-			actualID, ok := h.CreateRecord(context.Background(), mockPP, ipnet.IP6, domain.FQDN("sub.test.org"), mustIP("::1"), 100, false, "hello") //nolint:lll
+			actualID, ok := h.CreateRecord(context.Background(), mockPP, ipnet.IP6, domain.FQDN("sub.test.org"), mustIP("::1"), 100, false, "hello")
 			require.Equal(t, tc.ok, ok)
 			if ok {
 				require.Equal(t, api.ID("record1"), actualID)

--- a/internal/api/cloudflare_waf_test.go
+++ b/internal/api/cloudflare_waf_test.go
@@ -1,3 +1,4 @@
+// vim: nowrap
 package api_test
 
 import (
@@ -156,11 +157,7 @@ func TestListWAFLists(t *testing.T) {
 			h.(api.CloudflareHandle).FlushCache() //nolint:forcetypeassert
 
 			mockPP = mocks.NewMockPP(mockCtrl)
-			mockPP.EXPECT().Noticef(
-				pp.EmojiError,
-				"Failed to list existing lists: %v",
-				gomock.Any(),
-			)
+			mockPP.EXPECT().Noticef(pp.EmojiError, "Failed to list existing lists: %v", gomock.Any())
 			lists, ok = h.(api.CloudflareHandle).ListWAFLists(context.Background(), mockPP, mockAccountID)
 			require.False(t, ok)
 			require.Zero(t, lists)
@@ -195,10 +192,7 @@ func TestWAFListID(t *testing.T) {
 			"description",
 			false, false, "",
 			func(ppfmt *mocks.MockPP) {
-				ppfmt.EXPECT().Noticef(pp.EmojiImpossible,
-					"Found multiple lists named %q within the account %s (IDs: %s and %s); please report this at %s",
-					"list", mockAccountID, mockID("list", 0), mockID("list", 2), pp.IssueReportingURL,
-				)
+				ppfmt.EXPECT().Noticef(pp.EmojiImpossible, "Found multiple lists named %q within the account %s (IDs: %s and %s); please report this at %s", "list", mockAccountID, mockID("list", 0), mockID("list", 2), pp.IssueReportingURL)
 			},
 		},
 		"1ip1asn": {
@@ -219,15 +213,8 @@ func TestWAFListID(t *testing.T) {
 			true, true, mockID("list", 1),
 			func(ppfmt *mocks.MockPP) {
 				gomock.InOrder(
-					ppfmt.EXPECT().Infof(pp.EmojiUserWarning,
-						"The description of the list %s (ID: %s) differs from the value of WAF_LIST_DESCRIPTION (%q)",
-						"account456/list", mockID("list", 1), "mismatched description",
-					),
-					ppfmt.EXPECT().Hintf(pp.HintMismatchedWAFListAttributes,
-						"The updater will not overwrite WAF list descriptions; "+
-							"you can change them at https://dash.cloudflare.com/%s/configurations/lists",
-						mockAccountID,
-					),
+					ppfmt.EXPECT().Infof(pp.EmojiUserWarning, "The description of the list %s (ID: %s) differs from the value of WAF_LIST_DESCRIPTION (%q)", "account456/list", mockID("list", 1), "mismatched description"),
+					ppfmt.EXPECT().Hintf(pp.HintMismatchedWAFListAttributes, "The updater will not overwrite WAF list descriptions; "+"you can change them at https://dash.cloudflare.com/%s/configurations/lists", mockAccountID),
 				)
 			},
 		},
@@ -298,9 +285,7 @@ func TestListWAFListsHint(t *testing.T) {
 	mockPP = mocks.NewMockPP(mockCtrl)
 	gomock.InOrder(
 		mockPP.EXPECT().Noticef(pp.EmojiError, "Failed to list existing lists: %v", gomock.Any()),
-		mockPP.EXPECT().Hintf(pp.HintWAFListPermission,
-			"Double check your API token and account ID. "+
-				`Make sure you granted the "Edit" permission of "Account - Account Filter Lists"`),
+		mockPP.EXPECT().Hintf(pp.HintWAFListPermission, `Double check your API token and account ID. Make sure you granted the "Edit" permission of "Account - Account Filter Lists"`),
 	)
 	lists, ok := h.(api.CloudflareHandle).ListWAFLists(context.Background(), mockPP, mockAccountID)
 	require.False(t, ok)
@@ -355,10 +340,7 @@ func TestFindWAFList(t *testing.T) {
 			false, "",
 			func(ppfmt *mocks.MockPP) {
 				gomock.InOrder(
-					ppfmt.EXPECT().Noticef(pp.EmojiImpossible,
-						"Found multiple lists named %q within the account %s (IDs: %s and %s); please report this at %s",
-						"list", mockAccountID, mockID("list", 0), mockID("list", 2), pp.IssueReportingURL,
-					),
+					ppfmt.EXPECT().Noticef(pp.EmojiImpossible, "Found multiple lists named %q within the account %s (IDs: %s and %s); please report this at %s", "list", mockAccountID, mockID("list", 0), mockID("list", 2), pp.IssueReportingURL),
 					ppfmt.EXPECT().Noticef(pp.EmojiError, "Failed to find the list %s", "account456/list"),
 				)
 			},
@@ -494,9 +476,7 @@ func TestFinalClearWAFListAsync(t *testing.T) {
 			1, mockID("list", 0), 0, 1,
 			false, true,
 			func(ppfmt *mocks.MockPP) {
-				ppfmt.EXPECT().Noticef(pp.EmojiError,
-					"Failed to delete the list %s; clearing it instead: %v",
-					"account456/list", gomock.Any())
+				ppfmt.EXPECT().Noticef(pp.EmojiError, "Failed to delete the list %s; clearing it instead: %v", "account456/list", gomock.Any())
 			},
 		},
 		"delete-fail/clear-fail": {
@@ -504,12 +484,8 @@ func TestFinalClearWAFListAsync(t *testing.T) {
 			false, false,
 			func(ppfmt *mocks.MockPP) {
 				gomock.InOrder(
-					ppfmt.EXPECT().Noticef(pp.EmojiError,
-						"Failed to delete the list %s; clearing it instead: %v",
-						"account456/list", gomock.Any()),
-					ppfmt.EXPECT().Noticef(pp.EmojiError,
-						"Failed to start clearing the list %s: %v",
-						"account456/list", gomock.Any()),
+					ppfmt.EXPECT().Noticef(pp.EmojiError, "Failed to delete the list %s; clearing it instead: %v", "account456/list", gomock.Any()),
+					ppfmt.EXPECT().Noticef(pp.EmojiError, "Failed to start clearing the list %s: %v", "account456/list", gomock.Any()),
 				)
 			},
 		},
@@ -518,12 +494,8 @@ func TestFinalClearWAFListAsync(t *testing.T) {
 			false, false,
 			func(ppfmt *mocks.MockPP) {
 				gomock.InOrder(
-					ppfmt.EXPECT().Noticef(pp.EmojiError,
-						"Failed to delete the list %s; clearing it instead: %v",
-						"account456/list", gomock.Any()),
-					ppfmt.EXPECT().Noticef(pp.EmojiError,
-						"Failed to start clearing the list %s: %v",
-						"account456/list", gomock.Any()),
+					ppfmt.EXPECT().Noticef(pp.EmojiError, "Failed to delete the list %s; clearing it instead: %v", "account456/list", gomock.Any()),
+					ppfmt.EXPECT().Noticef(pp.EmojiError, "Failed to start clearing the list %s: %v", "account456/list", gomock.Any()),
 				)
 			},
 		},
@@ -697,9 +669,7 @@ func TestListWAFListItems(t *testing.T) {
 			0,
 			false, false, nil,
 			func(ppfmt *mocks.MockPP) {
-				ppfmt.EXPECT().Noticef(pp.EmojiError,
-					"Failed to retrieve items in the list %s: %v",
-					"account456/list", gomock.Any())
+				ppfmt.EXPECT().Noticef(pp.EmojiError, "Failed to retrieve items in the list %s: %v", "account456/list", gomock.Any())
 			},
 		},
 		"invalid": {
@@ -712,13 +682,9 @@ func TestListWAFListItems(t *testing.T) {
 			false, false, nil,
 			func(ppfmt *mocks.MockPP) {
 				gomock.InOrder(
-					ppfmt.EXPECT().Noticef(pp.EmojiImpossible,
-						"Failed to parse %q as an IP range: %v", "invalid item", gomock.Any()),
-					ppfmt.EXPECT().Noticef(pp.EmojiImpossible,
-						"Failed to parse %q as an IP address as well: %v", "invalid item", gomock.Any()),
-					ppfmt.EXPECT().Noticef(pp.EmojiImpossible,
-						"Found an invalid IP range/address %q in the list %s",
-						"invalid item", "account456/list"),
+					ppfmt.EXPECT().Noticef(pp.EmojiImpossible, "Failed to parse %q as an IP range: %v", "invalid item", gomock.Any()),
+					ppfmt.EXPECT().Noticef(pp.EmojiImpossible, "Failed to parse %q as an IP address as well: %v", "invalid item", gomock.Any()),
+					ppfmt.EXPECT().Noticef(pp.EmojiImpossible, "Found an invalid IP range/address %q in the list %s", "invalid item", "account456/list"),
 				)
 			},
 		},
@@ -893,9 +859,7 @@ func TestDeleteWAFListItems(t *testing.T) {
 			0, nil, 0,
 			false,
 			func(ppfmt *mocks.MockPP) {
-				ppfmt.EXPECT().Noticef(pp.EmojiError,
-					"Failed to finish deleting items from the list %s: %v",
-					"account456/list", gomock.Any())
+				ppfmt.EXPECT().Noticef(pp.EmojiError, "Failed to finish deleting items from the list %s: %v", "account456/list", gomock.Any())
 			},
 		},
 		"list-items-invalid": {
@@ -907,13 +871,9 @@ func TestDeleteWAFListItems(t *testing.T) {
 			false,
 			func(ppfmt *mocks.MockPP) {
 				gomock.InOrder(
-					ppfmt.EXPECT().Noticef(pp.EmojiImpossible,
-						"Failed to parse %q as an IP range: %v", "invalid item", gomock.Any()),
-					ppfmt.EXPECT().Noticef(pp.EmojiImpossible,
-						"Failed to parse %q as an IP address as well: %v", "invalid item", gomock.Any()),
-					ppfmt.EXPECT().Noticef(pp.EmojiImpossible,
-						"Found an invalid IP range/address %q in the list %s",
-						"invalid item", "account456/list"),
+					ppfmt.EXPECT().Noticef(pp.EmojiImpossible, "Failed to parse %q as an IP range: %v", "invalid item", gomock.Any()),
+					ppfmt.EXPECT().Noticef(pp.EmojiImpossible, "Failed to parse %q as an IP address as well: %v", "invalid item", gomock.Any()),
+					ppfmt.EXPECT().Noticef(pp.EmojiImpossible, "Found an invalid IP range/address %q in the list %s", "invalid item", "account456/list"),
 				)
 			},
 		},
@@ -1073,8 +1033,7 @@ func TestCreateWAFListItems(t *testing.T) {
 			0, nil, 0,
 			false,
 			func(ppfmt *mocks.MockPP) {
-				ppfmt.EXPECT().Noticef(pp.EmojiError, "Failed to finish adding items to the list %s: %v",
-					"account456/list", gomock.Any())
+				ppfmt.EXPECT().Noticef(pp.EmojiError, "Failed to finish adding items to the list %s: %v", "account456/list", gomock.Any())
 			},
 		},
 		"list-items-invalid": {
@@ -1086,13 +1045,9 @@ func TestCreateWAFListItems(t *testing.T) {
 			false,
 			func(ppfmt *mocks.MockPP) {
 				gomock.InOrder(
-					ppfmt.EXPECT().Noticef(pp.EmojiImpossible,
-						"Failed to parse %q as an IP range: %v", "invalid item", gomock.Any()),
-					ppfmt.EXPECT().Noticef(pp.EmojiImpossible,
-						"Failed to parse %q as an IP address as well: %v", "invalid item", gomock.Any()),
-					ppfmt.EXPECT().Noticef(pp.EmojiImpossible,
-						"Found an invalid IP range/address %q in the list %s",
-						"invalid item", "account456/list"),
+					ppfmt.EXPECT().Noticef(pp.EmojiImpossible, "Failed to parse %q as an IP range: %v", "invalid item", gomock.Any()),
+					ppfmt.EXPECT().Noticef(pp.EmojiImpossible, "Failed to parse %q as an IP address as well: %v", "invalid item", gomock.Any()),
+					ppfmt.EXPECT().Noticef(pp.EmojiImpossible, "Found an invalid IP range/address %q in the list %s", "invalid item", "account456/list"),
 				)
 			},
 		},

--- a/internal/config/check_root_test.go
+++ b/internal/config/check_root_test.go
@@ -1,3 +1,4 @@
+// vim: nowrap
 package config_test
 
 import (
@@ -32,11 +33,11 @@ func TestCheckRootWithOldConfigs(t *testing.T) {
 	mockPP := mocks.NewMockPP(mockCtrl)
 	var calls []any
 	if syscall.Geteuid() == 0 {
-		calls = append(calls, mockPP.EXPECT().Noticef(pp.EmojiUserWarning, "You are running this updater as root, which is usually a bad idea")) //nolint:lll
+		calls = append(calls, mockPP.EXPECT().Noticef(pp.EmojiUserWarning, "You are running this updater as root, which is usually a bad idea"))
 	}
 	calls = append(calls,
-		mockPP.EXPECT().Noticef(pp.EmojiUserWarning, "PUID=%s is ignored since 1.13.0; use Docker's built-in mechanism to set user ID", "1000"),  //nolint:lll
-		mockPP.EXPECT().Noticef(pp.EmojiUserWarning, "PGID=%s is ignored since 1.13.0; use Docker's built-in mechanism to set group ID", "1000"), //nolint:lll
+		mockPP.EXPECT().Noticef(pp.EmojiUserWarning, "PUID=%s is ignored since 1.13.0; use Docker's built-in mechanism to set user ID", "1000"),
+		mockPP.EXPECT().Noticef(pp.EmojiUserWarning, "PGID=%s is ignored since 1.13.0; use Docker's built-in mechanism to set group ID", "1000"),
 		mockPP.EXPECT().Hintf(pp.HintUpdateDockerTemplate, "See %s for the new Docker template", pp.ManualURL),
 	)
 	gomock.InOrder(calls...)

--- a/internal/config/config_read_test.go
+++ b/internal/config/config_read_test.go
@@ -1,3 +1,4 @@
+// vim: nowrap
 package config_test
 
 import (
@@ -145,7 +146,7 @@ func TestNormalize(t *testing.T) {
 					m.EXPECT().IsShowing(pp.Info).Return(true),
 					m.EXPECT().Infof(pp.EmojiEnvVars, "Checking settings . . ."),
 					m.EXPECT().Indent().Return(m),
-					m.EXPECT().Noticef(pp.EmojiUserError, "DELETE_ON_STOP=true will immediately delete all domains and WAF lists when UPDATE_CRON=@once"), //nolint:lll
+					m.EXPECT().Noticef(pp.EmojiUserError, "DELETE_ON_STOP=true will immediately delete all domains and WAF lists when UPDATE_CRON=@once"),
 				)
 			},
 		},
@@ -168,9 +169,7 @@ func TestNormalize(t *testing.T) {
 					m.EXPECT().IsShowing(pp.Info).Return(true),
 					m.EXPECT().Infof(pp.EmojiEnvVars, "Checking settings . . ."),
 					m.EXPECT().Indent().Return(m),
-					m.EXPECT().Noticef(pp.EmojiUserError,
-						"Nothing to update because both IP4_PROVIDER and IP6_PROVIDER are %q",
-						"none"),
+					m.EXPECT().Noticef(pp.EmojiUserError, "Nothing to update because both IP4_PROVIDER and IP6_PROVIDER are %q", "none"),
 				)
 			},
 		},
@@ -207,9 +206,7 @@ func TestNormalize(t *testing.T) {
 					m.EXPECT().IsShowing(pp.Info).Return(true),
 					m.EXPECT().Infof(pp.EmojiEnvVars, "Checking settings . . ."),
 					m.EXPECT().Indent().Return(m),
-					m.EXPECT().Noticef(pp.EmojiUserWarning,
-						"IP%d_PROVIDER was changed to %q because no domains or WAF lists use %s",
-						6, "none", "IPv6"),
+					m.EXPECT().Noticef(pp.EmojiUserWarning, "IP%d_PROVIDER was changed to %q because no domains or WAF lists use %s", 6, "none", "IPv6"),
 				)
 			},
 		},
@@ -230,12 +227,8 @@ func TestNormalize(t *testing.T) {
 					m.EXPECT().IsShowing(pp.Info).Return(true),
 					m.EXPECT().Infof(pp.EmojiEnvVars, "Checking settings . . ."),
 					m.EXPECT().Indent().Return(m),
-					m.EXPECT().Noticef(pp.EmojiUserWarning,
-						"IP%d_PROVIDER was changed to %q because no domains or WAF lists use %s",
-						6, "none", "IPv6"),
-					m.EXPECT().Noticef(pp.EmojiUserError,
-						"Nothing to update because both IP4_PROVIDER and IP6_PROVIDER are %q",
-						"none"),
+					m.EXPECT().Noticef(pp.EmojiUserWarning, "IP%d_PROVIDER was changed to %q because no domains or WAF lists use %s", 6, "none", "IPv6"),
+					m.EXPECT().Noticef(pp.EmojiUserError, "Nothing to update because both IP4_PROVIDER and IP6_PROVIDER are %q", "none"),
 				)
 			},
 		},
@@ -274,9 +267,7 @@ func TestNormalize(t *testing.T) {
 					m.EXPECT().IsShowing(pp.Info).Return(true),
 					m.EXPECT().Infof(pp.EmojiEnvVars, "Checking settings . . ."),
 					m.EXPECT().Indent().Return(m),
-					m.EXPECT().Noticef(pp.EmojiUserWarning,
-						"Domain %q is ignored because it is only for %s but %s is disabled",
-						"d.e.f", "IPv4", "IPv4"),
+					m.EXPECT().Noticef(pp.EmojiUserWarning, "Domain %q is ignored because it is only for %s but %s is disabled", "d.e.f", "IPv4", "IPv4"),
 				)
 			},
 		},
@@ -312,15 +303,9 @@ func TestNormalize(t *testing.T) {
 					m.EXPECT().IsShowing(pp.Info).Return(true),
 					m.EXPECT().Infof(pp.EmojiEnvVars, "Checking settings . . ."),
 					m.EXPECT().Indent().Return(m),
-					m.EXPECT().Noticef(pp.EmojiUserWarning,
-						"TTL=%v is ignored because no domains will be updated",
-						api.TTL(10000)),
-					m.EXPECT().Noticef(pp.EmojiUserWarning,
-						"PROXIED=%s is ignored because no domains will be updated",
-						"true"),
-					m.EXPECT().Noticef(pp.EmojiUserWarning,
-						"RECORD_COMMENT=%s is ignored because no domains will be updated",
-						"hello"),
+					m.EXPECT().Noticef(pp.EmojiUserWarning, "TTL=%v is ignored because no domains will be updated", api.TTL(10000)),
+					m.EXPECT().Noticef(pp.EmojiUserWarning, "PROXIED=%s is ignored because no domains will be updated", "true"),
+					m.EXPECT().Noticef(pp.EmojiUserWarning, "RECORD_COMMENT=%s is ignored because no domains will be updated", "hello"),
 				)
 			},
 		},
@@ -361,9 +346,7 @@ func TestNormalize(t *testing.T) {
 					m.EXPECT().IsShowing(pp.Info).Return(true),
 					m.EXPECT().Infof(pp.EmojiEnvVars, "Checking settings . . ."),
 					m.EXPECT().Indent().Return(m),
-					m.EXPECT().Noticef(pp.EmojiUserWarning,
-						"WAF_LIST_DESCRIPTION=%s is ignored because no WAF lists will be updated",
-						"My list"),
+					m.EXPECT().Noticef(pp.EmojiUserWarning, "WAF_LIST_DESCRIPTION=%s is ignored because no WAF lists will be updated", "My list"),
 				)
 			},
 		},
@@ -422,7 +405,7 @@ func TestNormalize(t *testing.T) {
 					m.EXPECT().IsShowing(pp.Info).Return(true),
 					m.EXPECT().Infof(pp.EmojiEnvVars, "Checking settings . . ."),
 					m.EXPECT().Indent().Return(m),
-					m.EXPECT().Noticef(pp.EmojiUserError, "%s (%q) is not a boolean expression: got unexpected token %q", keyProxied, `range`, `range`), //nolint:lll
+					m.EXPECT().Noticef(pp.EmojiUserError, "%s (%q) is not a boolean expression: got unexpected token %q", keyProxied, `range`, `range`),
 				)
 			},
 		},
@@ -444,7 +427,7 @@ func TestNormalize(t *testing.T) {
 					m.EXPECT().IsShowing(pp.Info).Return(true),
 					m.EXPECT().Infof(pp.EmojiEnvVars, "Checking settings . . ."),
 					m.EXPECT().Indent().Return(m),
-					m.EXPECT().Noticef(pp.EmojiUserError, "%s (%q) is not a boolean expression: got unexpected token %q", keyProxied, `999`, `999`), //nolint:lll
+					m.EXPECT().Noticef(pp.EmojiUserError, "%s (%q) is not a boolean expression: got unexpected token %q", keyProxied, `999`, `999`),
 				)
 			},
 		},
@@ -500,9 +483,7 @@ func TestNormalize(t *testing.T) {
 					m.EXPECT().IsShowing(pp.Info).Return(true),
 					m.EXPECT().Infof(pp.EmojiEnvVars, "Checking settings . . ."),
 					m.EXPECT().Indent().Return(m),
-					m.EXPECT().Noticef(pp.EmojiUserWarning,
-						"DETECTION_TIMEOUT=%s may be too short for trying 1.0.0.1 when 1.1.1.1 does not work",
-						time.Nanosecond),
+					m.EXPECT().Noticef(pp.EmojiUserWarning, "DETECTION_TIMEOUT=%s may be too short for trying 1.0.0.1 when 1.1.1.1 does not work", time.Nanosecond),
 					m.EXPECT().Hintf(pp.Hint1111Blockage, "%s", provider.Hint1111BlocakageText),
 				)
 			},

--- a/internal/config/env_auth.go
+++ b/internal/config/env_auth.go
@@ -12,15 +12,15 @@ var oauthBearerRegex = regexp.MustCompile(`^[-a-zA-Z0-9._~+/]+=*$`)
 
 // Keys of environment variables.
 const (
-	TokenKey1     string = "CLOUDFLARE_API_TOKEN"      //nolint:gosec
-	TokenKey2     string = "CF_API_TOKEN"              //nolint:gosec
-	TokenFileKey1 string = "CLOUDFLARE_API_TOKEN_FILE" //nolint:gosec
-	TokenFileKey2 string = "CF_API_TOKEN_FILE"         //nolint:gosec
+	TokenKey1     string = "CLOUDFLARE_API_TOKEN"
+	TokenKey2     string = "CF_API_TOKEN"
+	TokenFileKey1 string = "CLOUDFLARE_API_TOKEN_FILE"
+	TokenFileKey2 string = "CF_API_TOKEN_FILE"
 )
 
 // HintAuthTokenNewPrefix contains the hint about the transition from
 // CF_* to CLOUDFLARE_*.
-const HintAuthTokenNewPrefix string = "Cloudflare is transitioning its tools to use the prefix CLOUDFLARE instead of CF. To align with this change, it is recommended to use CLOUDFLARE_API_TOKEN (or CLOUDFLARE_API_TOKEN_FILE) instead of CF_API_TOKEN (or CF_API_TOKEN_FILE) moving forward. All these options will be fully supported until version 2.0." //nolint:lll,gosec
+const HintAuthTokenNewPrefix string = "Cloudflare is switching to the CLOUDFLARE_* prefix for its tools. Use CLOUDFLARE_API_TOKEN or CLOUDFLARE_API_TOKEN_FILE instead of CF_* (fully supported until 2.0.0 and then minimally supported until 3.0.0)." //nolint:lll
 
 func readPlainAuthTokens(ppfmt pp.PP) (string, string, bool) {
 	token1 := Getenv(TokenKey1)

--- a/internal/config/env_auth_test.go
+++ b/internal/config/env_auth_test.go
@@ -1,3 +1,4 @@
+// vim: nowrap
 package config_test
 
 import (
@@ -42,8 +43,7 @@ func TestReadAuth(t *testing.T) {
 			"", "", "", "", "",
 			false, "",
 			func(m *mocks.MockPP) {
-				m.EXPECT().Noticef(pp.EmojiUserError,
-					"Needs either %s or %s", "CLOUDFLARE_API_TOKEN", "CLOUDFLARE_API_TOKEN_FILE")
+				m.EXPECT().Noticef(pp.EmojiUserError, "Needs either %s or %s", "CLOUDFLARE_API_TOKEN", "CLOUDFLARE_API_TOKEN_FILE")
 			},
 		},
 		"conflicting": {
@@ -51,9 +51,7 @@ func TestReadAuth(t *testing.T) {
 			"token1", "token2", "", "", "",
 			false, "",
 			func(m *mocks.MockPP) {
-				m.EXPECT().Noticef(pp.EmojiUserError,
-					"The values of %s and %s do not match; they must specify the same token",
-					"CLOUDFLARE_API_TOKEN", "CF_API_TOKEN")
+				m.EXPECT().Noticef(pp.EmojiUserError, "The values of %s and %s do not match; they must specify the same token", "CLOUDFLARE_API_TOKEN", "CF_API_TOKEN")
 			},
 		},
 		"old": {
@@ -74,8 +72,7 @@ func TestReadAuth(t *testing.T) {
 			"!!!", "", "", "", "",
 			true, "!!!",
 			func(m *mocks.MockPP) {
-				m.EXPECT().Noticef(pp.EmojiUserWarning,
-					"The API token appears to be invalid; it does not follow the OAuth2 bearer token format")
+				m.EXPECT().Noticef(pp.EmojiUserWarning, "The API token appears to be invalid; it does not follow the OAuth2 bearer token format")
 			},
 		},
 		"account": {
@@ -91,8 +88,7 @@ func TestReadAuth(t *testing.T) {
 			"YOUR-CLOUDFLARE-API-TOKEN", "", "", "", "",
 			false, "",
 			func(m *mocks.MockPP) {
-				m.EXPECT().Noticef(pp.EmojiUserError,
-					"You need to provide a real API token as %s", "CLOUDFLARE_API_TOKEN")
+				m.EXPECT().Noticef(pp.EmojiUserError, "You need to provide a real API token as %s", "CLOUDFLARE_API_TOKEN")
 			},
 		},
 		"file/success": {
@@ -105,9 +101,7 @@ func TestReadAuth(t *testing.T) {
 			"", "", "empty.txt", "", "",
 			false, "",
 			func(m *mocks.MockPP) {
-				m.EXPECT().Noticef(pp.EmojiUserError,
-					"The file specified by %s does not contain an API token",
-					"CLOUDFLARE_API_TOKEN_FILE")
+				m.EXPECT().Noticef(pp.EmojiUserError, "The file specified by %s does not contain an API token", "CLOUDFLARE_API_TOKEN_FILE")
 			},
 		},
 		"file/conflicting": {
@@ -115,9 +109,7 @@ func TestReadAuth(t *testing.T) {
 			"", "", "token1.txt", "token2.txt", "",
 			false, "",
 			func(m *mocks.MockPP) {
-				m.EXPECT().Noticef(pp.EmojiUserError,
-					"The files specified by %s and %s have conflicting tokens; their content must match",
-					"CLOUDFLARE_API_TOKEN_FILE", "CF_API_TOKEN_FILE")
+				m.EXPECT().Noticef(pp.EmojiUserError, "The files specified by %s and %s have conflicting tokens; their content must match", "CLOUDFLARE_API_TOKEN_FILE", "CF_API_TOKEN_FILE")
 			},
 		},
 		"file/conflicting/non-file": {
@@ -125,11 +117,7 @@ func TestReadAuth(t *testing.T) {
 			"plain", "", "token.txt", "", "",
 			false, "",
 			func(m *mocks.MockPP) {
-				m.EXPECT().Noticef(pp.EmojiUserError,
-					"The value of %s does not match the token found in the file specified by %s; "+
-						"they must specify the same token",
-					"CLOUDFLARE_API_TOKEN", "CLOUDFLARE_API_TOKEN_FILE",
-				)
+				m.EXPECT().Noticef(pp.EmojiUserError, "The value of %s does not match the token found in the file specified by %s; they must specify the same token", "CLOUDFLARE_API_TOKEN", "CLOUDFLARE_API_TOKEN_FILE")
 			},
 		},
 		"file/same/non-file": {

--- a/internal/config/env_base_test.go
+++ b/internal/config/env_base_test.go
@@ -393,23 +393,13 @@ func TestReadCron(t *testing.T) {
 		"nil": {
 			false, "", cron.MustNew("* * * * *"), cron.MustNew("* * * * *"), true,
 			func(m *mocks.MockPP) {
-				m.EXPECT().Infof(
-					pp.EmojiBullet,
-					"Use default %s=%s",
-					key,
-					"* * * * *",
-				)
+				m.EXPECT().Infof(pp.EmojiBullet, "Use default %s=%s", key, "* * * * *")
 			},
 		},
 		"empty": {
 			true, "", cron.MustNew("@every 3m"), cron.MustNew("@every 3m"), true,
 			func(m *mocks.MockPP) {
-				m.EXPECT().Infof(
-					pp.EmojiBullet,
-					"Use default %s=%s",
-					key,
-					"@every 3m",
-				)
+				m.EXPECT().Infof(pp.EmojiBullet, "Use default %s=%s", key, "@every 3m")
 			},
 		},
 		"@daily": {true, " @daily  ", cron.MustNew("@yearly"), cron.MustNew("@daily"), true, nil},

--- a/internal/config/env_domain_test.go
+++ b/internal/config/env_domain_test.go
@@ -1,3 +1,4 @@
+// vim: nowrap
 package config_test
 
 import (
@@ -32,15 +33,15 @@ func TestReadDomains(t *testing.T) {
 		"star":      {true, "*", ds{}, ds{w("")}, true, nil},
 		"wildcard1": {true, "*.a", ds{}, ds{w("a")}, true, nil},
 		"wildcard2": {true, "*.a.b", ds{}, ds{w("a.b")}, true, nil},
-		"test1":     {true, "書.org ,  Bücher.org  ", ds{f("random.org")}, ds{f("xn--rov.org"), f("xn--bcher-kva.org")}, true, nil},                      //nolint:lll
-		"test2":     {true, "  \txn--rov.org    ,   xn--Bcher-kva.org  ", ds{f("random.org")}, ds{f("xn--rov.org"), f("xn--bcher-kva.org")}, true, nil}, //nolint:lll
+		"test1":     {true, "書.org ,  Bücher.org  ", ds{f("random.org")}, ds{f("xn--rov.org"), f("xn--bcher-kva.org")}, true, nil},
+		"test2":     {true, "  \txn--rov.org    ,   xn--Bcher-kva.org  ", ds{f("random.org")}, ds{f("xn--rov.org"), f("xn--bcher-kva.org")}, true, nil},
 		"illformed1": {
 			true, "xn--:D.org,a.org",
 			ds{f("random.org")},
 			ds{f("random.org")},
 			false,
 			func(m *mocks.MockPP) {
-				m.EXPECT().Noticef(pp.EmojiUserError, "%s (%q) contains an ill-formed domain %q: %v", key, "xn--:D.org,a.org", "xn--:d.org", gomock.Any()) //nolint:lll
+				m.EXPECT().Noticef(pp.EmojiUserError, "%s (%q) contains an ill-formed domain %q: %v", key, "xn--:D.org,a.org", "xn--:d.org", gomock.Any())
 			},
 		},
 		"illformed2": {
@@ -49,7 +50,7 @@ func TestReadDomains(t *testing.T) {
 			ds{f("random.org")},
 			false,
 			func(m *mocks.MockPP) {
-				m.EXPECT().Noticef(pp.EmojiUserError, "%s (%q) contains an ill-formed domain %q: %v", key, "*.xn--:D.org,a.org", "*.xn--:d.org", gomock.Any()) //nolint:lll
+				m.EXPECT().Noticef(pp.EmojiUserError, "%s (%q) contains an ill-formed domain %q: %v", key, "*.xn--:D.org,a.org", "*.xn--:d.org", gomock.Any())
 			},
 		},
 		"illformed3": {
@@ -127,9 +128,7 @@ func TestReadDomainMap(t *testing.T) {
 		"ill-formed": {
 			" ", "   ", "*.*", nil, false,
 			func(m *mocks.MockPP) {
-				m.EXPECT().Noticef(pp.EmojiUserError,
-					"%s (%q) contains an ill-formed domain %q: %v",
-					"IP6_DOMAINS", "*.*", "*.*", gomock.Any())
+				m.EXPECT().Noticef(pp.EmojiUserError, "%s (%q) contains an ill-formed domain %q: %v", "IP6_DOMAINS", "*.*", "*.*", gomock.Any())
 			},
 		},
 	} {

--- a/internal/config/env_monitor_test.go
+++ b/internal/config/env_monitor_test.go
@@ -1,3 +1,4 @@
+// vim: nowrap
 package config_test
 
 import (
@@ -35,30 +36,21 @@ func TestReadAndAppendHealthchecksURL(t *testing.T) {
 		"example": {
 			true, "https://hi.org/1234",
 			nil,
-			monitor.NewComposed(monitor.Healthchecks{
-				BaseURL: urlMustParse(t, "https://hi.org/1234"),
-				Timeout: monitor.HealthchecksDefaultTimeout,
-			}),
+			monitor.NewComposed(monitor.Healthchecks{BaseURL: urlMustParse(t, "https://hi.org/1234"), Timeout: monitor.HealthchecksDefaultTimeout}),
 			true,
 			nil,
 		},
 		"password": {
 			true, "https://me:pass@hi.org/1234",
 			nil,
-			monitor.NewComposed(monitor.Healthchecks{
-				BaseURL: urlMustParse(t, "https://me:pass@hi.org/1234"),
-				Timeout: monitor.HealthchecksDefaultTimeout,
-			}),
+			monitor.NewComposed(monitor.Healthchecks{BaseURL: urlMustParse(t, "https://me:pass@hi.org/1234"), Timeout: monitor.HealthchecksDefaultTimeout}),
 			true,
 			nil,
 		},
 		"fragment": {
 			true, "https://hi.org/1234#fragment",
 			nil,
-			monitor.NewComposed(monitor.Healthchecks{
-				BaseURL: urlMustParse(t, "https://hi.org/1234#fragment"),
-				Timeout: monitor.HealthchecksDefaultTimeout,
-			}),
+			monitor.NewComposed(monitor.Healthchecks{BaseURL: urlMustParse(t, "https://hi.org/1234#fragment"), Timeout: monitor.HealthchecksDefaultTimeout}),
 			true,
 			nil,
 		},
@@ -70,7 +62,7 @@ func TestReadAndAppendHealthchecksURL(t *testing.T) {
 			func(m *mocks.MockPP) {
 				gomock.InOrder(
 					m.EXPECT().Noticef(pp.EmojiUserError, `The Healthchecks URL (redacted) does not look like a valid URL`),
-					m.EXPECT().Noticef(pp.EmojiUserError, `A valid example is "https://hc-ping.com/01234567-0123-0123-0123-0123456789abc"`), //nolint:lll
+					m.EXPECT().Noticef(pp.EmojiUserError, `A valid example is "https://hc-ping.com/01234567-0123-0123-0123-0123456789abc"`),
 				)
 			},
 		},
@@ -89,7 +81,7 @@ func TestReadAndAppendHealthchecksURL(t *testing.T) {
 			func(m *mocks.MockPP) {
 				gomock.InOrder(
 					m.EXPECT().Noticef(pp.EmojiUserError, `The Healthchecks URL (redacted) does not look like a valid URL`),
-					m.EXPECT().Noticef(pp.EmojiUserError, `A valid example is "https://hc-ping.com/01234567-0123-0123-0123-0123456789abc"`), //nolint:lll
+					m.EXPECT().Noticef(pp.EmojiUserError, `A valid example is "https://hc-ping.com/01234567-0123-0123-0123-0123456789abc"`),
 				)
 			},
 		},
@@ -142,35 +134,24 @@ func TestReadAndAppendUptimeKumaURL(t *testing.T) {
 		"password": {
 			true, "https://me:pass@hi.org/1234",
 			nil,
-			monitor.NewComposed(monitor.UptimeKuma{
-				BaseURL: urlMustParse(t, "https://me:pass@hi.org/1234"),
-				Timeout: monitor.UptimeKumaDefaultTimeout,
-			}),
+			monitor.NewComposed(monitor.UptimeKuma{BaseURL: urlMustParse(t, "https://me:pass@hi.org/1234"), Timeout: monitor.UptimeKumaDefaultTimeout}),
 			true,
 			nil,
 		},
 		"fragment": {
 			true, "https://hi.org/1234#fragment",
 			nil,
-			monitor.NewComposed(monitor.UptimeKuma{
-				BaseURL: urlMustParse(t, "https://hi.org/1234#fragment"),
-				Timeout: monitor.UptimeKumaDefaultTimeout,
-			}),
+			monitor.NewComposed(monitor.UptimeKuma{BaseURL: urlMustParse(t, "https://hi.org/1234#fragment"), Timeout: monitor.UptimeKumaDefaultTimeout}),
 			true,
 			nil,
 		},
 		"query": {
 			true, "https://hi.org/1234?hello=123",
 			nil,
-			monitor.NewComposed(monitor.UptimeKuma{
-				BaseURL: urlMustParse(t, "https://hi.org/1234"),
-				Timeout: monitor.UptimeKumaDefaultTimeout,
-			}),
+			monitor.NewComposed(monitor.UptimeKuma{BaseURL: urlMustParse(t, "https://hi.org/1234"), Timeout: monitor.UptimeKumaDefaultTimeout}),
 			true,
 			func(m *mocks.MockPP) {
-				m.EXPECT().Noticef(pp.EmojiUserError,
-					`The Uptime Kuma URL (redacted) contains an unexpected query %s=... and it will be ignored`,
-					"hello")
+				m.EXPECT().Noticef(pp.EmojiUserError, `The Uptime Kuma URL (redacted) contains an unexpected query %s=... and it will be ignored`, "hello")
 			},
 		},
 		"illformed/not-url": {

--- a/internal/config/env_notifier_test.go
+++ b/internal/config/env_notifier_test.go
@@ -1,3 +1,4 @@
+// vim: nowrap
 package config_test
 
 import (
@@ -58,7 +59,7 @@ func TestReadAndAppendShoutrrrURL(t *testing.T) {
 			},
 			true,
 			func(m *mocks.MockPP) {
-				m.EXPECT().Hintf(pp.HintExperimentalShoutrrr, "You are using the experimental shoutrrr support added in version 1.12.0") //nolint:lll
+				m.EXPECT().Hintf(pp.HintExperimentalShoutrrr, "You are using the experimental shoutrrr support added in version 1.12.0")
 			},
 		},
 		"ill-formed": {
@@ -70,7 +71,7 @@ func TestReadAndAppendShoutrrrURL(t *testing.T) {
 			},
 			false,
 			func(m *mocks.MockPP) {
-				m.EXPECT().Hintf(pp.HintExperimentalShoutrrr, "You are using the experimental shoutrrr support added in version 1.12.0") //nolint:lll
+				m.EXPECT().Hintf(pp.HintExperimentalShoutrrr, "You are using the experimental shoutrrr support added in version 1.12.0")
 				m.EXPECT().Noticef(pp.EmojiUserError, `Could not create shoutrrr client: %v`, gomock.Any())
 			},
 		},
@@ -88,7 +89,7 @@ func TestReadAndAppendShoutrrrURL(t *testing.T) {
 			},
 			true,
 			func(m *mocks.MockPP) {
-				m.EXPECT().Hintf(pp.HintExperimentalShoutrrr, "You are using the experimental shoutrrr support added in version 1.12.0") //nolint:lll
+				m.EXPECT().Hintf(pp.HintExperimentalShoutrrr, "You are using the experimental shoutrrr support added in version 1.12.0")
 			},
 		},
 	} {

--- a/internal/config/env_provider_test.go
+++ b/internal/config/env_provider_test.go
@@ -1,3 +1,4 @@
+// vim: nowrap
 package config_test
 
 import (
@@ -53,70 +54,37 @@ func TestReadProvider(t *testing.T) {
 		"deprecated/cloudflare": {
 			false, "", true, "    cloudflare\t   ", none, trace, true,
 			func(m *mocks.MockPP) {
-				m.EXPECT().Noticef(
-					pp.EmojiUserWarning,
-					`%s=cloudflare is deprecated; use %s=cloudflare.trace or %s=cloudflare.doh`,
-					keyDeprecated, key, key,
-				)
+				m.EXPECT().Noticef(pp.EmojiUserWarning, `%s=cloudflare is deprecated; use %s=cloudflare.trace or %s=cloudflare.doh`, keyDeprecated, key, key)
 			},
 		},
 		"deprecated/cloudflare.trace": {
 			false, "", true, " cloudflare.trace", none, trace, true,
 			func(m *mocks.MockPP) {
-				m.EXPECT().Noticef(
-					pp.EmojiUserWarning,
-					`%s is deprecated; use %s=%s`,
-					keyDeprecated,
-					key,
-					"cloudflare.trace",
-				)
+				m.EXPECT().Noticef(pp.EmojiUserWarning, `%s is deprecated; use %s=%s`, keyDeprecated, key, "cloudflare.trace")
 			},
 		},
 		"deprecated/cloudflare.doh": {
 			false, "", true, "    \tcloudflare.doh   ", none, doh, true,
 			func(m *mocks.MockPP) {
-				m.EXPECT().Noticef(
-					pp.EmojiUserWarning,
-					`%s is deprecated; use %s=%s`,
-					keyDeprecated,
-					key,
-					"cloudflare.doh",
-				)
+				m.EXPECT().Noticef(pp.EmojiUserWarning, `%s is deprecated; use %s=%s`, keyDeprecated, key, "cloudflare.doh")
 			},
 		},
 		"deprecated/unmanaged": {
 			false, "", true, "   unmanaged   ", trace, none, true,
 			func(m *mocks.MockPP) {
-				m.EXPECT().Noticef(
-					pp.EmojiUserWarning,
-					`%s is deprecated; use %s=none`,
-					keyDeprecated,
-					key,
-				)
+				m.EXPECT().Noticef(pp.EmojiUserWarning, `%s is deprecated; use %s=none`, keyDeprecated, key)
 			},
 		},
 		"deprecated/local": {
 			false, "", true, "   local   ", trace, local, true,
 			func(m *mocks.MockPP) {
-				m.EXPECT().Noticef(
-					pp.EmojiUserWarning,
-					`%s is deprecated; use %s=%s`,
-					keyDeprecated,
-					key,
-					"local",
-				)
+				m.EXPECT().Noticef(pp.EmojiUserWarning, `%s is deprecated; use %s=%s`, keyDeprecated, key, "local")
 			},
 		},
 		"deprecated/ipify": {
 			false, "", true, "     ipify  ", trace, ipify, true,
 			func(m *mocks.MockPP) {
-				m.EXPECT().Noticef(
-					pp.EmojiUserWarning,
-					`%s=ipify is deprecated; use %s=cloudflare.trace or %s=cloudflare.doh`,
-					keyDeprecated,
-					key,
-					key,
-				)
+				m.EXPECT().Noticef(pp.EmojiUserWarning, `%s=ipify is deprecated; use %s=cloudflare.trace or %s=cloudflare.doh`, keyDeprecated, key, key)
 			},
 		},
 		"deprecated/others": {
@@ -128,11 +96,7 @@ func TestReadProvider(t *testing.T) {
 		"conflicts": {
 			true, "cloudflare.doh", true, "cloudflare.doh", ipify, ipify, false,
 			func(m *mocks.MockPP) {
-				m.EXPECT().Noticef(
-					pp.EmojiUserError,
-					`Cannot have both %s and %s set`,
-					key, keyDeprecated,
-				)
+				m.EXPECT().Noticef(pp.EmojiUserError, `Cannot have both %s and %s set`, key, keyDeprecated)
 			},
 		},
 		"empty": {
@@ -144,11 +108,7 @@ func TestReadProvider(t *testing.T) {
 		"cloudflare": {
 			true, "    cloudflare\t   ", false, "", none, none, false,
 			func(m *mocks.MockPP) {
-				m.EXPECT().Noticef(
-					pp.EmojiUserError,
-					`%s=cloudflare is invalid; use %s=cloudflare.trace or %s=cloudflare.doh`,
-					key, key, key,
-				)
+				m.EXPECT().Noticef(pp.EmojiUserError, `%s=cloudflare is invalid; use %s=cloudflare.trace or %s=cloudflare.doh`, key, key, key)
 			},
 		},
 		"cloudflare.trace": {true, " cloudflare.trace", false, "", none, trace, true, nil},
@@ -158,30 +118,20 @@ func TestReadProvider(t *testing.T) {
 		"local.iface:lo": {
 			true, "   local.iface   :  lo ", false, "", trace, localLoopback, true,
 			func(m *mocks.MockPP) {
-				m.EXPECT().Hintf(pp.HintExperimentalLocalWithInterface, `You are using the experimental provider "local.iface:%s" added in version 1.15.0`, "lo") //nolint:lll
+				m.EXPECT().Hintf(pp.HintExperimentalLocalWithInterface, `You are using the experimental provider "local.iface:%s" added in version 1.15.0`, "lo")
 			},
 		},
 		"local.iface:": {
 			true, "   local.iface: ", false, "", trace, trace, false,
 			func(m *mocks.MockPP) {
-				m.EXPECT().Noticef(
-					pp.EmojiUserError,
-					`%s=local.iface: must be followed by a network interface name`,
-					key,
-				)
+				m.EXPECT().Noticef(pp.EmojiUserError, `%s=local.iface: must be followed by a network interface name`, key)
 			},
 		},
 		"custom": {true, "   url:https://url.io   ", false, "", trace, custom, true, nil},
 		"ipify": {
 			true, "     ipify  ", false, "", trace, ipify, true,
 			func(m *mocks.MockPP) {
-				m.EXPECT().Noticef(
-					pp.EmojiUserWarning,
-					`%s=ipify is deprecated; use %s=cloudflare.trace or %s=cloudflare.doh`,
-					key,
-					key,
-					key,
-				)
+				m.EXPECT().Noticef(pp.EmojiUserWarning, `%s=ipify is deprecated; use %s=cloudflare.trace or %s=cloudflare.doh`, key, key, key)
 			},
 		},
 		"others": {

--- a/internal/config/env_waf_test.go
+++ b/internal/config/env_waf_test.go
@@ -1,3 +1,4 @@
+// vim: nowrap
 package config_test
 
 import (
@@ -36,8 +37,7 @@ func TestReadAndAppendWAFListNames(t *testing.T) {
 			[]api.WAFList{{AccountID: "hey", Name: "hello"}},
 			true,
 			func(m *mocks.MockPP) {
-				m.EXPECT().Hintf(pp.HintExperimentalWAF,
-					"You're using the experimental WAF list manipulation feature added in version 1.14.0")
+				m.EXPECT().Hintf(pp.HintExperimentalWAF, "You're using the experimental WAF list manipulation feature added in version 1.14.0")
 			},
 		},
 		"two": {
@@ -46,8 +46,7 @@ func TestReadAndAppendWAFListNames(t *testing.T) {
 			[]api.WAFList{{AccountID: "hey", Name: "hello"}, {AccountID: "here", Name: "aloha"}},
 			true,
 			func(m *mocks.MockPP) {
-				m.EXPECT().Hintf(pp.HintExperimentalWAF,
-					"You're using the experimental WAF list manipulation feature added in version 1.14.0")
+				m.EXPECT().Hintf(pp.HintExperimentalWAF, "You're using the experimental WAF list manipulation feature added in version 1.14.0")
 			},
 		},
 		"one+two": {
@@ -60,8 +59,7 @@ func TestReadAndAppendWAFListNames(t *testing.T) {
 			},
 			true,
 			func(m *mocks.MockPP) {
-				m.EXPECT().Hintf(pp.HintExperimentalWAF,
-					"You're using the experimental WAF list manipulation feature added in version 1.14.0")
+				m.EXPECT().Hintf(pp.HintExperimentalWAF, "You're using the experimental WAF list manipulation feature added in version 1.14.0")
 			},
 		},
 		"invalid-format": {
@@ -70,8 +68,7 @@ func TestReadAndAppendWAFListNames(t *testing.T) {
 			[]api.WAFList{{AccountID: "there", Name: "ciao"}},
 			false,
 			func(m *mocks.MockPP) {
-				m.EXPECT().Hintf(pp.HintExperimentalWAF,
-					"You're using the experimental WAF list manipulation feature added in version 1.14.0")
+				m.EXPECT().Hintf(pp.HintExperimentalWAF, "You're using the experimental WAF list manipulation feature added in version 1.14.0")
 				m.EXPECT().Noticef(pp.EmojiUserError, `List %q should be in format "account-id/list-name"`, "+++")
 			},
 		},
@@ -86,8 +83,7 @@ func TestReadAndAppendWAFListNames(t *testing.T) {
 			},
 			true,
 			func(m *mocks.MockPP) {
-				m.EXPECT().Hintf(pp.HintExperimentalWAF,
-					"You're using the experimental WAF list manipulation feature added in version 1.14.0")
+				m.EXPECT().Hintf(pp.HintExperimentalWAF, "You're using the experimental WAF list manipulation feature added in version 1.14.0")
 				m.EXPECT().Noticef(pp.EmojiUserWarning, "List name %q contains invalid character %q", "!!!", "!")
 			},
 		},

--- a/internal/domainexp/parser_test.go
+++ b/internal/domainexp/parser_test.go
@@ -1,3 +1,4 @@
+// vim: nowrap
 package domainexp_test
 
 import (
@@ -199,7 +200,7 @@ func TestParseExpression(t *testing.T) {
 		"utf8/invalid": {
 			"\200\300", false, nil, false,
 			func(m *mocks.MockPP) {
-				m.EXPECT().Noticef(pp.EmojiUserError, "%s (%q) is ill-formed: %v", key, "\200\300", ErrorMatcher{domainexp.ErrUTF8}) //nolint:lll
+				m.EXPECT().Noticef(pp.EmojiUserError, "%s (%q) is ill-formed: %v", key, "\200\300", ErrorMatcher{domainexp.ErrUTF8})
 			},
 		},
 	} {

--- a/internal/ipnet/ipnet_test.go
+++ b/internal/ipnet/ipnet_test.go
@@ -1,3 +1,4 @@
+// vim: nowrap
 package ipnet_test
 
 import (
@@ -100,9 +101,7 @@ func TestNormalizeDetectedIP(t *testing.T) {
 			ipnet.IP4, invalidIP,
 			false, invalidIP,
 			func(m *mocks.MockPP) {
-				m.EXPECT().Noticef(pp.EmojiImpossible,
-					`Detected IP address is not valid; this should not happen and please report it at %s`,
-					pp.IssueReportingURL)
+				m.EXPECT().Noticef(pp.EmojiImpossible, `Detected IP address is not valid; this should not happen and please report it at %s`, pp.IssueReportingURL)
 			},
 		},
 		"4-1::2": {
@@ -117,8 +116,7 @@ func TestNormalizeDetectedIP(t *testing.T) {
 			ipnet.IP4, mustIP("0.0.0.0"),
 			false, invalidIP,
 			func(m *mocks.MockPP) {
-				m.EXPECT().Noticef(pp.EmojiError,
-					"Detected %s address %s is an unspecified address", "IPv4", "0.0.0.0")
+				m.EXPECT().Noticef(pp.EmojiError, "Detected %s address %s is an unspecified address", "IPv4", "0.0.0.0")
 			},
 		},
 		"4-127.0.0.1": {
@@ -139,9 +137,7 @@ func TestNormalizeDetectedIP(t *testing.T) {
 			ipnet.IP6, invalidIP,
 			false, invalidIP,
 			func(m *mocks.MockPP) {
-				m.EXPECT().Noticef(pp.EmojiImpossible,
-					`Detected IP address is not valid; this should not happen and please report it at %s`,
-					pp.IssueReportingURL)
+				m.EXPECT().Noticef(pp.EmojiImpossible, `Detected IP address is not valid; this should not happen and please report it at %s`, pp.IssueReportingURL)
 			},
 		},
 		"6-1::2": {ipnet.IP6, mustIP("1::2"), true, mustIP("1::2"), nil},
@@ -157,14 +153,8 @@ func TestNormalizeDetectedIP(t *testing.T) {
 			false, invalidIP,
 			func(m *mocks.MockPP) {
 				gomock.InOrder(
-					m.EXPECT().Noticef(pp.EmojiError,
-						"Detected IP address %s is an IPv4-mapped IPv6 address",
-						"::ffff:10.10.10.10"),
-					m.EXPECT().Hintf(pp.HintIP4MappedIP6Address,
-						"An IPv4-mapped IPv6 address is an IPv4 address in disguise. "+
-							"It cannot be used for routing IPv6 traffic. "+
-							"If you need to use it for DNS, please open an issue at %s",
-						pp.IssueReportingURL),
+					m.EXPECT().Noticef(pp.EmojiError, "Detected IP address %s is an IPv4-mapped IPv6 address", "::ffff:10.10.10.10"),
+					m.EXPECT().Hintf(pp.HintIP4MappedIP6Address, "An IPv4-mapped IPv6 address is an IPv4 address in disguise. It cannot be used for routing IPv6 traffic. If you need to use it for DNS, please open an issue at %s", pp.IssueReportingURL),
 				)
 			},
 		},
@@ -179,18 +169,14 @@ func TestNormalizeDetectedIP(t *testing.T) {
 			ipnet.IP6, mustIP("ff01::1"),
 			false, invalidIP,
 			func(m *mocks.MockPP) {
-				m.EXPECT().Noticef(pp.EmojiError,
-					"Detected %s address %s is an interface-local multicast address",
-					"IPv6", "ff01::1")
+				m.EXPECT().Noticef(pp.EmojiError, "Detected %s address %s is an interface-local multicast address", "IPv6", "ff01::1")
 			},
 		},
 		"6-ff03::1": {
 			ipnet.IP6, mustIP("ff03::1"),
 			true, mustIP("ff03::1"),
 			func(m *mocks.MockPP) {
-				m.EXPECT().Noticef(pp.EmojiWarning,
-					"Detected %s address %s does not look like a global unicast address",
-					"IPv6", "ff03::1")
+				m.EXPECT().Noticef(pp.EmojiWarning, "Detected %s address %s does not look like a global unicast address", "IPv6", "ff03::1")
 			},
 		},
 		"100-10.10.10.10": {

--- a/internal/monitor/healthchecks_test.go
+++ b/internal/monitor/healthchecks_test.go
@@ -1,3 +1,4 @@
+// vim: nowrap
 package monitor_test
 
 import (
@@ -41,7 +42,7 @@ func TestNewHealthchecksFail1(t *testing.T) {
 	mockPP := mocks.NewMockPP(mockCtrl)
 	gomock.InOrder(
 		mockPP.EXPECT().Noticef(pp.EmojiUserError, `The Healthchecks URL (redacted) does not look like a valid URL`),
-		mockPP.EXPECT().Noticef(pp.EmojiUserError, `A valid example is "https://hc-ping.com/01234567-0123-0123-0123-0123456789abc"`), //nolint:lll
+		mockPP.EXPECT().Noticef(pp.EmojiUserError, `A valid example is "https://hc-ping.com/01234567-0123-0123-0123-0123456789abc"`),
 	)
 	_, ok := monitor.NewHealthchecks(mockPP, "this is not a valid URL")
 	require.False(t, ok)
@@ -54,7 +55,7 @@ func TestNewHealthchecksFail2(t *testing.T) {
 	mockPP := mocks.NewMockPP(mockCtrl)
 	gomock.InOrder(
 		mockPP.EXPECT().Noticef(pp.EmojiUserError, `The Healthchecks URL (redacted) does not look like a valid URL`),
-		mockPP.EXPECT().Noticef(pp.EmojiUserError, `A valid example is "https://hc-ping.com/01234567-0123-0123-0123-0123456789abc"`), //nolint:lll
+		mockPP.EXPECT().Noticef(pp.EmojiUserError, `A valid example is "https://hc-ping.com/01234567-0123-0123-0123-0123456789abc"`),
 	)
 	_, ok := monitor.NewHealthchecks(mockPP, "ftp://example.org")
 	require.False(t, ok)
@@ -134,7 +135,7 @@ func TestHealthchecksEndPoints(t *testing.T) {
 			func(m *mocks.MockPP) {
 				gomock.InOrder(
 					m.EXPECT().Noticef(pp.EmojiUserWarning, "The Healthchecks URL (redacted) uses HTTP; please consider using HTTPS"),
-					m.EXPECT().Noticef(pp.EmojiError, "Failed to ping the %s endpoint of Healthchecks; got response code: %d %s", `default (root)`, 400, "invalid url format"), //nolint:lll
+					m.EXPECT().Noticef(pp.EmojiError, "Failed to ping the %s endpoint of Healthchecks; got response code: %d %s", `default (root)`, 400, "invalid url format"),
 				)
 			},
 		},
@@ -148,7 +149,7 @@ func TestHealthchecksEndPoints(t *testing.T) {
 			func(m *mocks.MockPP) {
 				gomock.InOrder(
 					m.EXPECT().Noticef(pp.EmojiUserWarning, "The Healthchecks URL (redacted) uses HTTP; please consider using HTTPS"),
-					m.EXPECT().Noticef(pp.EmojiError, "Failed to send HTTP(S) request to the %s endpoint of Healthchecks: %v", `default (root)`, gomock.Any()), //nolint:lll
+					m.EXPECT().Noticef(pp.EmojiError, "Failed to send HTTP(S) request to the %s endpoint of Healthchecks: %v", `default (root)`, gomock.Any()),
 				)
 			},
 		},

--- a/internal/monitor/uptimekuma_test.go
+++ b/internal/monitor/uptimekuma_test.go
@@ -36,7 +36,7 @@ func TestNewUptimeKuma(t *testing.T) {
 		"unexpected": {
 			"https://user:pass@host/path?random=", true,
 			func(m *mocks.MockPP) {
-				m.EXPECT().Noticef(pp.EmojiUserError, "The Uptime Kuma URL (redacted) contains an unexpected query %s=... and it will be ignored", "random") //nolint:lll
+				m.EXPECT().Noticef(pp.EmojiUserError, "The Uptime Kuma URL (redacted) contains an unexpected query %s=... and it will be ignored", "random")
 			},
 		},
 		"ill-formed-query": {

--- a/internal/notifier/shoutrrr_test.go
+++ b/internal/notifier/shoutrrr_test.go
@@ -1,3 +1,4 @@
+// vim: nowrap
 package notifier_test
 
 import (
@@ -29,9 +30,7 @@ func TestDescribeShoutrrrService(t *testing.T) {
 		"empty": {
 			"", "",
 			func(ppfmt *mocks.MockPP) {
-				ppfmt.EXPECT().Noticef(pp.EmojiImpossible,
-					"Unknown shoutrrr service name %q; please report it at %s",
-					"", pp.IssueReportingURL)
+				ppfmt.EXPECT().Noticef(pp.EmojiImpossible, "Unknown shoutrrr service name %q; please report it at %s", "", pp.IssueReportingURL)
 			},
 		},
 	} {

--- a/internal/provider/protocol/doh_test.go
+++ b/internal/provider/protocol/doh_test.go
@@ -1,3 +1,4 @@
+// vim: nowrap
 package protocol_test
 
 import (
@@ -151,11 +152,7 @@ func TestDNSOverHTTPSGetIP(t *testing.T) {
 			},
 			invalidIP,
 			func(m *mocks.MockPP) {
-				m.EXPECT().Noticef(
-					pp.EmojiError,
-					"Failed to prepare the DNS query: %v",
-					gomock.Any(),
-				)
+				m.EXPECT().Noticef(pp.EmojiError, "Failed to prepare the DNS query: %v", gomock.Any())
 			},
 		},
 		"6to4": {
@@ -199,9 +196,7 @@ func TestDNSOverHTTPSGetIP(t *testing.T) {
 			},
 			invalidIP,
 			func(m *mocks.MockPP) {
-				m.EXPECT().Noticef(
-					pp.EmojiImpossible, `Invalid DNS response: mismatched transaction ID`,
-				)
+				m.EXPECT().Noticef(pp.EmojiImpossible, `Invalid DNS response: mismatched transaction ID`)
 			},
 		},
 		"notxt": {
@@ -213,9 +208,7 @@ func TestDNSOverHTTPSGetIP(t *testing.T) {
 			[]dnsmessage.Resource{},
 			invalidIP,
 			func(m *mocks.MockPP) {
-				m.EXPECT().Noticef(
-					pp.EmojiImpossible, `Invalid DNS response: no TXT records or all TXT records are empty`,
-				)
+				m.EXPECT().Noticef(pp.EmojiImpossible, `Invalid DNS response: no TXT records or all TXT records are empty`)
 			},
 		},
 		"notresponse": {
@@ -237,9 +230,7 @@ func TestDNSOverHTTPSGetIP(t *testing.T) {
 			},
 			invalidIP,
 			func(m *mocks.MockPP) {
-				m.EXPECT().Noticef(
-					pp.EmojiImpossible, `Invalid DNS response: QR was not set`,
-				)
+				m.EXPECT().Noticef(pp.EmojiImpossible, `Invalid DNS response: QR was not set`)
 			},
 		},
 		"truncated": {
@@ -261,9 +252,7 @@ func TestDNSOverHTTPSGetIP(t *testing.T) {
 			},
 			invalidIP,
 			func(m *mocks.MockPP) {
-				m.EXPECT().Noticef(
-					pp.EmojiImpossible, `Invalid DNS response: TC was set`,
-				)
+				m.EXPECT().Noticef(pp.EmojiImpossible, `Invalid DNS response: TC was set`)
 			},
 		},
 		"rcode": {
@@ -285,11 +274,7 @@ func TestDNSOverHTTPSGetIP(t *testing.T) {
 			},
 			invalidIP,
 			func(m *mocks.MockPP) {
-				m.EXPECT().Noticef(
-					pp.EmojiImpossible,
-					"Invalid DNS response: response code is %v",
-					dnsmessage.RCodeFormatError,
-				)
+				m.EXPECT().Noticef(pp.EmojiImpossible, "Invalid DNS response: response code is %v", dnsmessage.RCodeFormatError)
 			},
 		},
 		"irrelevant-records1": {
@@ -369,9 +354,7 @@ func TestDNSOverHTTPSGetIP(t *testing.T) {
 			},
 			invalidIP,
 			func(m *mocks.MockPP) {
-				m.EXPECT().Noticef(
-					pp.EmojiImpossible, `Invalid DNS response: no TXT records or all TXT records are empty`,
-				)
+				m.EXPECT().Noticef(pp.EmojiImpossible, `Invalid DNS response: no TXT records or all TXT records are empty`)
 			},
 		},
 		"irrelevant-records4": {
@@ -451,11 +434,7 @@ func TestDNSOverHTTPSGetIP(t *testing.T) {
 			},
 			invalidIP,
 			func(m *mocks.MockPP) {
-				m.EXPECT().Noticef(
-					pp.EmojiImpossible,
-					`Invalid DNS response: failed to parse the IP address in the TXT record: %s`,
-					"I am definitely not an IP address",
-				)
+				m.EXPECT().Noticef(pp.EmojiImpossible, `Invalid DNS response: failed to parse the IP address in the TXT record: %s`, "I am definitely not an IP address")
 			},
 		},
 		"multiple1": {
@@ -477,9 +456,7 @@ func TestDNSOverHTTPSGetIP(t *testing.T) {
 			},
 			invalidIP,
 			func(m *mocks.MockPP) {
-				m.EXPECT().Noticef(
-					pp.EmojiImpossible, `Invalid DNS response: more than one string in TXT records`,
-				)
+				m.EXPECT().Noticef(pp.EmojiImpossible, `Invalid DNS response: more than one string in TXT records`)
 			},
 		},
 		"multiple2": {
@@ -510,9 +487,7 @@ func TestDNSOverHTTPSGetIP(t *testing.T) {
 			},
 			invalidIP,
 			func(m *mocks.MockPP) {
-				m.EXPECT().Noticef(
-					pp.EmojiImpossible, `Invalid DNS response: more than one string in TXT records`,
-				)
+				m.EXPECT().Noticef(pp.EmojiImpossible, `Invalid DNS response: more than one string in TXT records`)
 			},
 		},
 		"noresponse": {
@@ -534,11 +509,7 @@ func TestDNSOverHTTPSGetIP(t *testing.T) {
 			},
 			invalidIP,
 			func(m *mocks.MockPP) {
-				m.EXPECT().Noticef(
-					pp.EmojiImpossible,
-					"Invalid DNS response: %v",
-					gomock.Any(),
-				)
+				m.EXPECT().Noticef(pp.EmojiImpossible, "Invalid DNS response: %v", gomock.Any())
 			},
 		},
 		"nourl": {
@@ -560,11 +531,7 @@ func TestDNSOverHTTPSGetIP(t *testing.T) {
 			},
 			invalidIP,
 			func(m *mocks.MockPP) {
-				m.EXPECT().Noticef(
-					pp.EmojiImpossible,
-					"Unhandled IP network: %s",
-					"IPv6",
-				)
+				m.EXPECT().Noticef(pp.EmojiImpossible, "Unhandled IP network: %s", "IPv6")
 			},
 		},
 	} {

--- a/internal/provider/protocol/http_test.go
+++ b/internal/provider/protocol/http_test.go
@@ -1,3 +1,4 @@
+// vim: nowrap
 package protocol_test
 
 import (
@@ -69,11 +70,7 @@ func TestHTTPGetIP(t *testing.T) {
 		"nilctx": {
 			true, ipnet.IP4, server4.URL, ipnet.IP4, invalidIP,
 			func(m *mocks.MockPP) {
-				m.EXPECT().Noticef(
-					pp.EmojiImpossible, "Failed to prepare HTTP(S) request to %q: %v",
-					server4.URL,
-					gomock.Any(),
-				)
+				m.EXPECT().Noticef(pp.EmojiImpossible, "Failed to prepare HTTP(S) request to %q: %v", server4.URL, gomock.Any())
 			},
 		},
 		"4": {false, ipnet.IP4, server4.URL, ipnet.IP4, ip4, nil},
@@ -96,46 +93,28 @@ func TestHTTPGetIP(t *testing.T) {
 			false,
 			ipnet.IP4, illformed4.URL, ipnet.IP4, invalidIP,
 			func(m *mocks.MockPP) {
-				m.EXPECT().Noticef(
-					pp.EmojiError,
-					`Failed to parse the IP address in the response of %q: %s`,
-					illformed4.URL,
-					"hello")
+				m.EXPECT().Noticef(pp.EmojiError, `Failed to parse the IP address in the response of %q: %s`, illformed4.URL, "hello")
 			},
 		},
 		"6/illformed": {
 			false,
 			ipnet.IP6, illformed6.URL, ipnet.IP6, invalidIP,
 			func(m *mocks.MockPP) {
-				m.EXPECT().Noticef(
-					pp.EmojiError,
-					`Failed to parse the IP address in the response of %q: %s`,
-					illformed6.URL,
-					"hello")
+				m.EXPECT().Noticef(pp.EmojiError, `Failed to parse the IP address in the response of %q: %s`, illformed6.URL, "hello")
 			},
 		},
 		"4/request-fail": {
 			false,
 			ipnet.IP4, "", ipnet.IP4, invalidIP,
 			func(m *mocks.MockPP) {
-				m.EXPECT().Noticef(
-					pp.EmojiError,
-					"Failed to send HTTP(S) request to %q: %v",
-					"",
-					gomock.Any(),
-				)
+				m.EXPECT().Noticef(pp.EmojiError, "Failed to send HTTP(S) request to %q: %v", "", gomock.Any())
 			},
 		},
 		"6/request-fail": {
 			false,
 			ipnet.IP6, "", ipnet.IP6, invalidIP,
 			func(m *mocks.MockPP) {
-				m.EXPECT().Noticef(
-					pp.EmojiError,
-					"Failed to send HTTP(S) request to %q: %v",
-					"",
-					gomock.Any(),
-				)
+				m.EXPECT().Noticef(pp.EmojiError, "Failed to send HTTP(S) request to %q: %v", "", gomock.Any())
 			},
 		},
 		"4/not-handled": {

--- a/internal/provider/protocol/local_auto_test.go
+++ b/internal/provider/protocol/local_auto_test.go
@@ -51,18 +51,14 @@ func TestExtractUDPAddr(t *testing.T) {
 			&net.UDPAddr{IP: net.IP([]byte{0x01, 0x02}), Zone: "", Port: 123},
 			false, invalidIP,
 			func(ppfmt *mocks.MockPP) {
-				ppfmt.EXPECT().Noticef(pp.EmojiImpossible,
-					"Failed to parse UDP source address %q",
-					"?0102")
+				ppfmt.EXPECT().Noticef(pp.EmojiImpossible, "Failed to parse UDP source address %q", "?0102")
 			},
 		},
 		"dummy": {
 			&Dummy{},
 			false, invalidIP,
 			func(ppfmt *mocks.MockPP) {
-				ppfmt.EXPECT().Noticef(pp.EmojiImpossible,
-					"Unexpected UDP source address data %q of type %T",
-					"dummy/string", &Dummy{})
+				ppfmt.EXPECT().Noticef(pp.EmojiImpossible, "Unexpected UDP source address data %q of type %T", "dummy/string", &Dummy{})
 			},
 		},
 	} {
@@ -98,16 +94,14 @@ func TestLocalAuteGetIP(t *testing.T) {
 			"127.0.0.1:80", ipnet.IP4,
 			false, invalidIP,
 			func(m *mocks.MockPP) {
-				m.EXPECT().Noticef(pp.EmojiError,
-					"Detected %s address %s is a loopback address", "IPv4", "127.0.0.1")
+				m.EXPECT().Noticef(pp.EmojiError, "Detected %s address %s is a loopback address", "IPv4", "127.0.0.1")
 			},
 		},
 		"loopback/6": {
 			"[::1]:80", ipnet.IP6,
 			false, invalidIP,
 			func(m *mocks.MockPP) {
-				m.EXPECT().Noticef(pp.EmojiError,
-					"Detected %s address %s is a loopback address", "IPv6", "::1")
+				m.EXPECT().Noticef(pp.EmojiError, "Detected %s address %s is a loopback address", "IPv6", "::1")
 			},
 		},
 		"empty/4": {

--- a/internal/provider/protocol/local_iface_test.go
+++ b/internal/provider/protocol/local_iface_test.go
@@ -1,3 +1,4 @@
+// vim: nowrap
 //go:build linux
 
 package protocol_test
@@ -58,9 +59,7 @@ func TestExtractInterfaceAddr(t *testing.T) {
 			&net.IPAddr{IP: net.IP([]byte{0x01, 0x02}), Zone: ""},
 			false, invalidIP,
 			func(ppfmt *mocks.MockPP) {
-				ppfmt.EXPECT().Noticef(pp.EmojiImpossible,
-					"Failed to parse address %q assigned to interface %s",
-					"?0102", "iface")
+				ppfmt.EXPECT().Noticef(pp.EmojiImpossible, "Failed to parse address %q assigned to interface %s", "?0102", "iface")
 			},
 		},
 		"ipnet/4": {
@@ -72,18 +71,14 @@ func TestExtractInterfaceAddr(t *testing.T) {
 			&net.IPNet{IP: net.IP([]byte{0x01, 0x02}), Mask: net.CIDRMask(10, 22)},
 			false, invalidIP,
 			func(ppfmt *mocks.MockPP) {
-				ppfmt.EXPECT().Noticef(pp.EmojiImpossible,
-					"Failed to parse address %q assigned to interface %s",
-					"?0102", "iface")
+				ppfmt.EXPECT().Noticef(pp.EmojiImpossible, "Failed to parse address %q assigned to interface %s", "?0102", "iface")
 			},
 		},
 		"dummy": {
 			&Dummy{},
 			false, invalidIP,
 			func(ppfmt *mocks.MockPP) {
-				ppfmt.EXPECT().Noticef(pp.EmojiImpossible,
-					"Unexpected address data %q of type %T found in interface %s",
-					"dummy/string", &Dummy{}, "iface")
+				ppfmt.EXPECT().Noticef(pp.EmojiImpossible, "Unexpected address data %q of type %T found in interface %s", "dummy/string", &Dummy{}, "iface")
 			},
 		},
 	} {
@@ -132,10 +127,7 @@ func TestSelectInterfaceIP(t *testing.T) {
 			[]net.Addr{&net.IPAddr{IP: net.ParseIP("1::1"), Zone: ""}, &net.IPAddr{IP: net.ParseIP("2::2"), Zone: ""}},
 			false, protocol.MethodUnspecified, invalidIP,
 			func(ppfmt *mocks.MockPP) {
-				ppfmt.EXPECT().Noticef(pp.EmojiError,
-					"Failed to find any global unicast %s address assigned to interface %s",
-					"IPv4", "iface",
-				)
+				ppfmt.EXPECT().Noticef(pp.EmojiError, "Failed to find any global unicast %s address assigned to interface %s", "IPv4", "iface")
 			},
 		},
 		"ipaddr/4/loopback": {
@@ -143,10 +135,7 @@ func TestSelectInterfaceIP(t *testing.T) {
 			[]net.Addr{&net.IPAddr{IP: net.ParseIP("127.0.0.1"), Zone: ""}},
 			false, protocol.MethodUnspecified, invalidIP,
 			func(ppfmt *mocks.MockPP) {
-				ppfmt.EXPECT().Noticef(pp.EmojiError,
-					"Failed to find any global unicast %s address assigned to interface %s",
-					"IPv4", "iface",
-				)
+				ppfmt.EXPECT().Noticef(pp.EmojiError, "Failed to find any global unicast %s address assigned to interface %s", "IPv4", "iface")
 			},
 		},
 		"ipaddr/6/ff05::2": {
@@ -154,11 +143,7 @@ func TestSelectInterfaceIP(t *testing.T) {
 			[]net.Addr{&net.IPAddr{IP: net.ParseIP("ff05::2"), Zone: "site"}},
 			true, protocol.MethodPrimary, netip.MustParseAddr("ff05::2%site"),
 			func(ppfmt *mocks.MockPP) {
-				ppfmt.EXPECT().Noticef(pp.EmojiWarning,
-					"Failed to find any global unicast %s address assigned to interface %s, "+
-						"but found an address %s with a scope larger than the link-local scope",
-					"IPv6", "iface", "ff05::2%site",
-				)
+				ppfmt.EXPECT().Noticef(pp.EmojiWarning, "Failed to find any global unicast %s address assigned to interface %s, but found an address %s with a scope larger than the link-local scope", "IPv6", "iface", "ff05::2%site")
 			},
 		},
 		"ipaddr/4/dummy": {
@@ -166,9 +151,7 @@ func TestSelectInterfaceIP(t *testing.T) {
 			[]net.Addr{&Dummy{}},
 			false, protocol.MethodUnspecified, invalidIP,
 			func(ppfmt *mocks.MockPP) {
-				ppfmt.EXPECT().Noticef(pp.EmojiImpossible,
-					"Unexpected address data %q of type %T found in interface %s",
-					"dummy/string", &Dummy{}, "iface")
+				ppfmt.EXPECT().Noticef(pp.EmojiImpossible, "Unexpected address data %q of type %T found in interface %s", "dummy/string", &Dummy{}, "iface")
 			},
 		},
 	} {
@@ -203,28 +186,21 @@ func TestLocalWithInterfaceGetIP(t *testing.T) {
 			"lo", ipnet.IP4, false,
 			netip.Addr{},
 			func(ppfmt *mocks.MockPP) {
-				ppfmt.EXPECT().Noticef(pp.EmojiError,
-					"Failed to find any global unicast %s address assigned to interface %s",
-					"IPv4", "lo")
+				ppfmt.EXPECT().Noticef(pp.EmojiError, "Failed to find any global unicast %s address assigned to interface %s", "IPv4", "lo")
 			},
 		},
 		"lo/6": {
 			"lo", ipnet.IP6, false,
 			netip.Addr{},
 			func(ppfmt *mocks.MockPP) {
-				ppfmt.EXPECT().Noticef(pp.EmojiError,
-					"Failed to find any global unicast %s address assigned to interface %s",
-					"IPv6", "lo")
+				ppfmt.EXPECT().Noticef(pp.EmojiError, "Failed to find any global unicast %s address assigned to interface %s", "IPv6", "lo")
 			},
 		},
 		"non-existent": {
 			"non-existent-iface", ipnet.IP4, false,
 			netip.Addr{},
 			func(ppfmt *mocks.MockPP) {
-				ppfmt.EXPECT().Noticef(pp.EmojiUserError,
-					"Failed to find an interface named %q: %v",
-					"non-existent-iface", gomock.Any(),
-				)
+				ppfmt.EXPECT().Noticef(pp.EmojiUserError, "Failed to find an interface named %q: %v", "non-existent-iface", gomock.Any())
 			},
 		},
 	} {

--- a/internal/provider/protocol/regexp_test.go
+++ b/internal/provider/protocol/regexp_test.go
@@ -1,3 +1,4 @@
+// vim: nowrap
 package protocol_test
 
 import (
@@ -84,43 +85,25 @@ func TestRegexpGetIP(t *testing.T) {
 		"4/illformed": {
 			ipnet.IP4, illformed4.URL, regexp.MustCompile(`<<(.*)>>`), ipnet.IP4, invalidIP,
 			func(m *mocks.MockPP) {
-				m.EXPECT().Noticef(
-					pp.EmojiError,
-					`Failed to parse the IP address in the response of %q: %s`,
-					illformed4.URL,
-					"hello")
+				m.EXPECT().Noticef(pp.EmojiError, `Failed to parse the IP address in the response of %q: %s`, illformed4.URL, "hello")
 			},
 		},
 		"6/illformed": {
 			ipnet.IP6, illformed6.URL, regexp.MustCompile(`<<(.*)>>`), ipnet.IP6, invalidIP,
 			func(m *mocks.MockPP) {
-				m.EXPECT().Noticef(
-					pp.EmojiError,
-					`Failed to parse the IP address in the response of %q: %s`,
-					illformed6.URL,
-					"hello")
+				m.EXPECT().Noticef(pp.EmojiError, `Failed to parse the IP address in the response of %q: %s`, illformed6.URL, "hello")
 			},
 		},
 		"4/request-fail": {
 			ipnet.IP4, "", regexp.MustCompile(``), ipnet.IP4, invalidIP,
 			func(m *mocks.MockPP) {
-				m.EXPECT().Noticef(
-					pp.EmojiError,
-					"Failed to send HTTP(S) request to %q: %v",
-					"",
-					gomock.Any(),
-				)
+				m.EXPECT().Noticef(pp.EmojiError, "Failed to send HTTP(S) request to %q: %v", "", gomock.Any())
 			},
 		},
 		"6/request-fail": {
 			ipnet.IP6, "", regexp.MustCompile(``), ipnet.IP6, invalidIP,
 			func(m *mocks.MockPP) {
-				m.EXPECT().Noticef(
-					pp.EmojiError,
-					"Failed to send HTTP(S) request to %q: %v",
-					"",
-					gomock.Any(),
-				)
+				m.EXPECT().Noticef(pp.EmojiError, "Failed to send HTTP(S) request to %q: %v", "", gomock.Any())
 			},
 		},
 		"4/not-handled": {
@@ -138,19 +121,13 @@ func TestRegexpGetIP(t *testing.T) {
 		"4/no-match": {
 			ipnet.IP4, illformed4.URL, regexp.MustCompile(`some random string`), ipnet.IP4, invalidIP,
 			func(m *mocks.MockPP) {
-				m.EXPECT().Noticef(pp.EmojiError,
-					`Failed to find the IP address in the response of %q: %s`,
-					illformed4.URL,
-					[]byte("<<hello>>"))
+				m.EXPECT().Noticef(pp.EmojiError, `Failed to find the IP address in the response of %q: %s`, illformed4.URL, []byte("<<hello>>"))
 			},
 		},
 		"6/no-match": {
 			ipnet.IP6, illformed6.URL, regexp.MustCompile(`some random string`), ipnet.IP6, invalidIP,
 			func(m *mocks.MockPP) {
-				m.EXPECT().Noticef(pp.EmojiError,
-					`Failed to find the IP address in the response of %q: %s`,
-					illformed6.URL,
-					[]byte("<<hello>>"))
+				m.EXPECT().Noticef(pp.EmojiError, `Failed to find the IP address in the response of %q: %s`, illformed6.URL, []byte("<<hello>>"))
 			},
 		},
 	} {

--- a/internal/setter/setter_test.go
+++ b/internal/setter/setter_test.go
@@ -1,3 +1,4 @@
+// vim: nowrap
 package setter_test
 
 import (
@@ -16,8 +17,7 @@ import (
 	"github.com/favonia/cloudflare-ddns/internal/setter"
 )
 
-func wrapCancelAsDelete(cancel func(),
-) func(context.Context, pp.PP, ipnet.Type, domain.Domain, api.ID, api.DeletionMode) bool {
+func wrapCancelAsDelete(cancel func()) func(context.Context, pp.PP, ipnet.Type, domain.Domain, api.ID, api.DeletionMode) bool {
 	return func(context.Context, pp.PP, ipnet.Type, domain.Domain, api.ID, api.DeletionMode) bool {
 		cancel()
 		return false
@@ -62,7 +62,7 @@ func TestSet(t *testing.T) {
 				gomock.InOrder(
 					h.EXPECT().ListRecords(ctx, p, ipNetwork, domain).Return([]api.Record{}, true, true),
 					h.EXPECT().CreateRecord(ctx, p, ipNetwork, domain, ip1, api.TTLAuto, false, "hello").Return(record1, false),
-					p.EXPECT().Noticef(pp.EmojiError, "Failed to properly update %s records of %s; records might be inconsistent", "AAAA", "sub.test.org"), //nolint:lll
+					p.EXPECT().Noticef(pp.EmojiError, "Failed to properly update %s records of %s; records might be inconsistent", "AAAA", "sub.test.org"),
 				)
 			},
 		},
@@ -73,12 +73,7 @@ func TestSet(t *testing.T) {
 				gomock.InOrder(
 					h.EXPECT().ListRecords(ctx, p, ipNetwork, domain).Return([]api.Record{{ID: record1, IP: ip2}}, true, true),
 					h.EXPECT().UpdateRecord(ctx, p, ipNetwork, domain, record1, ip1, api.TTLAuto, false, "hello").Return(true),
-					p.EXPECT().Noticef(pp.EmojiUpdate,
-						"Updated a stale %s record of %s (ID: %s)",
-						"AAAA",
-						"sub.test.org",
-						record1,
-					),
+					p.EXPECT().Noticef(pp.EmojiUpdate, "Updated a stale %s record of %s (ID: %s)", "AAAA", "sub.test.org", record1),
 				)
 			},
 		},
@@ -89,7 +84,7 @@ func TestSet(t *testing.T) {
 				gomock.InOrder(
 					h.EXPECT().ListRecords(ctx, p, ipNetwork, domain).Return([]api.Record{{ID: record1, IP: ip2}}, true, true),
 					h.EXPECT().UpdateRecord(ctx, p, ipNetwork, domain, record1, ip1, api.TTLAuto, false, "hello").Return(false),
-					p.EXPECT().Noticef(pp.EmojiError, "Failed to properly update %s records of %s; records might be inconsistent", "AAAA", "sub.test.org"), //nolint:lll
+					p.EXPECT().Noticef(pp.EmojiError, "Failed to properly update %s records of %s; records might be inconsistent", "AAAA", "sub.test.org"),
 				)
 			},
 		},
@@ -119,24 +114,11 @@ func TestSet(t *testing.T) {
 			setter.ResponseUpdated,
 			func(ctx context.Context, _ func(), p *mocks.MockPP, h *mocks.MockHandle) {
 				gomock.InOrder(
-					h.EXPECT().ListRecords(ctx, p, ipNetwork, domain).
-						Return([]api.Record{{ID: record1, IP: ip1}, {ID: record2, IP: ip1}, {ID: record3, IP: ip1}}, true, true),
+					h.EXPECT().ListRecords(ctx, p, ipNetwork, domain).Return([]api.Record{{ID: record1, IP: ip1}, {ID: record2, IP: ip1}, {ID: record3, IP: ip1}}, true, true),
 					h.EXPECT().DeleteRecord(ctx, p, ipNetwork, domain, record2, api.RegularDelitionMode).Return(true),
-					p.EXPECT().Noticef(
-						pp.EmojiDeletion,
-						"Deleted a duplicate %s record of %s (ID: %s)",
-						"AAAA",
-						"sub.test.org",
-						record2,
-					),
+					p.EXPECT().Noticef(pp.EmojiDeletion, "Deleted a duplicate %s record of %s (ID: %s)", "AAAA", "sub.test.org", record2),
 					h.EXPECT().DeleteRecord(ctx, p, ipNetwork, domain, record3, api.RegularDelitionMode).Return(true),
-					p.EXPECT().Noticef(
-						pp.EmojiDeletion,
-						"Deleted a duplicate %s record of %s (ID: %s)",
-						"AAAA",
-						"sub.test.org",
-						record3,
-					),
+					p.EXPECT().Noticef(pp.EmojiDeletion, "Deleted a duplicate %s record of %s (ID: %s)", "AAAA", "sub.test.org", record3),
 				)
 			},
 		},
@@ -145,17 +127,10 @@ func TestSet(t *testing.T) {
 			setter.ResponseUpdated,
 			func(ctx context.Context, _ func(), p *mocks.MockPP, h *mocks.MockHandle) {
 				gomock.InOrder(
-					h.EXPECT().ListRecords(ctx, p, ipNetwork, domain).
-						Return([]api.Record{{ID: record1, IP: ip1}, {ID: record2, IP: ip1}, {ID: record3, IP: ip1}}, true, true),
+					h.EXPECT().ListRecords(ctx, p, ipNetwork, domain).Return([]api.Record{{ID: record1, IP: ip1}, {ID: record2, IP: ip1}, {ID: record3, IP: ip1}}, true, true),
 					h.EXPECT().DeleteRecord(ctx, p, ipNetwork, domain, record2, api.RegularDelitionMode).Return(false),
 					h.EXPECT().DeleteRecord(ctx, p, ipNetwork, domain, record3, api.RegularDelitionMode).Return(true),
-					p.EXPECT().Noticef(
-						pp.EmojiDeletion,
-						"Deleted a duplicate %s record of %s (ID: %s)",
-						"AAAA",
-						"sub.test.org",
-						record3,
-					),
+					p.EXPECT().Noticef(pp.EmojiDeletion, "Deleted a duplicate %s record of %s (ID: %s)", "AAAA", "sub.test.org", record3),
 				)
 			},
 		},
@@ -164,16 +139,9 @@ func TestSet(t *testing.T) {
 			setter.ResponseUpdated,
 			func(ctx context.Context, _ func(), p *mocks.MockPP, h *mocks.MockHandle) {
 				gomock.InOrder(
-					h.EXPECT().ListRecords(ctx, p, ipNetwork, domain).
-						Return([]api.Record{{ID: record1, IP: ip1}, {ID: record2, IP: ip1}, {ID: record3, IP: ip1}}, true, true),
+					h.EXPECT().ListRecords(ctx, p, ipNetwork, domain).Return([]api.Record{{ID: record1, IP: ip1}, {ID: record2, IP: ip1}, {ID: record3, IP: ip1}}, true, true),
 					h.EXPECT().DeleteRecord(ctx, p, ipNetwork, domain, record2, api.RegularDelitionMode).Return(true),
-					p.EXPECT().Noticef(
-						pp.EmojiDeletion,
-						"Deleted a duplicate %s record of %s (ID: %s)",
-						"AAAA",
-						"sub.test.org",
-						record2,
-					),
+					p.EXPECT().Noticef(pp.EmojiDeletion, "Deleted a duplicate %s record of %s (ID: %s)", "AAAA", "sub.test.org", record2),
 					h.EXPECT().DeleteRecord(ctx, p, ipNetwork, domain, record3, api.RegularDelitionMode).Return(false),
 				)
 			},
@@ -183,10 +151,8 @@ func TestSet(t *testing.T) {
 			setter.ResponseUpdated,
 			func(ctx context.Context, cancel func(), p *mocks.MockPP, h *mocks.MockHandle) {
 				gomock.InOrder(
-					h.EXPECT().ListRecords(ctx, p, ipNetwork, domain).
-						Return([]api.Record{{ID: record1, IP: ip1}, {ID: record2, IP: ip1}}, true, true),
-					h.EXPECT().DeleteRecord(ctx, p, ipNetwork, domain, record2, api.RegularDelitionMode).
-						Do(wrapCancelAsDelete(cancel)).Return(false),
+					h.EXPECT().ListRecords(ctx, p, ipNetwork, domain).Return([]api.Record{{ID: record1, IP: ip1}, {ID: record2, IP: ip1}}, true, true),
+					h.EXPECT().DeleteRecord(ctx, p, ipNetwork, domain, record2, api.RegularDelitionMode).Do(wrapCancelAsDelete(cancel)).Return(false),
 				)
 			},
 		},
@@ -195,22 +161,11 @@ func TestSet(t *testing.T) {
 			setter.ResponseUpdated,
 			func(ctx context.Context, _ func(), p *mocks.MockPP, h *mocks.MockHandle) {
 				gomock.InOrder(
-					h.EXPECT().ListRecords(ctx, p, ipNetwork, domain).
-						Return([]api.Record{{ID: record1, IP: ip2}, {ID: record2, IP: ip2}}, true, true),
+					h.EXPECT().ListRecords(ctx, p, ipNetwork, domain).Return([]api.Record{{ID: record1, IP: ip2}, {ID: record2, IP: ip2}}, true, true),
 					h.EXPECT().UpdateRecord(ctx, p, ipNetwork, domain, record1, ip1, api.TTLAuto, false, "hello").Return(true),
-					p.EXPECT().Noticef(
-						pp.EmojiUpdate,
-						"Updated a stale %s record of %s (ID: %s)",
-						"AAAA",
-						"sub.test.org",
-						record1,
-					),
+					p.EXPECT().Noticef(pp.EmojiUpdate, "Updated a stale %s record of %s (ID: %s)", "AAAA", "sub.test.org", record1),
 					h.EXPECT().DeleteRecord(ctx, p, ipNetwork, domain, record2, api.RegularDelitionMode).Return(true),
-					p.EXPECT().Noticef(pp.EmojiDeletion,
-						"Deleted a stale %s record of %s (ID: %s)",
-						"AAAA",
-						"sub.test.org",
-						record2),
+					p.EXPECT().Noticef(pp.EmojiDeletion, "Deleted a stale %s record of %s (ID: %s)", "AAAA", "sub.test.org", record2),
 				)
 			},
 		},
@@ -219,19 +174,11 @@ func TestSet(t *testing.T) {
 			setter.ResponseFailed,
 			func(ctx context.Context, cancel func(), p *mocks.MockPP, h *mocks.MockHandle) {
 				gomock.InOrder(
-					h.EXPECT().ListRecords(ctx, p, ipNetwork, domain).
-						Return([]api.Record{{ID: record1, IP: ip2}, {ID: record2, IP: ip2}}, true, true),
+					h.EXPECT().ListRecords(ctx, p, ipNetwork, domain).Return([]api.Record{{ID: record1, IP: ip2}, {ID: record2, IP: ip2}}, true, true),
 					h.EXPECT().UpdateRecord(ctx, p, ipNetwork, domain, record1, ip1, api.TTLAuto, false, "hello").Return(true),
-					p.EXPECT().Noticef(
-						pp.EmojiUpdate,
-						"Updated a stale %s record of %s (ID: %s)",
-						"AAAA",
-						"sub.test.org",
-						record1,
-					),
-					h.EXPECT().DeleteRecord(ctx, p, ipNetwork, domain, record2, api.RegularDelitionMode).
-						Do(wrapCancelAsDelete(cancel)).Return(false),
-					p.EXPECT().Noticef(pp.EmojiError, "Failed to properly update %s records of %s; records might be inconsistent", "AAAA", "sub.test.org"), //nolint:lll
+					p.EXPECT().Noticef(pp.EmojiUpdate, "Updated a stale %s record of %s (ID: %s)", "AAAA", "sub.test.org", record1),
+					h.EXPECT().DeleteRecord(ctx, p, ipNetwork, domain, record2, api.RegularDelitionMode).Do(wrapCancelAsDelete(cancel)).Return(false),
+					p.EXPECT().Noticef(pp.EmojiError, "Failed to properly update %s records of %s; records might be inconsistent", "AAAA", "sub.test.org"),
 				)
 			},
 		},
@@ -240,10 +187,9 @@ func TestSet(t *testing.T) {
 			setter.ResponseFailed,
 			func(ctx context.Context, _ func(), p *mocks.MockPP, h *mocks.MockHandle) {
 				gomock.InOrder(
-					h.EXPECT().ListRecords(ctx, p, ipNetwork, domain).
-						Return([]api.Record{{ID: record1, IP: ip2}, {ID: record2, IP: ip2}}, true, true),
+					h.EXPECT().ListRecords(ctx, p, ipNetwork, domain).Return([]api.Record{{ID: record1, IP: ip2}, {ID: record2, IP: ip2}}, true, true),
 					h.EXPECT().UpdateRecord(ctx, p, ipNetwork, domain, record1, ip1, api.TTLAuto, false, "hello").Return(false),
-					p.EXPECT().Noticef(pp.EmojiError, "Failed to properly update %s records of %s; records might be inconsistent", "AAAA", "sub.test.org"), //nolint:lll
+					p.EXPECT().Noticef(pp.EmojiError, "Failed to properly update %s records of %s; records might be inconsistent", "AAAA", "sub.test.org"),
 				)
 			},
 		},
@@ -301,7 +247,7 @@ func TestFinalDelete(t *testing.T) {
 			func(ctx context.Context, _ func(), p *mocks.MockPP, h *mocks.MockHandle) {
 				gomock.InOrder(
 					h.EXPECT().ListRecords(ctx, p, ipNetwork, domain).Return([]api.Record{}, true, true),
-					p.EXPECT().Infof(pp.EmojiAlreadyDone, "The %s records of %s were already deleted (cached)", "AAAA", "sub.test.org"), //nolint:lll
+					p.EXPECT().Infof(pp.EmojiAlreadyDone, "The %s records of %s were already deleted (cached)", "AAAA", "sub.test.org"),
 				)
 			},
 		},
@@ -320,7 +266,7 @@ func TestFinalDelete(t *testing.T) {
 				gomock.InOrder(
 					h.EXPECT().ListRecords(ctx, p, ipNetwork, domain).Return([]api.Record{{ID: record1, IP: ip1}}, true, true),
 					h.EXPECT().DeleteRecord(ctx, p, ipNetwork, domain, record1, api.FinalDeletionMode).Return(true),
-					p.EXPECT().Noticef(pp.EmojiDeletion, "Deleted a stale %s record of %s (ID: %s)", "AAAA", "sub.test.org", record1), //nolint:lll
+					p.EXPECT().Noticef(pp.EmojiDeletion, "Deleted a stale %s record of %s (ID: %s)", "AAAA", "sub.test.org", record1),
 				)
 			},
 		},
@@ -330,7 +276,7 @@ func TestFinalDelete(t *testing.T) {
 				gomock.InOrder(
 					h.EXPECT().ListRecords(ctx, p, ipNetwork, domain).Return([]api.Record{{ID: record1, IP: ip1}}, true, true),
 					h.EXPECT().DeleteRecord(ctx, p, ipNetwork, domain, record1, api.FinalDeletionMode).Return(false),
-					p.EXPECT().Noticef(pp.EmojiError, "Failed to properly delete %s records of %s; records might be inconsistent", "AAAA", "sub.test.org"), //nolint:lll
+					p.EXPECT().Noticef(pp.EmojiError, "Failed to properly delete %s records of %s; records might be inconsistent", "AAAA", "sub.test.org"),
 				)
 			},
 		},
@@ -338,13 +284,9 @@ func TestFinalDelete(t *testing.T) {
 			setter.ResponseFailed,
 			func(ctx context.Context, cancel func(), p *mocks.MockPP, h *mocks.MockHandle) {
 				gomock.InOrder(
-					h.EXPECT().ListRecords(ctx, p, ipNetwork, domain).
-						Return([]api.Record{{ID: record1, IP: ip1}}, true, true),
-					h.EXPECT().DeleteRecord(ctx, p, ipNetwork, domain, record1, api.FinalDeletionMode).
-						Do(wrapCancelAsDelete(cancel)).Return(false),
-					p.EXPECT().Infof(pp.EmojiTimeout,
-						"Deletion of %s records of %s aborted by timeout or signals; records might be inconsistent",
-						"AAAA", "sub.test.org"),
+					h.EXPECT().ListRecords(ctx, p, ipNetwork, domain).Return([]api.Record{{ID: record1, IP: ip1}}, true, true),
+					h.EXPECT().DeleteRecord(ctx, p, ipNetwork, domain, record1, api.FinalDeletionMode).Do(wrapCancelAsDelete(cancel)).Return(false),
+					p.EXPECT().Infof(pp.EmojiTimeout, "Deletion of %s records of %s aborted by timeout or signals; records might be inconsistent", "AAAA", "sub.test.org"),
 				)
 			},
 		},
@@ -352,11 +294,11 @@ func TestFinalDelete(t *testing.T) {
 			setter.ResponseUpdated,
 			func(ctx context.Context, _ func(), p *mocks.MockPP, h *mocks.MockHandle) {
 				gomock.InOrder(
-					h.EXPECT().ListRecords(ctx, p, ipNetwork, domain).Return([]api.Record{{ID: record1, IP: ip1}, {ID: record2, IP: invalidIP}}, true, true), //nolint:lll
+					h.EXPECT().ListRecords(ctx, p, ipNetwork, domain).Return([]api.Record{{ID: record1, IP: ip1}, {ID: record2, IP: invalidIP}}, true, true),
 					h.EXPECT().DeleteRecord(ctx, p, ipNetwork, domain, record1, api.FinalDeletionMode).Return(true),
-					p.EXPECT().Noticef(pp.EmojiDeletion, "Deleted a stale %s record of %s (ID: %s)", "AAAA", "sub.test.org", record1), //nolint:lll
+					p.EXPECT().Noticef(pp.EmojiDeletion, "Deleted a stale %s record of %s (ID: %s)", "AAAA", "sub.test.org", record1),
 					h.EXPECT().DeleteRecord(ctx, p, ipNetwork, domain, record2, api.FinalDeletionMode).Return(true),
-					p.EXPECT().Noticef(pp.EmojiDeletion, "Deleted a stale %s record of %s (ID: %s)", "AAAA", "sub.test.org", record2), //nolint:lll
+					p.EXPECT().Noticef(pp.EmojiDeletion, "Deleted a stale %s record of %s (ID: %s)", "AAAA", "sub.test.org", record2),
 				)
 			},
 		},
@@ -431,12 +373,9 @@ func TestSetWAFList(t *testing.T) {
 				gomock.InOrder(
 					m.EXPECT().ListWAFListItems(ctx, p, wafList, listDescription).Return(items{}, false, false, true),
 					p.EXPECT().Noticef(pp.EmojiCreation, "Created a new list %s", wafListDescribed),
-					m.EXPECT().CreateWAFListItems(ctx, p, wafList, listDescription,
-						[]netip.Prefix{prefix4.Prefix, prefix6.Prefix}, "").Return(true),
-					p.EXPECT().Noticef(pp.EmojiCreation,
-						"Added %s to the list %s", "10.0.0.1", wafListDescribed),
-					p.EXPECT().Noticef(pp.EmojiCreation,
-						"Added %s to the list %s", "2001:db8::/64", wafListDescribed),
+					m.EXPECT().CreateWAFListItems(ctx, p, wafList, listDescription, []netip.Prefix{prefix4.Prefix, prefix6.Prefix}, "").Return(true),
+					p.EXPECT().Noticef(pp.EmojiCreation, "Added %s to the list %s", "10.0.0.1", wafListDescribed),
+					p.EXPECT().Noticef(pp.EmojiCreation, "Added %s to the list %s", "2001:db8::/64", wafListDescribed),
 					m.EXPECT().DeleteWAFListItems(ctx, p, wafList, listDescription, []api.ID{}).Return(true),
 				)
 			},
@@ -453,15 +392,13 @@ func TestSetWAFList(t *testing.T) {
 			setter.ResponseNoop,
 			func(ctx context.Context, _ func(), p *mocks.MockPP, m *mocks.MockHandle) {
 				gomock.InOrder(
-					m.EXPECT().ListWAFListItems(ctx, p, wafList, listDescription).
-						Return(items{
-							prefix4wrong2,
-							prefix6range1,
-							prefix4wrong1,
-							prefix4wrong3,
-						}, true, true, true),
-					p.EXPECT().Infof(pp.EmojiAlreadyDone,
-						"The list %s is already up to date (cached)", wafListDescribed),
+					m.EXPECT().ListWAFListItems(ctx, p, wafList, listDescription).Return(items{
+						prefix4wrong2,
+						prefix6range1,
+						prefix4wrong1,
+						prefix4wrong3,
+					}, true, true, true),
+					p.EXPECT().Infof(pp.EmojiAlreadyDone, "The list %s is already up to date (cached)", wafListDescribed),
 				)
 			},
 		},
@@ -470,10 +407,8 @@ func TestSetWAFList(t *testing.T) {
 			setter.ResponseNoop,
 			func(ctx context.Context, _ func(), p *mocks.MockPP, m *mocks.MockHandle) {
 				gomock.InOrder(
-					m.EXPECT().ListWAFListItems(ctx, p, wafList, listDescription).
-						Return(items{prefix4, prefix6}, true, false, true),
-					p.EXPECT().Infof(pp.EmojiAlreadyDone,
-						"The list %s is already up to date", wafListDescribed),
+					m.EXPECT().ListWAFListItems(ctx, p, wafList, listDescription).Return(items{prefix4, prefix6}, true, false, true),
+					p.EXPECT().Infof(pp.EmojiAlreadyDone, "The list %s is already up to date", wafListDescribed),
 				)
 			},
 		},
@@ -482,10 +417,8 @@ func TestSetWAFList(t *testing.T) {
 			setter.ResponseNoop,
 			func(ctx context.Context, _ func(), p *mocks.MockPP, m *mocks.MockHandle) {
 				gomock.InOrder(
-					m.EXPECT().ListWAFListItems(ctx, p, wafList, listDescription).
-						Return(items{prefix4, prefix6}, true, true, true),
-					p.EXPECT().Infof(pp.EmojiAlreadyDone,
-						"The list %s is already up to date (cached)", wafListDescribed),
+					m.EXPECT().ListWAFListItems(ctx, p, wafList, listDescription).Return(items{prefix4, prefix6}, true, true, true),
+					p.EXPECT().Infof(pp.EmojiAlreadyDone, "The list %s is already up to date (cached)", wafListDescribed),
 				)
 			},
 		},
@@ -494,43 +427,35 @@ func TestSetWAFList(t *testing.T) {
 			setter.ResponseUpdated,
 			func(ctx context.Context, _ func(), p *mocks.MockPP, m *mocks.MockHandle) {
 				gomock.InOrder(
-					m.EXPECT().ListWAFListItems(ctx, p, wafList, listDescription).
-						Return(items{
-							prefix6range1,
-							prefix4wrong2,
-							prefix6range2,
-							prefix6range3,
-							prefix4range2,
-							prefix4range3,
-							prefix6wrong2,
-							prefix6wrong3,
-							prefix4wrong3,
-							prefix4range1,
-							prefix4wrong1,
-							prefix6wrong1,
-						}, true, false, true),
+					m.EXPECT().ListWAFListItems(ctx, p, wafList, listDescription).Return(items{
+						prefix6range1,
+						prefix4wrong2,
+						prefix6range2,
+						prefix6range3,
+						prefix4range2,
+						prefix4range3,
+						prefix6wrong2,
+						prefix6wrong3,
+						prefix4wrong3,
+						prefix4range1,
+						prefix4wrong1,
+						prefix6wrong1,
+					}, true, false, true),
 					m.EXPECT().CreateWAFListItems(ctx, p, wafList, listDescription, nil, "").Return(true),
-					m.EXPECT().DeleteWAFListItems(ctx, p, wafList, listDescription,
-						gomock.InAnyOrder([]api.ID{
-							prefix4wrong2.ID,
-							prefix6wrong2.ID,
-							prefix6wrong3.ID,
-							prefix4wrong3.ID,
-							prefix4wrong1.ID,
-							prefix6wrong1.ID,
-						})).Return(true),
-					p.EXPECT().Noticef(pp.EmojiDeletion,
-						"Deleted %s from the list %s", "20.0.0.0/20", wafListDescribed),
-					p.EXPECT().Noticef(pp.EmojiDeletion,
-						"Deleted %s from the list %s", "20.0.0.0/24", wafListDescribed),
-					p.EXPECT().Noticef(pp.EmojiDeletion,
-						"Deleted %s from the list %s", "20.0.0.0/16", wafListDescribed),
-					p.EXPECT().Noticef(pp.EmojiDeletion,
-						"Deleted %s from the list %s", "4001:db8::/40", wafListDescribed),
-					p.EXPECT().Noticef(pp.EmojiDeletion,
-						"Deleted %s from the list %s", "4001:db8::/48", wafListDescribed),
-					p.EXPECT().Noticef(pp.EmojiDeletion,
-						"Deleted %s from the list %s", "4001:db8::/32", wafListDescribed),
+					m.EXPECT().DeleteWAFListItems(ctx, p, wafList, listDescription, gomock.InAnyOrder([]api.ID{
+						prefix4wrong2.ID,
+						prefix6wrong2.ID,
+						prefix6wrong3.ID,
+						prefix4wrong3.ID,
+						prefix4wrong1.ID,
+						prefix6wrong1.ID,
+					})).Return(true),
+					p.EXPECT().Noticef(pp.EmojiDeletion, "Deleted %s from the list %s", "20.0.0.0/20", wafListDescribed),
+					p.EXPECT().Noticef(pp.EmojiDeletion, "Deleted %s from the list %s", "20.0.0.0/24", wafListDescribed),
+					p.EXPECT().Noticef(pp.EmojiDeletion, "Deleted %s from the list %s", "20.0.0.0/16", wafListDescribed),
+					p.EXPECT().Noticef(pp.EmojiDeletion, "Deleted %s from the list %s", "4001:db8::/40", wafListDescribed),
+					p.EXPECT().Noticef(pp.EmojiDeletion, "Deleted %s from the list %s", "4001:db8::/48", wafListDescribed),
+					p.EXPECT().Noticef(pp.EmojiDeletion, "Deleted %s from the list %s", "4001:db8::/32", wafListDescribed),
 				)
 			},
 		},
@@ -539,42 +464,31 @@ func TestSetWAFList(t *testing.T) {
 			setter.ResponseUpdated,
 			func(ctx context.Context, _ func(), p *mocks.MockPP, m *mocks.MockHandle) {
 				gomock.InOrder(
-					m.EXPECT().ListWAFListItems(ctx, p, wafList, listDescription).
-						Return(items{
-							prefix4wrong2,
-							prefix6wrong2,
-							prefix6wrong3,
-							prefix4wrong3,
-							prefix4wrong1,
-							prefix6wrong1,
-						}, true, false, true),
-					m.EXPECT().CreateWAFListItems(ctx, p, wafList, listDescription,
-						[]netip.Prefix{prefix4.Prefix, prefix6.Prefix}, "").Return(true),
-					p.EXPECT().Noticef(pp.EmojiCreation,
-						"Added %s to the list %s", "10.0.0.1", wafListDescribed),
-					p.EXPECT().Noticef(pp.EmojiCreation,
-						"Added %s to the list %s", "2001:db8::/64", wafListDescribed),
-					m.EXPECT().DeleteWAFListItems(ctx, p, wafList, listDescription,
-						gomock.InAnyOrder([]api.ID{
-							prefix4wrong2.ID,
-							prefix6wrong2.ID,
-							prefix6wrong3.ID,
-							prefix4wrong3.ID,
-							prefix4wrong1.ID,
-							prefix6wrong1.ID,
-						})).Return(true),
-					p.EXPECT().Noticef(pp.EmojiDeletion,
-						"Deleted %s from the list %s", "20.0.0.0/20", wafListDescribed),
-					p.EXPECT().Noticef(pp.EmojiDeletion,
-						"Deleted %s from the list %s", "20.0.0.0/24", wafListDescribed),
-					p.EXPECT().Noticef(pp.EmojiDeletion,
-						"Deleted %s from the list %s", "20.0.0.0/16", wafListDescribed),
-					p.EXPECT().Noticef(pp.EmojiDeletion,
-						"Deleted %s from the list %s", "4001:db8::/40", wafListDescribed),
-					p.EXPECT().Noticef(pp.EmojiDeletion,
-						"Deleted %s from the list %s", "4001:db8::/48", wafListDescribed),
-					p.EXPECT().Noticef(pp.EmojiDeletion,
-						"Deleted %s from the list %s", "4001:db8::/32", wafListDescribed),
+					m.EXPECT().ListWAFListItems(ctx, p, wafList, listDescription).Return(items{
+						prefix4wrong2,
+						prefix6wrong2,
+						prefix6wrong3,
+						prefix4wrong3,
+						prefix4wrong1,
+						prefix6wrong1,
+					}, true, false, true),
+					m.EXPECT().CreateWAFListItems(ctx, p, wafList, listDescription, []netip.Prefix{prefix4.Prefix, prefix6.Prefix}, "").Return(true),
+					p.EXPECT().Noticef(pp.EmojiCreation, "Added %s to the list %s", "10.0.0.1", wafListDescribed),
+					p.EXPECT().Noticef(pp.EmojiCreation, "Added %s to the list %s", "2001:db8::/64", wafListDescribed),
+					m.EXPECT().DeleteWAFListItems(ctx, p, wafList, listDescription, gomock.InAnyOrder([]api.ID{
+						prefix4wrong2.ID,
+						prefix6wrong2.ID,
+						prefix6wrong3.ID,
+						prefix4wrong3.ID,
+						prefix4wrong1.ID,
+						prefix6wrong1.ID,
+					})).Return(true),
+					p.EXPECT().Noticef(pp.EmojiDeletion, "Deleted %s from the list %s", "20.0.0.0/20", wafListDescribed),
+					p.EXPECT().Noticef(pp.EmojiDeletion, "Deleted %s from the list %s", "20.0.0.0/24", wafListDescribed),
+					p.EXPECT().Noticef(pp.EmojiDeletion, "Deleted %s from the list %s", "20.0.0.0/16", wafListDescribed),
+					p.EXPECT().Noticef(pp.EmojiDeletion, "Deleted %s from the list %s", "4001:db8::/40", wafListDescribed),
+					p.EXPECT().Noticef(pp.EmojiDeletion, "Deleted %s from the list %s", "4001:db8::/48", wafListDescribed),
+					p.EXPECT().Noticef(pp.EmojiDeletion, "Deleted %s from the list %s", "4001:db8::/32", wafListDescribed),
 				)
 			},
 		},
@@ -583,12 +497,9 @@ func TestSetWAFList(t *testing.T) {
 			setter.ResponseFailed,
 			func(ctx context.Context, _ func(), p *mocks.MockPP, m *mocks.MockHandle) {
 				gomock.InOrder(
-					m.EXPECT().ListWAFListItems(ctx, p, wafList, listDescription).
-						Return(items{}, true, false, true),
-					m.EXPECT().CreateWAFListItems(ctx, p, wafList, listDescription,
-						[]netip.Prefix{prefix4.Prefix, prefix6.Prefix}, "").Return(false),
-					p.EXPECT().Noticef(pp.EmojiError,
-						"Failed to properly update the list %s; its content may be inconsistent", wafListDescribed),
+					m.EXPECT().ListWAFListItems(ctx, p, wafList, listDescription).Return(items{}, true, false, true),
+					m.EXPECT().CreateWAFListItems(ctx, p, wafList, listDescription, []netip.Prefix{prefix4.Prefix, prefix6.Prefix}, "").Return(false),
+					p.EXPECT().Noticef(pp.EmojiError, "Failed to properly update the list %s; its content may be inconsistent", wafListDescribed),
 				)
 			},
 		},
@@ -597,33 +508,30 @@ func TestSetWAFList(t *testing.T) {
 			setter.ResponseFailed,
 			func(ctx context.Context, _ func(), p *mocks.MockPP, m *mocks.MockHandle) {
 				gomock.InOrder(
-					m.EXPECT().ListWAFListItems(ctx, p, wafList, listDescription).
-						Return(items{
-							prefix6range1,
-							prefix4wrong2,
-							prefix6range2,
-							prefix6range3,
-							prefix4range2,
-							prefix4range3,
-							prefix6wrong2,
-							prefix6wrong3,
-							prefix4wrong3,
-							prefix4range1,
-							prefix4wrong1,
-							prefix6wrong1,
-						}, true, false, true),
+					m.EXPECT().ListWAFListItems(ctx, p, wafList, listDescription).Return(items{
+						prefix6range1,
+						prefix4wrong2,
+						prefix6range2,
+						prefix6range3,
+						prefix4range2,
+						prefix4range3,
+						prefix6wrong2,
+						prefix6wrong3,
+						prefix4wrong3,
+						prefix4range1,
+						prefix4wrong1,
+						prefix6wrong1,
+					}, true, false, true),
 					m.EXPECT().CreateWAFListItems(ctx, p, wafList, listDescription, nil, "").Return(true),
-					m.EXPECT().DeleteWAFListItems(ctx, p, wafList, listDescription,
-						gomock.InAnyOrder([]api.ID{
-							prefix4wrong2.ID,
-							prefix6wrong2.ID,
-							prefix6wrong3.ID,
-							prefix4wrong3.ID,
-							prefix4wrong1.ID,
-							prefix6wrong1.ID,
-						})).Return(false),
-					p.EXPECT().Noticef(pp.EmojiError,
-						"Failed to properly update the list %s; its content may be inconsistent", wafListDescribed),
+					m.EXPECT().DeleteWAFListItems(ctx, p, wafList, listDescription, gomock.InAnyOrder([]api.ID{
+						prefix4wrong2.ID,
+						prefix6wrong2.ID,
+						prefix6wrong3.ID,
+						prefix4wrong3.ID,
+						prefix4wrong1.ID,
+						prefix6wrong1.ID,
+					})).Return(false),
+					p.EXPECT().Noticef(pp.EmojiError, "Failed to properly update the list %s; its content may be inconsistent", wafListDescribed),
 				)
 			},
 		},

--- a/internal/updater/updater_test.go
+++ b/internal/updater/updater_test.go
@@ -1,3 +1,4 @@
+// vim: nowrap
 package updater_test
 
 import (
@@ -62,9 +63,7 @@ func initConfig() *config.Config {
 }
 
 func hintIP6DetectionFails(p *mocks.MockPP) *mocks.PPHintfCall {
-	return p.EXPECT().Hintf(pp.HintIP6DetectionFails,
-		"If you are using Docker or Kubernetes, IPv6 might need extra setup. Read more at %s. If your network doesn't support IPv6, you can turn it off by setting IP6_PROVIDER=none", //nolint:lll
-		pp.ManualURL)
+	return p.EXPECT().Hintf(pp.HintIP6DetectionFails, "If you are using Docker or Kubernetes, IPv6 might need extra setup. Read more at %s. If your network doesn't support IPv6, you can turn it off by setting IP6_PROVIDER=none", pp.ManualURL)
 }
 
 func TestUpdateIPsMultiple(t *testing.T) {
@@ -92,9 +91,12 @@ func TestUpdateIPsMultiple(t *testing.T) {
 	}{
 		"1yes1doing1no": {
 			false,
-			[]string{"Failed to set A (127.0.0.1) of ip4.hello2", "Failed to set list(s) xxxxxxxx/list2"},
 			[]string{
-				"Failed to properly update A records of ip4.hello2 with 127.0.0.1; updating those of ip4.hello1; updated those of ip4.hello4.", //nolint:lll
+				"Failed to set A (127.0.0.1) of ip4.hello2",
+				"Failed to set list(s) xxxxxxxx/list2",
+			},
+			[]string{
+				"Failed to properly update A records of ip4.hello2 with 127.0.0.1; updating those of ip4.hello1; updated those of ip4.hello4.",
 				`Failed to properly update WAF list(s) xxxxxxxx/list2; updating 12341234/list1; updated zzz/list4.`,
 			},
 			providerEnablers{ipnet.IP4: true},
@@ -103,22 +105,14 @@ func TestUpdateIPsMultiple(t *testing.T) {
 					pv[ipnet.IP4].EXPECT().GetIP(gomock.Any(), p, ipnet.IP4).Return(ip4, provider.MethodPrimary, true),
 					p.EXPECT().Infof(pp.EmojiInternet, "Detected the %s address %v", "IPv4", ip4),
 					p.EXPECT().SuppressHint(pp.HintIP4DetectionFails),
-					s.EXPECT().Set(gomock.Any(), p, ipnet.IP4, domain.FQDN("ip4.hello1"), ip4, api.TTLAuto, false, recordComment).
-						Return(setter.ResponseUpdating),
-					s.EXPECT().Set(gomock.Any(), p, ipnet.IP4, domain.FQDN("ip4.hello2"), ip4, api.TTLAuto, false, recordComment).
-						Return(setter.ResponseFailed),
-					s.EXPECT().Set(gomock.Any(), p, ipnet.IP4, domain.FQDN("ip4.hello3"), ip4, api.TTLAuto, false, recordComment).
-						Return(setter.ResponseNoop),
-					s.EXPECT().Set(gomock.Any(), p, ipnet.IP4, domain.FQDN("ip4.hello4"), ip4, api.TTLAuto, false, recordComment).
-						Return(setter.ResponseUpdated),
-					s.EXPECT().SetWAFList(gomock.Any(), p, list1, wafListDescription, detected{ipnet.IP4: ip4}, "").
-						Return(setter.ResponseUpdating),
-					s.EXPECT().SetWAFList(gomock.Any(), p, list2, wafListDescription, detected{ipnet.IP4: ip4}, "").
-						Return(setter.ResponseFailed),
-					s.EXPECT().SetWAFList(gomock.Any(), p, list3, wafListDescription, detected{ipnet.IP4: ip4}, "").
-						Return(setter.ResponseNoop),
-					s.EXPECT().SetWAFList(gomock.Any(), p, list4, wafListDescription, detected{ipnet.IP4: ip4}, "").
-						Return(setter.ResponseUpdated),
+					s.EXPECT().Set(gomock.Any(), p, ipnet.IP4, domain.FQDN("ip4.hello1"), ip4, api.TTLAuto, false, recordComment).Return(setter.ResponseUpdating),
+					s.EXPECT().Set(gomock.Any(), p, ipnet.IP4, domain.FQDN("ip4.hello2"), ip4, api.TTLAuto, false, recordComment).Return(setter.ResponseFailed),
+					s.EXPECT().Set(gomock.Any(), p, ipnet.IP4, domain.FQDN("ip4.hello3"), ip4, api.TTLAuto, false, recordComment).Return(setter.ResponseNoop),
+					s.EXPECT().Set(gomock.Any(), p, ipnet.IP4, domain.FQDN("ip4.hello4"), ip4, api.TTLAuto, false, recordComment).Return(setter.ResponseUpdated),
+					s.EXPECT().SetWAFList(gomock.Any(), p, list1, wafListDescription, detected{ipnet.IP4: ip4}, "").Return(setter.ResponseUpdating),
+					s.EXPECT().SetWAFList(gomock.Any(), p, list2, wafListDescription, detected{ipnet.IP4: ip4}, "").Return(setter.ResponseFailed),
+					s.EXPECT().SetWAFList(gomock.Any(), p, list3, wafListDescription, detected{ipnet.IP4: ip4}, "").Return(setter.ResponseNoop),
+					s.EXPECT().SetWAFList(gomock.Any(), p, list4, wafListDescription, detected{ipnet.IP4: ip4}, "").Return(setter.ResponseUpdated),
 				)
 			},
 		},
@@ -139,22 +133,14 @@ func TestUpdateIPsMultiple(t *testing.T) {
 					pv[ipnet.IP4].EXPECT().GetIP(gomock.Any(), p, ipnet.IP4).Return(ip4, provider.MethodPrimary, true),
 					p.EXPECT().Infof(pp.EmojiInternet, "Detected the %s address %v", "IPv4", ip4),
 					p.EXPECT().SuppressHint(pp.HintIP4DetectionFails),
-					s.EXPECT().Set(gomock.Any(), p, ipnet.IP4, domain.FQDN("ip4.hello1"), ip4, api.TTLAuto, false, recordComment).
-						Return(setter.ResponseUpdated),
-					s.EXPECT().Set(gomock.Any(), p, ipnet.IP4, domain.FQDN("ip4.hello2"), ip4, api.TTLAuto, false, recordComment).
-						Return(setter.ResponseNoop),
-					s.EXPECT().Set(gomock.Any(), p, ipnet.IP4, domain.FQDN("ip4.hello3"), ip4, api.TTLAuto, false, recordComment).
-						Return(setter.ResponseUpdated),
-					s.EXPECT().Set(gomock.Any(), p, ipnet.IP4, domain.FQDN("ip4.hello4"), ip4, api.TTLAuto, false, recordComment).
-						Return(setter.ResponseUpdated),
-					s.EXPECT().SetWAFList(gomock.Any(), p, list1, wafListDescription, detected{ipnet.IP4: ip4}, "").
-						Return(setter.ResponseUpdating),
-					s.EXPECT().SetWAFList(gomock.Any(), p, list2, wafListDescription, detected{ipnet.IP4: ip4}, "").
-						Return(setter.ResponseNoop),
-					s.EXPECT().SetWAFList(gomock.Any(), p, list3, wafListDescription, detected{ipnet.IP4: ip4}, "").
-						Return(setter.ResponseUpdated),
-					s.EXPECT().SetWAFList(gomock.Any(), p, list4, wafListDescription, detected{ipnet.IP4: ip4}, "").
-						Return(setter.ResponseUpdated),
+					s.EXPECT().Set(gomock.Any(), p, ipnet.IP4, domain.FQDN("ip4.hello1"), ip4, api.TTLAuto, false, recordComment).Return(setter.ResponseUpdated),
+					s.EXPECT().Set(gomock.Any(), p, ipnet.IP4, domain.FQDN("ip4.hello2"), ip4, api.TTLAuto, false, recordComment).Return(setter.ResponseNoop),
+					s.EXPECT().Set(gomock.Any(), p, ipnet.IP4, domain.FQDN("ip4.hello3"), ip4, api.TTLAuto, false, recordComment).Return(setter.ResponseUpdated),
+					s.EXPECT().Set(gomock.Any(), p, ipnet.IP4, domain.FQDN("ip4.hello4"), ip4, api.TTLAuto, false, recordComment).Return(setter.ResponseUpdated),
+					s.EXPECT().SetWAFList(gomock.Any(), p, list1, wafListDescription, detected{ipnet.IP4: ip4}, "").Return(setter.ResponseUpdating),
+					s.EXPECT().SetWAFList(gomock.Any(), p, list2, wafListDescription, detected{ipnet.IP4: ip4}, "").Return(setter.ResponseNoop),
+					s.EXPECT().SetWAFList(gomock.Any(), p, list3, wafListDescription, detected{ipnet.IP4: ip4}, "").Return(setter.ResponseUpdated),
+					s.EXPECT().SetWAFList(gomock.Any(), p, list4, wafListDescription, detected{ipnet.IP4: ip4}, "").Return(setter.ResponseUpdated),
 				)
 			},
 		},
@@ -214,21 +200,20 @@ func TestFinalDeleteIPsMultiple(t *testing.T) {
 	}{
 		"1yes1doing1no": {
 			false,
-			[]string{"Failed to delete A of ip4.hello2", "Failed to clear list(s) xxxxxxxx/list2"},
+			[]string{
+				"Failed to delete A of ip4.hello2",
+				"Failed to clear list(s) xxxxxxxx/list2",
+			},
 			[]string{
 				"Failed to properly delete A records of ip4.hello2; deleting those of ip4.hello1; deleted those of ip4.hello4.",
 				`Failed to properly clear WAF list(s) xxxxxxxx/list2; clearing 12341234/list1; cleared zzz/list4.`,
 			},
 			func(p *mocks.MockPP, s *mocks.MockSetter) {
 				gomock.InOrder(
-					s.EXPECT().FinalDelete(gomock.Any(), p, ipnet.IP4, domain.FQDN("ip4.hello1")).
-						Return(setter.ResponseUpdating),
-					s.EXPECT().FinalDelete(gomock.Any(), p, ipnet.IP4, domain.FQDN("ip4.hello2")).
-						Return(setter.ResponseFailed),
-					s.EXPECT().FinalDelete(gomock.Any(), p, ipnet.IP4, domain.FQDN("ip4.hello3")).
-						Return(setter.ResponseNoop),
-					s.EXPECT().FinalDelete(gomock.Any(), p, ipnet.IP4, domain.FQDN("ip4.hello4")).
-						Return(setter.ResponseUpdated),
+					s.EXPECT().FinalDelete(gomock.Any(), p, ipnet.IP4, domain.FQDN("ip4.hello1")).Return(setter.ResponseUpdating),
+					s.EXPECT().FinalDelete(gomock.Any(), p, ipnet.IP4, domain.FQDN("ip4.hello2")).Return(setter.ResponseFailed),
+					s.EXPECT().FinalDelete(gomock.Any(), p, ipnet.IP4, domain.FQDN("ip4.hello3")).Return(setter.ResponseNoop),
+					s.EXPECT().FinalDelete(gomock.Any(), p, ipnet.IP4, domain.FQDN("ip4.hello4")).Return(setter.ResponseUpdated),
 					s.EXPECT().FinalClearWAFList(gomock.Any(), p, list1, wafListDescription).Return(setter.ResponseUpdating),
 					s.EXPECT().FinalClearWAFList(gomock.Any(), p, list2, wafListDescription).Return(setter.ResponseFailed),
 					s.EXPECT().FinalClearWAFList(gomock.Any(), p, list3, wafListDescription).Return(setter.ResponseNoop),
@@ -248,14 +233,10 @@ func TestFinalDeleteIPsMultiple(t *testing.T) {
 			},
 			func(p *mocks.MockPP, s *mocks.MockSetter) {
 				gomock.InOrder(
-					s.EXPECT().FinalDelete(gomock.Any(), p, ipnet.IP4, domain.FQDN("ip4.hello1")).
-						Return(setter.ResponseUpdated),
-					s.EXPECT().FinalDelete(gomock.Any(), p, ipnet.IP4, domain.FQDN("ip4.hello2")).
-						Return(setter.ResponseNoop),
-					s.EXPECT().FinalDelete(gomock.Any(), p, ipnet.IP4, domain.FQDN("ip4.hello3")).
-						Return(setter.ResponseUpdated),
-					s.EXPECT().FinalDelete(gomock.Any(), p, ipnet.IP4, domain.FQDN("ip4.hello4")).
-						Return(setter.ResponseUpdated),
+					s.EXPECT().FinalDelete(gomock.Any(), p, ipnet.IP4, domain.FQDN("ip4.hello1")).Return(setter.ResponseUpdated),
+					s.EXPECT().FinalDelete(gomock.Any(), p, ipnet.IP4, domain.FQDN("ip4.hello2")).Return(setter.ResponseNoop),
+					s.EXPECT().FinalDelete(gomock.Any(), p, ipnet.IP4, domain.FQDN("ip4.hello3")).Return(setter.ResponseUpdated),
+					s.EXPECT().FinalDelete(gomock.Any(), p, ipnet.IP4, domain.FQDN("ip4.hello4")).Return(setter.ResponseUpdated),
 					s.EXPECT().FinalClearWAFList(gomock.Any(), p, list1, wafListDescription).Return(setter.ResponseUpdated),
 					s.EXPECT().FinalClearWAFList(gomock.Any(), p, list2, wafListDescription).Return(setter.ResponseNoop),
 					s.EXPECT().FinalClearWAFList(gomock.Any(), p, list3, wafListDescription).Return(setter.ResponseUpdated),
@@ -326,90 +307,68 @@ func TestUpdateIPs(t *testing.T) {
 					pv[ipnet.IP4].EXPECT().GetIP(gomock.Any(), p, ipnet.IP4).Return(ip4, provider.MethodPrimary, true),
 					p.EXPECT().Infof(pp.EmojiInternet, "Detected the %s address %v", "IPv4", ip4),
 					p.EXPECT().SuppressHint(pp.HintIP4DetectionFails),
-					s.EXPECT().Set(gomock.Any(), p, ipnet.IP4, domain.FQDN("ip4.hello"), ip4, api.TTLAuto, false, recordComment).
-						Return(setter.ResponseNoop),
-					s.EXPECT().SetWAFList(gomock.Any(), p, list, wafListDescription, detectedIPs{ipnet.IP4: ip4}, "").
-						Return(setter.ResponseNoop),
+					s.EXPECT().Set(gomock.Any(), p, ipnet.IP4, domain.FQDN("ip4.hello"), ip4, api.TTLAuto, false, recordComment).Return(setter.ResponseNoop),
+					s.EXPECT().SetWAFList(gomock.Any(), p, list, wafListDescription, detectedIPs{ipnet.IP4: ip4}, "").Return(setter.ResponseNoop),
 				)
 			},
 		},
 		"ip4-only/set-fail": {
 			false,
 			[]string{"Failed to set A (127.0.0.1) of ip4.hello", "Failed to set list(s) 12341234/list"},
-			[]string{
-				"Failed to properly update A records of ip4.hello with 127.0.0.1.",
-				`Failed to properly update WAF list(s) 12341234/list.`,
-			},
+			[]string{"Failed to properly update A records of ip4.hello with 127.0.0.1.", `Failed to properly update WAF list(s) 12341234/list.`},
 			providerEnablers{ipnet.IP4: true},
 			func(p *mocks.MockPP, pv mockProviders, s *mocks.MockSetter) {
 				gomock.InOrder(
 					pv[ipnet.IP4].EXPECT().GetIP(gomock.Any(), p, ipnet.IP4).Return(ip4, provider.MethodPrimary, true),
 					p.EXPECT().Infof(pp.EmojiInternet, "Detected the %s address %v", "IPv4", ip4),
 					p.EXPECT().SuppressHint(pp.HintIP4DetectionFails),
-					s.EXPECT().Set(gomock.Any(), p, ipnet.IP4, domain.FQDN("ip4.hello"), ip4, api.TTLAuto, false, recordComment).
-						Return(setter.ResponseFailed),
-					s.EXPECT().SetWAFList(gomock.Any(), p, list, wafListDescription, detectedIPs{ipnet.IP4: ip4}, "").
-						Return(setter.ResponseFailed),
+					s.EXPECT().Set(gomock.Any(), p, ipnet.IP4, domain.FQDN("ip4.hello"), ip4, api.TTLAuto, false, recordComment).Return(setter.ResponseFailed),
+					s.EXPECT().SetWAFList(gomock.Any(), p, list, wafListDescription, detectedIPs{ipnet.IP4: ip4}, "").Return(setter.ResponseFailed),
 				)
 			},
 		},
 		"ip4-only/setting": {
 			true,
 			[]string{"Setting A (127.0.0.1) of ip4.hello", "Setting list(s) 12341234/list"},
-			[]string{
-				"Updating A records of ip4.hello with 127.0.0.1.",
-				`Updating WAF list(s) 12341234/list.`,
-			},
+			[]string{"Updating A records of ip4.hello with 127.0.0.1.", `Updating WAF list(s) 12341234/list.`},
 			providerEnablers{ipnet.IP4: true},
 			func(p *mocks.MockPP, pv mockProviders, s *mocks.MockSetter) {
 				gomock.InOrder(
 					pv[ipnet.IP4].EXPECT().GetIP(gomock.Any(), p, ipnet.IP4).Return(ip4, provider.MethodPrimary, true),
 					p.EXPECT().Infof(pp.EmojiInternet, "Detected the %s address %v", "IPv4", ip4),
 					p.EXPECT().SuppressHint(pp.HintIP4DetectionFails),
-					s.EXPECT().Set(gomock.Any(), p, ipnet.IP4, domain.FQDN("ip4.hello"), ip4, api.TTLAuto, false, recordComment).
-						Return(setter.ResponseUpdating),
-					s.EXPECT().SetWAFList(gomock.Any(), p, list, wafListDescription, detectedIPs{ipnet.IP4: ip4}, "").
-						Return(setter.ResponseUpdating),
+					s.EXPECT().Set(gomock.Any(), p, ipnet.IP4, domain.FQDN("ip4.hello"), ip4, api.TTLAuto, false, recordComment).Return(setter.ResponseUpdating),
+					s.EXPECT().SetWAFList(gomock.Any(), p, list, wafListDescription, detectedIPs{ipnet.IP4: ip4}, "").Return(setter.ResponseUpdating),
 				)
 			},
 		},
 		"ip6-only": {
 			true,
 			[]string{"Set AAAA (::1) of ip6.hello", "Set list(s) 12341234/list"},
-			[]string{
-				"Updated AAAA records of ip6.hello with ::1.",
-				`Updated WAF list(s) 12341234/list.`,
-			},
+			[]string{"Updated AAAA records of ip6.hello with ::1.", `Updated WAF list(s) 12341234/list.`},
 			providerEnablers{ipnet.IP6: true},
 			func(p *mocks.MockPP, pv mockProviders, s *mocks.MockSetter) {
 				gomock.InOrder(
 					pv[ipnet.IP6].EXPECT().GetIP(gomock.Any(), p, ipnet.IP6).Return(ip6, provider.MethodPrimary, true),
 					p.EXPECT().Infof(pp.EmojiInternet, "Detected the %s address %v", "IPv6", ip6),
 					p.EXPECT().SuppressHint(pp.HintIP6DetectionFails),
-					s.EXPECT().Set(gomock.Any(), p, ipnet.IP6, domain.FQDN("ip6.hello"), ip6, api.TTLAuto, false, recordComment).
-						Return(setter.ResponseUpdated),
-					s.EXPECT().SetWAFList(gomock.Any(), p, list, wafListDescription, detectedIPs{ipnet.IP6: ip6}, "").
-						Return(setter.ResponseUpdated),
+					s.EXPECT().Set(gomock.Any(), p, ipnet.IP6, domain.FQDN("ip6.hello"), ip6, api.TTLAuto, false, recordComment).Return(setter.ResponseUpdated),
+					s.EXPECT().SetWAFList(gomock.Any(), p, list, wafListDescription, detectedIPs{ipnet.IP6: ip6}, "").Return(setter.ResponseUpdated),
 				)
 			},
 		},
 		"ip6-only/set-fail": {
 			false,
 			[]string{"Failed to set AAAA (::1) of ip6.hello", "Failed to set list(s) 12341234/list"},
-			[]string{
-				"Failed to properly update AAAA records of ip6.hello with ::1.",
-				`Failed to properly update WAF list(s) 12341234/list.`,
-			},
+			[]string{"Failed to properly update AAAA records of ip6.hello with ::1.", `Failed to properly update WAF list(s) 12341234/list.`},
 			providerEnablers{ipnet.IP6: true},
 			func(p *mocks.MockPP, pv mockProviders, s *mocks.MockSetter) {
 				gomock.InOrder(
 					pv[ipnet.IP6].EXPECT().GetIP(gomock.Any(), p, ipnet.IP6).Return(ip6, provider.MethodPrimary, true),
 					p.EXPECT().Infof(pp.EmojiInternet, "Detected the %s address %v", "IPv6", ip6),
 					p.EXPECT().SuppressHint(pp.HintIP6DetectionFails),
-					s.EXPECT().Set(gomock.Any(), p, ipnet.IP6, domain.FQDN("ip6.hello"), ip6, api.TTLAuto, false, recordComment).
-						Return(setter.ResponseFailed),
-					s.EXPECT().SetWAFList(gomock.Any(), p, list, wafListDescription, detectedIPs{ipnet.IP6: ip6}, "").
-						Return(setter.ResponseFailed),
+					s.EXPECT().Set(gomock.Any(), p, ipnet.IP6, domain.FQDN("ip6.hello"), ip6, api.TTLAuto, false, recordComment).Return(setter.ResponseFailed),
+					s.EXPECT().SetWAFList(gomock.Any(), p, list, wafListDescription, detectedIPs{ipnet.IP6: ip6}, "").Return(setter.ResponseFailed),
 				)
 			},
 		},
@@ -422,16 +381,12 @@ func TestUpdateIPs(t *testing.T) {
 					p.EXPECT().Infof(pp.EmojiInternet, "Detected the %s address %v (using 1.0.0.1)", "IPv4", ip4),
 					expectHint1111Blockage(p),
 					p.EXPECT().SuppressHint(pp.HintIP4DetectionFails),
-					s.EXPECT().Set(gomock.Any(), p, ipnet.IP4, domain.FQDN("ip4.hello"), ip4, api.TTLAuto, false, recordComment).
-						Return(setter.ResponseNoop),
+					s.EXPECT().Set(gomock.Any(), p, ipnet.IP4, domain.FQDN("ip4.hello"), ip4, api.TTLAuto, false, recordComment).Return(setter.ResponseNoop),
 					pv[ipnet.IP6].EXPECT().GetIP(gomock.Any(), p, ipnet.IP6).Return(ip6, provider.MethodPrimary, true),
 					p.EXPECT().Infof(pp.EmojiInternet, "Detected the %s address %v", "IPv6", ip6),
 					p.EXPECT().SuppressHint(pp.HintIP6DetectionFails),
-					s.EXPECT().Set(gomock.Any(), p, ipnet.IP6, domain.FQDN("ip6.hello"), ip6, api.TTLAuto, false, recordComment).
-						Return(setter.ResponseNoop),
-					s.EXPECT().SetWAFList(gomock.Any(), p, list, wafListDescription,
-						detectedIPs{ipnet.IP4: ip4, ipnet.IP6: ip6}, "").
-						Return(setter.ResponseNoop),
+					s.EXPECT().Set(gomock.Any(), p, ipnet.IP6, domain.FQDN("ip6.hello"), ip6, api.TTLAuto, false, recordComment).Return(setter.ResponseNoop),
+					s.EXPECT().SetWAFList(gomock.Any(), p, list, wafListDescription, detectedIPs{ipnet.IP4: ip4, ipnet.IP6: ip6}, "").Return(setter.ResponseNoop),
 				)
 			},
 		},
@@ -446,16 +401,12 @@ func TestUpdateIPs(t *testing.T) {
 					p.EXPECT().Infof(pp.EmojiInternet, "Detected the %s address %v (using 1.0.0.1)", "IPv4", ip4),
 					expectHint1111Blockage(p),
 					p.EXPECT().SuppressHint(pp.HintIP4DetectionFails),
-					s.EXPECT().Set(gomock.Any(), p, ipnet.IP4, domain.FQDN("ip4.hello"), ip4, api.TTLAuto, false, recordComment).
-						Return(setter.ResponseFailed),
+					s.EXPECT().Set(gomock.Any(), p, ipnet.IP4, domain.FQDN("ip4.hello"), ip4, api.TTLAuto, false, recordComment).Return(setter.ResponseFailed),
 					pv[ipnet.IP6].EXPECT().GetIP(gomock.Any(), p, ipnet.IP6).Return(ip6, provider.MethodPrimary, true),
 					p.EXPECT().Infof(pp.EmojiInternet, "Detected the %s address %v", "IPv6", ip6),
 					p.EXPECT().SuppressHint(pp.HintIP6DetectionFails),
-					s.EXPECT().Set(gomock.Any(), p, ipnet.IP6, domain.FQDN("ip6.hello"), ip6, api.TTLAuto, false, recordComment).
-						Return(setter.ResponseNoop),
-					s.EXPECT().SetWAFList(gomock.Any(), p, list, wafListDescription,
-						detectedIPs{ipnet.IP4: ip4, ipnet.IP6: ip6}, "").
-						Return(setter.ResponseNoop),
+					s.EXPECT().Set(gomock.Any(), p, ipnet.IP6, domain.FQDN("ip6.hello"), ip6, api.TTLAuto, false, recordComment).Return(setter.ResponseNoop),
+					s.EXPECT().SetWAFList(gomock.Any(), p, list, wafListDescription, detectedIPs{ipnet.IP4: ip4, ipnet.IP6: ip6}, "").Return(setter.ResponseNoop),
 				)
 			},
 		},
@@ -470,16 +421,12 @@ func TestUpdateIPs(t *testing.T) {
 					p.EXPECT().Infof(pp.EmojiInternet, "Detected the %s address %v (using 1.0.0.1)", "IPv4", ip4),
 					expectHint1111Blockage(p),
 					p.EXPECT().SuppressHint(pp.HintIP4DetectionFails),
-					s.EXPECT().Set(gomock.Any(), p, ipnet.IP4, domain.FQDN("ip4.hello"), ip4, api.TTLAuto, false, recordComment).
-						Return(setter.ResponseNoop),
+					s.EXPECT().Set(gomock.Any(), p, ipnet.IP4, domain.FQDN("ip4.hello"), ip4, api.TTLAuto, false, recordComment).Return(setter.ResponseNoop),
 					pv[ipnet.IP6].EXPECT().GetIP(gomock.Any(), p, ipnet.IP6).Return(ip6, provider.MethodPrimary, true),
 					p.EXPECT().Infof(pp.EmojiInternet, "Detected the %s address %v", "IPv6", ip6),
 					p.EXPECT().SuppressHint(pp.HintIP6DetectionFails),
-					s.EXPECT().Set(gomock.Any(), p, ipnet.IP6, domain.FQDN("ip6.hello"), ip6, api.TTLAuto, false, recordComment).
-						Return(setter.ResponseFailed),
-					s.EXPECT().SetWAFList(gomock.Any(), p, list, wafListDescription,
-						detectedIPs{ipnet.IP4: ip4, ipnet.IP6: ip6}, "").
-						Return(setter.ResponseNoop),
+					s.EXPECT().Set(gomock.Any(), p, ipnet.IP6, domain.FQDN("ip6.hello"), ip6, api.TTLAuto, false, recordComment).Return(setter.ResponseFailed),
+					s.EXPECT().SetWAFList(gomock.Any(), p, list, wafListDescription, detectedIPs{ipnet.IP4: ip4, ipnet.IP6: ip6}, "").Return(setter.ResponseNoop),
 				)
 			},
 		},
@@ -494,16 +441,12 @@ func TestUpdateIPs(t *testing.T) {
 					p.EXPECT().Infof(pp.EmojiInternet, "Detected the %s address %v (using 1.0.0.1)", "IPv4", ip4),
 					expectHint1111Blockage(p),
 					p.EXPECT().SuppressHint(pp.HintIP4DetectionFails),
-					s.EXPECT().Set(gomock.Any(), p, ipnet.IP4, domain.FQDN("ip4.hello"), ip4, api.TTLAuto, false, recordComment).
-						Return(setter.ResponseNoop),
+					s.EXPECT().Set(gomock.Any(), p, ipnet.IP4, domain.FQDN("ip4.hello"), ip4, api.TTLAuto, false, recordComment).Return(setter.ResponseNoop),
 					pv[ipnet.IP6].EXPECT().GetIP(gomock.Any(), p, ipnet.IP6).Return(ip6, provider.MethodPrimary, true),
 					p.EXPECT().Infof(pp.EmojiInternet, "Detected the %s address %v", "IPv6", ip6),
 					p.EXPECT().SuppressHint(pp.HintIP6DetectionFails),
-					s.EXPECT().Set(gomock.Any(), p, ipnet.IP6, domain.FQDN("ip6.hello"), ip6, api.TTLAuto, false, recordComment).
-						Return(setter.ResponseNoop),
-					s.EXPECT().SetWAFList(gomock.Any(), p, list, wafListDescription,
-						detectedIPs{ipnet.IP4: ip4, ipnet.IP6: ip6}, "").
-						Return(setter.ResponseFailed),
+					s.EXPECT().Set(gomock.Any(), p, ipnet.IP6, domain.FQDN("ip6.hello"), ip6, api.TTLAuto, false, recordComment).Return(setter.ResponseNoop),
+					s.EXPECT().SetWAFList(gomock.Any(), p, list, wafListDescription, detectedIPs{ipnet.IP4: ip4, ipnet.IP6: ip6}, "").Return(setter.ResponseFailed),
 				)
 			},
 		},
@@ -516,14 +459,12 @@ func TestUpdateIPs(t *testing.T) {
 				gomock.InOrder(
 					pv[ipnet.IP4].EXPECT().GetIP(gomock.Any(), p, ipnet.IP4).Return(netip.Addr{}, provider.MethodUnspecified, false),
 					p.EXPECT().Noticef(pp.EmojiError, "Failed to detect the %s address", "IPv4"),
-					p.EXPECT().Hintf(pp.HintIP4DetectionFails, "If your network does not support IPv4, you can disable it with IP4_PROVIDER=none"), //nolint:lll
+					p.EXPECT().Hintf(pp.HintIP4DetectionFails, "If your network does not support IPv4, you can disable it with IP4_PROVIDER=none"),
 					pv[ipnet.IP6].EXPECT().GetIP(gomock.Any(), p, ipnet.IP6).Return(ip6, provider.MethodPrimary, true),
 					p.EXPECT().Infof(pp.EmojiInternet, "Detected the %s address %v", "IPv6", ip6),
 					p.EXPECT().SuppressHint(pp.HintIP6DetectionFails),
-					s.EXPECT().Set(gomock.Any(), p, ipnet.IP6, domain.FQDN("ip6.hello"), ip6, api.TTLAuto, false, recordComment).
-						Return(setter.ResponseNoop),
-					s.EXPECT().SetWAFList(gomock.Any(), p, list, wafListDescription,
-						detectedIPs{ipnet.IP4: netip.Addr{}, ipnet.IP6: ip6}, ""),
+					s.EXPECT().Set(gomock.Any(), p, ipnet.IP6, domain.FQDN("ip6.hello"), ip6, api.TTLAuto, false, recordComment).Return(setter.ResponseNoop),
+					s.EXPECT().SetWAFList(gomock.Any(), p, list, wafListDescription, detectedIPs{ipnet.IP4: netip.Addr{}, ipnet.IP6: ip6}, ""),
 				)
 			},
 		},
@@ -538,13 +479,11 @@ func TestUpdateIPs(t *testing.T) {
 					p.EXPECT().Infof(pp.EmojiInternet, "Detected the %s address %v (using 1.0.0.1)", "IPv4", ip4),
 					expectHint1111Blockage(p),
 					p.EXPECT().SuppressHint(pp.HintIP4DetectionFails),
-					s.EXPECT().Set(gomock.Any(), p, ipnet.IP4, domain.FQDN("ip4.hello"), ip4, api.TTLAuto, false, recordComment).
-						Return(setter.ResponseNoop),
+					s.EXPECT().Set(gomock.Any(), p, ipnet.IP4, domain.FQDN("ip4.hello"), ip4, api.TTLAuto, false, recordComment).Return(setter.ResponseNoop),
 					pv[ipnet.IP6].EXPECT().GetIP(gomock.Any(), p, ipnet.IP6).Return(netip.Addr{}, provider.MethodUnspecified, false),
 					p.EXPECT().Noticef(pp.EmojiError, "Failed to detect the %s address", "IPv6"),
 					hintIP6DetectionFails(p),
-					s.EXPECT().SetWAFList(gomock.Any(), p, list, wafListDescription,
-						detectedIPs{ipnet.IP4: ip4, ipnet.IP6: netip.Addr{}}, ""),
+					s.EXPECT().SetWAFList(gomock.Any(), p, list, wafListDescription, detectedIPs{ipnet.IP4: ip4, ipnet.IP6: netip.Addr{}}, ""),
 				)
 			},
 		},
@@ -557,7 +496,7 @@ func TestUpdateIPs(t *testing.T) {
 				gomock.InOrder(
 					pv[ipnet.IP4].EXPECT().GetIP(gomock.Any(), p, ipnet.IP4).Return(netip.Addr{}, provider.MethodUnspecified, false),
 					p.EXPECT().Noticef(pp.EmojiError, "Failed to detect the %s address", "IPv4"),
-					p.EXPECT().Hintf(pp.HintIP4DetectionFails, "If your network does not support IPv4, you can disable it with IP4_PROVIDER=none"), //nolint:lll
+					p.EXPECT().Hintf(pp.HintIP4DetectionFails, "If your network does not support IPv4, you can disable it with IP4_PROVIDER=none"),
 					pv[ipnet.IP6].EXPECT().GetIP(gomock.Any(), p, ipnet.IP6).Return(netip.Addr{}, provider.MethodUnspecified, false),
 					p.EXPECT().Noticef(pp.EmojiError, "Failed to detect the %s address", "IPv6"),
 					hintIP6DetectionFails(p),
@@ -571,18 +510,16 @@ func TestUpdateIPs(t *testing.T) {
 			providerEnablers{ipnet.IP4: true},
 			func(p *mocks.MockPP, pv mockProviders, s *mocks.MockSetter) {
 				gomock.InOrder(
-					pv[ipnet.IP4].EXPECT().GetIP(gomock.Any(), p, ipnet.IP4).
-						DoAndReturn(
-							func(context.Context, pp.PP, ipnet.Type) (netip.Addr, provider.Method, bool) {
-								time.Sleep(2 * time.Second)
-								return netip.Addr{}, provider.MethodUnspecified, false
-							},
-						),
+					pv[ipnet.IP4].EXPECT().GetIP(gomock.Any(), p, ipnet.IP4).DoAndReturn(
+						func(context.Context, pp.PP, ipnet.Type) (netip.Addr, provider.Method, bool) {
+							time.Sleep(2 * time.Second)
+							return netip.Addr{}, provider.MethodUnspecified, false
+						},
+					),
 					p.EXPECT().Noticef(pp.EmojiError, "Failed to detect the %s address", "IPv4"),
-					p.EXPECT().Hintf(pp.HintIP4DetectionFails, "If your network does not support IPv4, you can disable it with IP4_PROVIDER=none"),                    //nolint:lll
-					p.EXPECT().Hintf(pp.HintDetectionTimeouts, "If your network is experiencing high latency, consider increasing DETECTION_TIMEOUT=%v", time.Second), //nolint:lll
-					s.EXPECT().SetWAFList(gomock.Any(), p, list, wafListDescription, detectedIPs{ipnet.IP4: netip.Addr{}}, "").
-						Return(setter.ResponseNoop),
+					p.EXPECT().Hintf(pp.HintIP4DetectionFails, "If your network does not support IPv4, you can disable it with IP4_PROVIDER=none"),
+					p.EXPECT().Hintf(pp.HintDetectionTimeouts, "If your network is experiencing high latency, consider increasing DETECTION_TIMEOUT=%v", time.Second),
+					s.EXPECT().SetWAFList(gomock.Any(), p, list, wafListDescription, detectedIPs{ipnet.IP4: netip.Addr{}}, "").Return(setter.ResponseNoop),
 				)
 			},
 		},
@@ -596,15 +533,13 @@ func TestUpdateIPs(t *testing.T) {
 					pv[ipnet.IP4].EXPECT().GetIP(gomock.Any(), p, ipnet.IP4).Return(ip4, provider.MethodPrimary, true),
 					p.EXPECT().Infof(pp.EmojiInternet, "Detected the %s address %v", "IPv4", ip4),
 					p.EXPECT().SuppressHint(pp.HintIP4DetectionFails),
-					s.EXPECT().Set(gomock.Any(), p, ipnet.IP4, domain.FQDN("ip4.hello"), ip4, api.TTLAuto, false, recordComment).
-						DoAndReturn(
-							func(context.Context, pp.PP, ipnet.Type, domain.Domain, netip.Addr, api.TTL, bool, string) setter.ResponseCode { //nolint:lll
-								time.Sleep(2 * time.Second)
-								return setter.ResponseFailed
-							}),
-					p.EXPECT().Hintf(pp.HintUpdateTimeouts, "If your network is experiencing high latency, consider increasing UPDATE_TIMEOUT=%v", time.Second), //nolint:lll
-					s.EXPECT().SetWAFList(gomock.Any(), p, list, wafListDescription, detectedIPs{ipnet.IP4: ip4}, "").
-						Return(setter.ResponseNoop),
+					s.EXPECT().Set(gomock.Any(), p, ipnet.IP4, domain.FQDN("ip4.hello"), ip4, api.TTLAuto, false, recordComment).DoAndReturn(
+						func(context.Context, pp.PP, ipnet.Type, domain.Domain, netip.Addr, api.TTL, bool, string) setter.ResponseCode {
+							time.Sleep(2 * time.Second)
+							return setter.ResponseFailed
+						}),
+					p.EXPECT().Hintf(pp.HintUpdateTimeouts, "If your network is experiencing high latency, consider increasing UPDATE_TIMEOUT=%v", time.Second),
+					s.EXPECT().SetWAFList(gomock.Any(), p, list, wafListDescription, detectedIPs{ipnet.IP4: ip4}, "").Return(setter.ResponseNoop),
 				)
 			},
 		},
@@ -618,15 +553,13 @@ func TestUpdateIPs(t *testing.T) {
 					pv[ipnet.IP4].EXPECT().GetIP(gomock.Any(), p, ipnet.IP4).Return(ip4, provider.MethodPrimary, true),
 					p.EXPECT().Infof(pp.EmojiInternet, "Detected the %s address %v", "IPv4", ip4),
 					p.EXPECT().SuppressHint(pp.HintIP4DetectionFails),
-					s.EXPECT().Set(gomock.Any(), p, ipnet.IP4, domain.FQDN("ip4.hello"), ip4, api.TTLAuto, false, recordComment).
-						Return(setter.ResponseNoop),
-					s.EXPECT().SetWAFList(gomock.Any(), p, list, wafListDescription, detectedIPs{ipnet.IP4: ip4}, "").
-						DoAndReturn(
-							func(context.Context, pp.PP, api.WAFList, string, detectedIPs, string) setter.ResponseCode {
-								time.Sleep(2 * time.Second)
-								return setter.ResponseFailed
-							}),
-					p.EXPECT().Hintf(pp.HintUpdateTimeouts, "If your network is experiencing high latency, consider increasing UPDATE_TIMEOUT=%v", time.Second), //nolint:lll
+					s.EXPECT().Set(gomock.Any(), p, ipnet.IP4, domain.FQDN("ip4.hello"), ip4, api.TTLAuto, false, recordComment).Return(setter.ResponseNoop),
+					s.EXPECT().SetWAFList(gomock.Any(), p, list, wafListDescription, detectedIPs{ipnet.IP4: ip4}, "").DoAndReturn(
+						func(context.Context, pp.PP, api.WAFList, string, detectedIPs, string) setter.ResponseCode {
+							time.Sleep(2 * time.Second)
+							return setter.ResponseFailed
+						}),
+					p.EXPECT().Hintf(pp.HintUpdateTimeouts, "If your network is experiencing high latency, consider increasing UPDATE_TIMEOUT=%v", time.Second),
 				)
 			},
 		},
@@ -687,10 +620,7 @@ func TestFinalDeleteIPs(t *testing.T) {
 		"ip4-only": {
 			true,
 			[]string{"Deleted A of ip4.hello", "Cleared list(s) 12341234/list"},
-			[]string{
-				"Deleted A records of ip4.hello.",
-				`Cleared WAF list(s) 12341234/list.`,
-			},
+			[]string{"Deleted A records of ip4.hello.", `Cleared WAF list(s) 12341234/list.`},
 			mockproviders{ipnet.IP4: true},
 			func(ppfmt *mocks.MockPP, s *mocks.MockSetter) {
 				gomock.InOrder(
@@ -821,13 +751,12 @@ func TestFinalDeleteIPs(t *testing.T) {
 			mockproviders{ipnet.IP4: true},
 			func(ppfmt *mocks.MockPP, s *mocks.MockSetter) {
 				gomock.InOrder(
-					s.EXPECT().FinalDelete(gomock.Any(), ppfmt, ipnet.IP4, domain.FQDN("ip4.hello")).
-						DoAndReturn(
-							func(context.Context, pp.PP, ipnet.Type, domain.Domain) setter.ResponseCode {
-								time.Sleep(2 * time.Second)
-								return setter.ResponseFailed
-							}),
-					ppfmt.EXPECT().Hintf(pp.HintUpdateTimeouts, "If your network is experiencing high latency, consider increasing UPDATE_TIMEOUT=%v", time.Second), //nolint:lll
+					s.EXPECT().FinalDelete(gomock.Any(), ppfmt, ipnet.IP4, domain.FQDN("ip4.hello")).DoAndReturn(
+						func(context.Context, pp.PP, ipnet.Type, domain.Domain) setter.ResponseCode {
+							time.Sleep(2 * time.Second)
+							return setter.ResponseFailed
+						}),
+					ppfmt.EXPECT().Hintf(pp.HintUpdateTimeouts, "If your network is experiencing high latency, consider increasing UPDATE_TIMEOUT=%v", time.Second),
 					s.EXPECT().FinalClearWAFList(gomock.Any(), ppfmt, list, wafListDescription).Return(setter.ResponseNoop),
 				)
 			},
@@ -839,15 +768,13 @@ func TestFinalDeleteIPs(t *testing.T) {
 			mockproviders{ipnet.IP4: true},
 			func(ppfmt *mocks.MockPP, s *mocks.MockSetter) {
 				gomock.InOrder(
-					s.EXPECT().FinalDelete(gomock.Any(), ppfmt, ipnet.IP4, domain.FQDN("ip4.hello")).
-						Return(setter.ResponseNoop),
-					s.EXPECT().FinalClearWAFList(gomock.Any(), ppfmt, list, wafListDescription).
-						DoAndReturn(
-							func(context.Context, pp.PP, api.WAFList, string) setter.ResponseCode {
-								time.Sleep(2 * time.Second)
-								return setter.ResponseFailed
-							}),
-					ppfmt.EXPECT().Hintf(pp.HintUpdateTimeouts, "If your network is experiencing high latency, consider increasing UPDATE_TIMEOUT=%v", time.Second), //nolint:lll
+					s.EXPECT().FinalDelete(gomock.Any(), ppfmt, ipnet.IP4, domain.FQDN("ip4.hello")).Return(setter.ResponseNoop),
+					s.EXPECT().FinalClearWAFList(gomock.Any(), ppfmt, list, wafListDescription).DoAndReturn(
+						func(context.Context, pp.PP, api.WAFList, string) setter.ResponseCode {
+							time.Sleep(2 * time.Second)
+							return setter.ResponseFailed
+						}),
+					ppfmt.EXPECT().Hintf(pp.HintUpdateTimeouts, "If your network is experiencing high latency, consider increasing UPDATE_TIMEOUT=%v", time.Second),
 				)
 			},
 		},

--- a/test/fuzzer/fuzzer_test.go
+++ b/test/fuzzer/fuzzer_test.go
@@ -34,10 +34,10 @@ func FuzzParseList(f *testing.F) {
 		mockPP := mocks.NewMockPP(mockCtrl)
 		mockPP.EXPECT().Noticef(pp.EmojiUserError, `%s (%q) is ill-formed: %v`, key, input, domainexp.ErrSingleAnd).AnyTimes()
 		mockPP.EXPECT().Noticef(pp.EmojiUserError, `%s (%q) is ill-formed: %v`, key, input, domainexp.ErrSingleOr).AnyTimes()
-		mockPP.EXPECT().Noticef(pp.EmojiUserError, "%s (%q) is ill-formed: %v", key, input, ErrorMatcher{domainexp.ErrUTF8}).AnyTimes() //nolint:lll
+		mockPP.EXPECT().Noticef(pp.EmojiUserError, "%s (%q) is ill-formed: %v", key, input, ErrorMatcher{domainexp.ErrUTF8}).AnyTimes()
 		mockPP.EXPECT().Noticef(pp.EmojiUserError, `%s (%q) has unexpected token %q`, key, input, gomock.Any()).AnyTimes()
-		mockPP.EXPECT().Noticef(pp.EmojiUserError, `%s (%q) contains an ill-formed domain %q: %v`, key, input, gomock.Any(), gomock.Any()).AnyTimes() //nolint:lll
-		mockPP.EXPECT().Noticef(pp.EmojiUserError, `%s (%q) is missing a comma "," before %q`, key, input, gomock.Any()).AnyTimes()                   //nolint:lll
+		mockPP.EXPECT().Noticef(pp.EmojiUserError, `%s (%q) contains an ill-formed domain %q: %v`, key, input, gomock.Any(), gomock.Any()).AnyTimes()
+		mockPP.EXPECT().Noticef(pp.EmojiUserError, `%s (%q) is missing a comma "," before %q`, key, input, gomock.Any()).AnyTimes()
 
 		_, _ = domainexp.ParseList(mockPP, key, input)
 	})
@@ -50,14 +50,14 @@ func FuzzParseExpression(f *testing.F) {
 		mockPP := mocks.NewMockPP(mockCtrl)
 		mockPP.EXPECT().Noticef(pp.EmojiUserError, `%s (%q) is ill-formed: %v`, key, input, domainexp.ErrSingleAnd).AnyTimes()
 		mockPP.EXPECT().Noticef(pp.EmojiUserError, `%s (%q) is ill-formed: %v`, key, input, domainexp.ErrSingleOr).AnyTimes()
-		mockPP.EXPECT().Noticef(pp.EmojiUserError, "%s (%q) is ill-formed: %v", key, input, ErrorMatcher{domainexp.ErrUTF8}).AnyTimes() //nolint:lll
+		mockPP.EXPECT().Noticef(pp.EmojiUserError, "%s (%q) is ill-formed: %v", key, input, ErrorMatcher{domainexp.ErrUTF8}).AnyTimes()
 		mockPP.EXPECT().Noticef(pp.EmojiUserError, `%s (%q) has unexpected token %q`, key, input, gomock.Any()).AnyTimes()
-		mockPP.EXPECT().Noticef(pp.EmojiUserError, `%s (%q) has unexpected token %q when %q is expected`, key, input, gomock.Any(), gomock.Any()).AnyTimes() //nolint:lll
+		mockPP.EXPECT().Noticef(pp.EmojiUserError, `%s (%q) has unexpected token %q when %q is expected`, key, input, gomock.Any(), gomock.Any()).AnyTimes()
 		mockPP.EXPECT().Noticef(pp.EmojiUserError, `%s (%q) is missing %q at the end`, key, input, gomock.Any()).AnyTimes()
-		mockPP.EXPECT().Noticef(pp.EmojiUserError, `%s (%q) is not a boolean expression: got unexpected token %q`, key, input, gomock.Any()).AnyTimes() //nolint:lll
+		mockPP.EXPECT().Noticef(pp.EmojiUserError, `%s (%q) is not a boolean expression: got unexpected token %q`, key, input, gomock.Any()).AnyTimes()
 		mockPP.EXPECT().Noticef(pp.EmojiUserError, `%s (%q) is not a boolean expression`, key, input).AnyTimes()
-		mockPP.EXPECT().Noticef(pp.EmojiUserError, `%s (%q) contains an ill-formed domain %q: %v`, key, input, gomock.Any(), gomock.Any()).AnyTimes() //nolint:lll
-		mockPP.EXPECT().Noticef(pp.EmojiUserError, `%s (%q) is missing a comma "," before %q`, key, input, gomock.Any()).AnyTimes()                   //nolint:lll
+		mockPP.EXPECT().Noticef(pp.EmojiUserError, `%s (%q) contains an ill-formed domain %q: %v`, key, input, gomock.Any(), gomock.Any()).AnyTimes()
+		mockPP.EXPECT().Noticef(pp.EmojiUserError, `%s (%q) is missing a comma "," before %q`, key, input, gomock.Any()).AnyTimes()
 
 		_, _ = domainexp.ParseExpression(mockPP, key, input)
 	})


### PR DESCRIPTION
I'm getting tired of the `lll` linter for `*_test.go` files :upside_down_face: