### PR TITLE
feat: update only IPv6 prefix

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -54,7 +54,7 @@ jobs:
       group: ${{ github.workflow }}-fuzz-${{ github.ref }}
       cancel-in-progress: true
     env:
-      FUZZTIME: "60s"
+      FUZZTIME: "45s"
     steps:
       - name: 🛡️ Harden Runner
         uses: step-security/harden-runner@cb605e52c26070c328afc4562f0b4ada7618a84e # v2.10.4
@@ -73,7 +73,8 @@ jobs:
           go-version: stable
       - name: 🧪 Run `go test`
         run: |
-          go test ./test/fuzzer -fuzztime ${{ env.FUZZTIME }} -fuzz FuzzParseList
+          go test ./test/fuzzer -fuzztime ${{ env.FUZZTIME }} -fuzz FuzzParseDomainList
+          go test ./test/fuzzer -fuzztime ${{ env.FUZZTIME }} -fuzz FuzzParseDomainHostIDList
           go test ./test/fuzzer -fuzztime ${{ env.FUZZTIME }} -fuzz FuzzParseExpression
   regenerate:
     name: Regenerate

--- a/internal/api/cloudflare_waf.go
+++ b/internal/api/cloudflare_waf.go
@@ -12,19 +12,21 @@ import (
 	"github.com/favonia/cloudflare-ddns/internal/pp"
 )
 
-// WAFListMaxBitLen records the maximum number of bits of an IP range/address
-// Cloudflare can support in a WAF list.
+// WAFListMinPrefixLen and WAFListMaxPrefixLen record the minimum and maximum
+// numbers of bits of an IP range Cloudflare can support in a WAF list.
 //
 // According to the Cloudflare docs, an IP range/address in a list must be
 // in one of the following formats:
 // - An individual IPv4 address
 // - An IPv4 CIDR ranges with a prefix from /8 to /32
-// - An IPv6 CIDR ranges with a prefix from /4 to /64
+// - An IPv6 CIDR ranges with a prefix from /12 to /64
 // For this updater, only the maximum values matter.
-var WAFListMaxBitLen = map[ipnet.Type]int{ //nolint:gochecknoglobals
-	ipnet.IP4: 32,
-	ipnet.IP6: 64,
-}
+//
+//nolint:gochecknoglobals
+var (
+	WAFListMinPrefixLen = map[ipnet.Type]int{ipnet.IP4: 8, ipnet.IP6: 12}
+	WAFListMaxPrefixLen = map[ipnet.Type]int{ipnet.IP4: 32, ipnet.IP6: 64}
+)
 
 func hintWAFListPermission(ppfmt pp.PP, err error) {
 	var authentication *cloudflare.AuthenticationError

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -19,7 +19,10 @@ type Config struct {
 	Auth               api.Auth
 	Provider           map[ipnet.Type]provider.Provider
 	Domains            map[ipnet.Type][]domain.Domain
+	IP6PrefixLen       int
+	IP6HostID          map[domain.Domain]ipnet.HostID
 	WAFLists           []api.WAFList
+	WAFListPrefixLen   map[ipnet.Type]int
 	UpdateCron         cron.Schedule
 	UpdateOnStart      bool
 	DeleteOnStop       bool
@@ -47,7 +50,13 @@ func Default() *Config {
 			ipnet.IP4: nil,
 			ipnet.IP6: nil,
 		},
-		WAFLists:           nil,
+		IP6PrefixLen: 64,
+		IP6HostID:    map[domain.Domain]ipnet.HostID{},
+		WAFLists:     nil,
+		WAFListPrefixLen: map[ipnet.Type]int{
+			ipnet.IP4: 32,
+			ipnet.IP6: 64,
+		},
 		UpdateCron:         cron.MustNew("@every 5m"),
 		UpdateOnStart:      true,
 		DeleteOnStop:       false,

--- a/internal/config/config_read_test.go
+++ b/internal/config/config_read_test.go
@@ -24,6 +24,7 @@ func unsetAll(t *testing.T) {
 		"CF_API_TOKEN", "CF_API_TOKEN_FILE", "CF_ACCOUNT_ID",
 		"IP4_PROVIDER", "IP6_PROVIDER",
 		"DOMAINS", "IP4_DOMAINS", "IP6_DOMAINS", "WAF_LISTS",
+		"IP6_PREFIX_LEN",
 		"UPDATE_CRON",
 		"UPDATE_ON_START",
 		"DELETE_ON_STOP",
@@ -38,6 +39,13 @@ func unsetAll(t *testing.T) {
 		"UPTIMEKUMA",
 		"SHOUTRRR",
 	)
+}
+
+func TestConstant(t *testing.T) {
+	t.Parallel()
+	// The normalization code assumes these constants. It may require updates.
+	require.Equal(t, 12, api.WAFListMinPrefixLen[ipnet.IP6])
+	require.Equal(t, 64, api.WAFListMaxPrefixLen[ipnet.IP6])
 }
 
 //nolint:paralleltest // environment variables are global
@@ -56,6 +64,7 @@ func TestReadEnvWithOnlyToken(t *testing.T) {
 		mockPP.EXPECT().Indent().Return(innerMockPP),
 		innerMockPP.EXPECT().Infof(pp.EmojiBullet, "Use default %s=%s", "IP4_PROVIDER", "none"),
 		innerMockPP.EXPECT().Infof(pp.EmojiBullet, "Use default %s=%s", "IP6_PROVIDER", "none"),
+		innerMockPP.EXPECT().Infof(pp.EmojiBullet, "Use default %s=%d", "IP6_PREFIX_LEN", 0),
 		innerMockPP.EXPECT().Infof(pp.EmojiBullet, "Use default %s=%s", "UPDATE_CRON", "@once"),
 		innerMockPP.EXPECT().Infof(pp.EmojiBullet, "Use default %s=%t", "UPDATE_ON_START", false),
 		innerMockPP.EXPECT().Infof(pp.EmojiBullet, "Use default %s=%t", "DELETE_ON_STOP", false),
@@ -101,6 +110,7 @@ func TestNormalize(t *testing.T) {
 	}{
 		"nothing-to-do": {
 			input: &config.Config{ //nolint:exhaustruct
+				IP6PrefixLen: 64,
 			},
 			ok:       false,
 			expected: nil,
@@ -113,11 +123,12 @@ func TestNormalize(t *testing.T) {
 				)
 			},
 		},
-		"once/update-on-start": {
+		"update-cron-once/update-on-start": {
 			input: &config.Config{ //nolint:exhaustruct
 				Domains: map[ipnet.Type][]domain.Domain{
 					ipnet.IP4: {domain.FQDN("a.b.c")},
 				},
+				IP6PrefixLen:  64,
 				UpdateOnStart: false,
 			},
 			ok:       false,
@@ -131,11 +142,12 @@ func TestNormalize(t *testing.T) {
 				)
 			},
 		},
-		"once/delete-on-stop": {
+		"update-cron-once/delete-on-stop": {
 			input: &config.Config{ //nolint:exhaustruct
 				Domains: map[ipnet.Type][]domain.Domain{
 					ipnet.IP4: {domain.FQDN("a.b.c")},
 				},
+				IP6PrefixLen:  64,
 				DeleteOnStop:  true,
 				UpdateOnStart: true,
 			},
@@ -150,9 +162,8 @@ func TestNormalize(t *testing.T) {
 				)
 			},
 		},
-		"nilprovider": {
+		"nil-provider": {
 			input: &config.Config{ //nolint:exhaustruct
-				UpdateOnStart: true,
 				Provider: map[ipnet.Type]provider.Provider{
 					ipnet.IP4: nil,
 					ipnet.IP6: nil,
@@ -160,6 +171,8 @@ func TestNormalize(t *testing.T) {
 				Domains: map[ipnet.Type][]domain.Domain{
 					ipnet.IP4: {domain.FQDN("a.b.c")},
 				},
+				IP6PrefixLen:    64,
+				UpdateOnStart:   true,
 				ProxiedTemplate: "false",
 			},
 			ok:       false,
@@ -173,9 +186,8 @@ func TestNormalize(t *testing.T) {
 				)
 			},
 		},
-		"dns6empty": {
+		"dns6-empty": {
 			input: &config.Config{ //nolint:exhaustruct
-				UpdateOnStart: true,
 				Provider: map[ipnet.Type]provider.Provider{
 					ipnet.IP4: provider.NewCloudflareTrace(),
 					ipnet.IP6: provider.NewCloudflareTrace(),
@@ -183,19 +195,24 @@ func TestNormalize(t *testing.T) {
 				Domains: map[ipnet.Type][]domain.Domain{
 					ipnet.IP4: {domain.FQDN("a.b.c")},
 				},
+				IP6PrefixLen:     64,
+				UpdateOnStart:    true,
 				ProxiedTemplate:  "false",
 				DetectionTimeout: 5 * time.Second,
 			},
 			ok: true,
 			expected: &config.Config{ //nolint:exhaustruct
-				UpdateOnStart: true,
 				Provider: map[ipnet.Type]provider.Provider{
 					ipnet.IP4: provider.NewCloudflareTrace(),
 				},
 				Domains: map[ipnet.Type][]domain.Domain{
 					ipnet.IP4: {domain.FQDN("a.b.c")},
 				},
-				ProxiedTemplate: "false",
+				IP6PrefixLen:     64,
+				IP6HostID:        map[domain.Domain]ipnet.HostID{},
+				WAFListPrefixLen: map[ipnet.Type]int{},
+				UpdateOnStart:    true,
+				ProxiedTemplate:  "false",
 				Proxied: map[domain.Domain]bool{
 					domain.FQDN("a.b.c"): false,
 				},
@@ -210,15 +227,16 @@ func TestNormalize(t *testing.T) {
 				)
 			},
 		},
-		"dns6empty-ip4none": {
+		"dns6-empty/ip4-none": {
 			input: &config.Config{ //nolint:exhaustruct
-				UpdateOnStart: true,
 				Provider: map[ipnet.Type]provider.Provider{
 					ipnet.IP6: provider.NewCloudflareTrace(),
 				},
 				Domains: map[ipnet.Type][]domain.Domain{
 					ipnet.IP4: {domain.FQDN("a.b.c")},
 				},
+				IP6PrefixLen:  64,
+				UpdateOnStart: true,
 			},
 			ok:       false,
 			expected: nil,
@@ -232,9 +250,8 @@ func TestNormalize(t *testing.T) {
 				)
 			},
 		},
-		"ip4none": {
+		"ip4-none": {
 			input: &config.Config{ //nolint:exhaustruct
-				UpdateOnStart: true,
 				Provider: map[ipnet.Type]provider.Provider{
 					ipnet.IP6: provider.NewCloudflareTrace(),
 				},
@@ -242,12 +259,13 @@ func TestNormalize(t *testing.T) {
 					ipnet.IP4: {domain.FQDN("a.b.c"), domain.FQDN("d.e.f")},
 					ipnet.IP6: {domain.FQDN("a.b.c"), domain.FQDN("g.h.i")},
 				},
+				IP6PrefixLen:     64,
+				UpdateOnStart:    true,
 				ProxiedTemplate:  "false",
 				DetectionTimeout: 5 * time.Second,
 			},
 			ok: true,
 			expected: &config.Config{ //nolint:exhaustruct
-				UpdateOnStart: true,
 				Provider: map[ipnet.Type]provider.Provider{
 					ipnet.IP6: provider.NewCloudflareTrace(),
 				},
@@ -255,7 +273,11 @@ func TestNormalize(t *testing.T) {
 					ipnet.IP4: {domain.FQDN("a.b.c"), domain.FQDN("d.e.f")},
 					ipnet.IP6: {domain.FQDN("a.b.c"), domain.FQDN("g.h.i")},
 				},
-				ProxiedTemplate: "false",
+				IP6PrefixLen:     64,
+				IP6HostID:        map[domain.Domain]ipnet.HostID{},
+				WAFListPrefixLen: map[ipnet.Type]int{},
+				UpdateOnStart:    true,
+				ProxiedTemplate:  "false",
 				Proxied: map[domain.Domain]bool{
 					domain.FQDN("a.b.c"): false,
 					domain.FQDN("g.h.i"): false,
@@ -267,18 +289,267 @@ func TestNormalize(t *testing.T) {
 					m.EXPECT().IsShowing(pp.Info).Return(true),
 					m.EXPECT().Infof(pp.EmojiEnvVars, "Checking settings . . ."),
 					m.EXPECT().Indent().Return(m),
-					m.EXPECT().Noticef(pp.EmojiUserWarning, "Domain %q is ignored because it is only for %s but %s is disabled", "d.e.f", "IPv4", "IPv4"),
+					m.EXPECT().Noticef(pp.EmojiUserWarning, "The domain %q is ignored because it is only for %s but %s is disabled", "d.e.f", "IPv4", "IPv4"),
 				)
 			},
 		},
-		"ignored/dns": {
+		"host": {
 			input: &config.Config{ //nolint:exhaustruct
-				UpdateOnStart: true,
+				Provider: map[ipnet.Type]provider.Provider{
+					ipnet.IP4: provider.NewCloudflareTrace(),
+					ipnet.IP6: provider.NewCloudflareTrace(),
+				},
+				Domains: map[ipnet.Type][]domain.Domain{
+					ipnet.IP4: {domain.FQDN("a.b.c"), domain.FQDN("d.e.f")},
+					ipnet.IP6: {domain.FQDN("a.b.c"), domain.FQDN("g.h.i"), domain.FQDN("j.k.l"), domain.FQDN("m.n.o")},
+				},
+				IP6PrefixLen: 56,
+				IP6HostID: map[domain.Domain]ipnet.HostID{
+					domain.FQDN("a.b.c"): ipnet.IP6Suffix{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15},
+					domain.FQDN("g.h.i"): ipnet.EUI48{0, 1, 2, 3, 4, 5},
+					domain.FQDN("j.k.l"): nil,
+				},
+				UpdateOnStart:    true,
+				ProxiedTemplate:  "false",
+				TTL:              api.TTLAuto,
+				DetectionTimeout: 5 * time.Second,
+			},
+			ok: true,
+			expected: &config.Config{ //nolint:exhaustruct
+				Provider: map[ipnet.Type]provider.Provider{
+					ipnet.IP4: provider.NewCloudflareTrace(),
+					ipnet.IP6: provider.NewCloudflareTrace(),
+				},
+				Domains: map[ipnet.Type][]domain.Domain{
+					ipnet.IP4: {domain.FQDN("a.b.c"), domain.FQDN("d.e.f")},
+					ipnet.IP6: {domain.FQDN("a.b.c"), domain.FQDN("g.h.i"), domain.FQDN("j.k.l"), domain.FQDN("m.n.o")},
+				},
+				IP6PrefixLen:     56,
+				WAFListPrefixLen: map[ipnet.Type]int{},
+				IP6HostID: map[domain.Domain]ipnet.HostID{
+					domain.FQDN("a.b.c"): ipnet.IP6Suffix{0, 0, 0, 0, 0, 0, 0, 7, 8, 9, 10, 11, 12, 13, 14, 15},
+					domain.FQDN("g.h.i"): ipnet.EUI48{0, 1, 2, 3, 4, 5},
+				},
+				UpdateOnStart:   true,
+				ProxiedTemplate: "false",
+				Proxied: map[domain.Domain]bool{
+					domain.FQDN("a.b.c"): false,
+					domain.FQDN("d.e.f"): false,
+					domain.FQDN("g.h.i"): false,
+					domain.FQDN("j.k.l"): false,
+					domain.FQDN("m.n.o"): false,
+				},
+				TTL:              api.TTLAuto,
+				DetectionTimeout: 5 * time.Second,
+			},
+			prepareMockPP: func(m *mocks.MockPP) {
+				gomock.InOrder(
+					m.EXPECT().IsShowing(pp.Info).Return(true),
+					m.EXPECT().Infof(pp.EmojiEnvVars, "Checking settings . . ."),
+					m.EXPECT().Indent().Return(m),
+					m.EXPECT().Infof(pp.EmojiTruncate, "The host ID %q of %q was truncated to %q (with %d higher bits removed)", "1:203:405:607:809:a0b:c0d:e0f", "a.b.c", "::7:809:a0b:c0d:e0f", 56),
+				)
+			},
+		},
+		"host/large-prefix-len": {
+			input: &config.Config{ //nolint:exhaustruct
+				Provider: map[ipnet.Type]provider.Provider{
+					ipnet.IP4: provider.NewCloudflareTrace(),
+					ipnet.IP6: provider.NewCloudflareTrace(),
+				},
+				Domains: map[ipnet.Type][]domain.Domain{
+					ipnet.IP4: {domain.FQDN("a.b.c"), domain.FQDN("d.e.f")},
+					ipnet.IP6: {domain.FQDN("a.b.c"), domain.FQDN("g.h.i")},
+				},
+				IP6PrefixLen: 96,
+				IP6HostID: map[domain.Domain]ipnet.HostID{
+					domain.FQDN("a.b.c"): ipnet.IP6Suffix{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15},
+					domain.FQDN("g.h.i"): ipnet.EUI48{0, 1, 2, 3, 4, 5},
+				},
+				UpdateOnStart:    true,
+				ProxiedTemplate:  "false",
+				TTL:              api.TTLAuto,
+				DetectionTimeout: 5 * time.Second,
+			},
+			ok:       false,
+			expected: nil,
+			prepareMockPP: func(m *mocks.MockPP) {
+				gomock.InOrder(
+					m.EXPECT().IsShowing(pp.Info).Return(true),
+					m.EXPECT().Infof(pp.EmojiEnvVars, "Checking settings . . ."),
+					m.EXPECT().Indent().Return(m),
+					m.EXPECT().Infof(pp.EmojiTruncate, "The host ID %q of %q was truncated to %q (with %d higher bits removed)", "1:203:405:607:809:a0b:c0d:e0f", "a.b.c", "::c0d:e0f", 96),
+					m.EXPECT().Noticef(pp.EmojiUserError, "IP6_PREFIX_LEN (%d) is too large (> 64) to use the MAC (EUI-48) address %q as the IPv6 host ID of %q. Converting a MAC address to a host ID requires IPv6 Stateless Address Auto-configuration (SLAAC), which necessitates an IPv6 range of size at least /64 (represented by a prefix length at most 64).", 96, "00:01:02:03:04:05", "g.h.i"),
+				)
+			},
+		},
+		"host/no-ip6-provider": {
+			input: &config.Config{ //nolint:exhaustruct
+				Provider: map[ipnet.Type]provider.Provider{
+					ipnet.IP4: provider.NewCloudflareTrace(),
+				},
+				Domains: map[ipnet.Type][]domain.Domain{
+					ipnet.IP4: {domain.FQDN("a.b.c")},
+					ipnet.IP6: {domain.FQDN("a.b.c"), domain.FQDN("d.e.f")},
+				},
+				IP6PrefixLen: 60,
+				IP6HostID: map[domain.Domain]ipnet.HostID{
+					domain.FQDN("a.b.c"): ipnet.EUI48{0, 1, 2, 3, 4, 5},
+					domain.FQDN("d.e.f"): ipnet.EUI48{6, 7, 8, 9, 10, 11},
+				},
+				UpdateOnStart:    true,
+				ProxiedTemplate:  "false",
+				TTL:              api.TTLAuto,
+				DetectionTimeout: 5 * time.Second,
+			},
+			ok: true,
+			expected: &config.Config{ //nolint:exhaustruct
+				Provider: map[ipnet.Type]provider.Provider{
+					ipnet.IP4: provider.NewCloudflareTrace(),
+				},
+				Domains: map[ipnet.Type][]domain.Domain{
+					ipnet.IP4: {domain.FQDN("a.b.c")},
+					ipnet.IP6: {domain.FQDN("a.b.c"), domain.FQDN("d.e.f")},
+				},
+				IP6PrefixLen:     60,
+				IP6HostID:        map[domain.Domain]ipnet.HostID{},
+				WAFListPrefixLen: map[ipnet.Type]int{},
+				UpdateOnStart:    true,
+				ProxiedTemplate:  "false",
+				Proxied: map[domain.Domain]bool{
+					domain.FQDN("a.b.c"): false,
+				},
+				TTL:              api.TTLAuto,
+				DetectionTimeout: 5 * time.Second,
+			},
+			prepareMockPP: func(m *mocks.MockPP) {
+				gomock.InOrder(
+					m.EXPECT().IsShowing(pp.Info).Return(true),
+					m.EXPECT().Infof(pp.EmojiEnvVars, "Checking settings . . ."),
+					m.EXPECT().Indent().Return(m),
+					m.EXPECT().Noticef(pp.EmojiUserWarning, "The domain %q is ignored because it is only for %s but %s is disabled", "d.e.f", "IPv6", "IPv6"),
+					m.EXPECT().Noticef(pp.EmojiUserWarning, "The host ID %q of %q is ignored because IPv6 is disabled", "00:01:02:03:04:05", "a.b.c"),
+					m.EXPECT().Noticef(pp.EmojiUserWarning, "IP6_PREFIX_LEN=%d is ignored because no domains use IPv6 host IDs", 60),
+				)
+			},
+		},
+		"waf": {
+			input: &config.Config{ //nolint:exhaustruct
+				Provider: map[ipnet.Type]provider.Provider{
+					ipnet.IP4: provider.NewCloudflareTrace(),
+					ipnet.IP6: provider.NewCloudflareTrace(),
+				},
+				Domains:            map[ipnet.Type][]domain.Domain{},
+				WAFLists:           []api.WAFList{{AccountID: "account", Name: "list"}},
+				IP6PrefixLen:       64,
+				UpdateOnStart:      true,
+				ProxiedTemplate:    "false",
+				TTL:                api.TTLAuto,
+				WAFListDescription: "My list",
+				DetectionTimeout:   5 * time.Second,
+			},
+			ok: true,
+			expected: &config.Config{ //nolint:exhaustruct
+				Provider: map[ipnet.Type]provider.Provider{
+					ipnet.IP4: provider.NewCloudflareTrace(),
+					ipnet.IP6: provider.NewCloudflareTrace(),
+				},
+				Domains:            map[ipnet.Type][]domain.Domain{},
+				WAFLists:           []api.WAFList{{AccountID: "account", Name: "list"}},
+				IP6PrefixLen:       64,
+				IP6HostID:          map[domain.Domain]ipnet.HostID{},
+				WAFListPrefixLen:   map[ipnet.Type]int{ipnet.IP4: 32, ipnet.IP6: 64},
+				UpdateOnStart:      true,
+				ProxiedTemplate:    "false",
+				Proxied:            map[domain.Domain]bool{},
+				TTL:                api.TTLAuto,
+				WAFListDescription: "My list",
+				DetectionTimeout:   5 * time.Second,
+			},
+			prepareMockPP: func(m *mocks.MockPP) {
+				gomock.InOrder(
+					m.EXPECT().IsShowing(pp.Info).Return(true),
+					m.EXPECT().Infof(pp.EmojiEnvVars, "Checking settings . . ."),
+					m.EXPECT().Indent().Return(m),
+				)
+			},
+		},
+		"waf/large-prefix-len": {
+			input: &config.Config{ //nolint:exhaustruct
+				Provider: map[ipnet.Type]provider.Provider{
+					ipnet.IP6: provider.NewCloudflareTrace(),
+				},
+				Domains:            map[ipnet.Type][]domain.Domain{},
+				WAFLists:           []api.WAFList{{AccountID: "account", Name: "list"}},
+				IP6PrefixLen:       96,
+				UpdateOnStart:      true,
+				ProxiedTemplate:    "false",
+				TTL:                api.TTLAuto,
+				WAFListDescription: "My list",
+				DetectionTimeout:   5 * time.Second,
+			},
+			ok: true,
+			expected: &config.Config{ //nolint:exhaustruct
+				Provider: map[ipnet.Type]provider.Provider{
+					ipnet.IP6: provider.NewCloudflareTrace(),
+				},
+				Domains:            map[ipnet.Type][]domain.Domain{},
+				WAFLists:           []api.WAFList{{AccountID: "account", Name: "list"}},
+				IP6PrefixLen:       96,
+				IP6HostID:          map[domain.Domain]ipnet.HostID{},
+				WAFListPrefixLen:   map[ipnet.Type]int{ipnet.IP6: 64},
+				UpdateOnStart:      true,
+				ProxiedTemplate:    "false",
+				Proxied:            map[domain.Domain]bool{},
+				TTL:                api.TTLAuto,
+				WAFListDescription: "My list",
+				DetectionTimeout:   5 * time.Second,
+			},
+			prepareMockPP: func(m *mocks.MockPP) {
+				gomock.InOrder(
+					m.EXPECT().IsShowing(pp.Info).Return(true),
+					m.EXPECT().Infof(pp.EmojiEnvVars, "Checking settings . . ."),
+					m.EXPECT().Indent().Return(m),
+					m.EXPECT().Noticef(pp.EmojiUserWarning, "The detected IPv6 range in WAF lists will be forced to have a prefix length of 64 (instead of IP6_PREFIX_LEN (%d)) due to Cloudflare's limitations", 96),
+				)
+			},
+		},
+		"waf/small-prefix-len": {
+			input: &config.Config{ //nolint:exhaustruct
+				Provider: map[ipnet.Type]provider.Provider{
+					ipnet.IP6: provider.NewCloudflareTrace(),
+				},
+				Domains:            map[ipnet.Type][]domain.Domain{},
+				WAFLists:           []api.WAFList{{AccountID: "account", Name: "list"}},
+				IP6PrefixLen:       10,
+				UpdateOnStart:      true,
+				ProxiedTemplate:    "false",
+				TTL:                api.TTLAuto,
+				WAFListDescription: "My list",
+				DetectionTimeout:   5 * time.Second,
+			},
+			ok:       false,
+			expected: nil,
+			prepareMockPP: func(m *mocks.MockPP) {
+				gomock.InOrder(
+					m.EXPECT().IsShowing(pp.Info).Return(true),
+					m.EXPECT().Infof(pp.EmojiEnvVars, "Checking settings . . ."),
+					m.EXPECT().Indent().Return(m),
+					m.EXPECT().Noticef(pp.EmojiUserError, "WAF lists do not support IPv6 ranges with a prefix length as small as IP6_PREFIX_LEN (%d); it must be at least 12", 10),
+				)
+			},
+		},
+		"dns-ignored-params": {
+			input: &config.Config{ //nolint:exhaustruct
 				Provider: map[ipnet.Type]provider.Provider{
 					ipnet.IP6: provider.NewCloudflareTrace(),
 				},
 				Domains:          map[ipnet.Type][]domain.Domain{},
+				IP6PrefixLen:     64,
+				IP6HostID:        map[domain.Domain]ipnet.HostID{},
 				WAFLists:         []api.WAFList{{AccountID: "account", Name: "list"}},
+				WAFListPrefixLen: map[ipnet.Type]int{},
+				UpdateOnStart:    true,
 				TTL:              10000,
 				ProxiedTemplate:  "true",
 				RecordComment:    "hello",
@@ -286,12 +557,15 @@ func TestNormalize(t *testing.T) {
 			},
 			ok: true,
 			expected: &config.Config{ //nolint:exhaustruct
-				UpdateOnStart: true,
 				Provider: map[ipnet.Type]provider.Provider{
 					ipnet.IP6: provider.NewCloudflareTrace(),
 				},
 				Domains:          map[ipnet.Type][]domain.Domain{},
+				IP6PrefixLen:     64,
+				IP6HostID:        map[domain.Domain]ipnet.HostID{},
 				WAFLists:         []api.WAFList{{AccountID: "account", Name: "list"}},
+				WAFListPrefixLen: map[ipnet.Type]int{ipnet.IP6: 64},
+				UpdateOnStart:    true,
 				TTL:              10000,
 				ProxiedTemplate:  "true",
 				Proxied:          map[domain.Domain]bool{},
@@ -303,38 +577,42 @@ func TestNormalize(t *testing.T) {
 					m.EXPECT().IsShowing(pp.Info).Return(true),
 					m.EXPECT().Infof(pp.EmojiEnvVars, "Checking settings . . ."),
 					m.EXPECT().Indent().Return(m),
-					m.EXPECT().Noticef(pp.EmojiUserWarning, "TTL=%v is ignored because no domains will be updated", api.TTL(10000)),
+					m.EXPECT().Noticef(pp.EmojiUserWarning, "TTL=%d is ignored because no domains will be updated", 10000),
 					m.EXPECT().Noticef(pp.EmojiUserWarning, "PROXIED=%s is ignored because no domains will be updated", "true"),
 					m.EXPECT().Noticef(pp.EmojiUserWarning, "RECORD_COMMENT=%s is ignored because no domains will be updated", "hello"),
 				)
 			},
 		},
-		"ignored/waf": {
+		"waf-ignored-comment": {
 			input: &config.Config{ //nolint:exhaustruct
-				UpdateOnStart: true,
 				Provider: map[ipnet.Type]provider.Provider{
 					ipnet.IP6: provider.NewCloudflareTrace(),
 				},
 				Domains: map[ipnet.Type][]domain.Domain{
 					ipnet.IP6: {domain.FQDN("a.b.c")},
 				},
+				IP6PrefixLen:    64,
 				ProxiedTemplate: "true",
 				Proxied: map[domain.Domain]bool{
 					domain.FQDN("a.b.c"): true,
 				},
 				WAFListDescription: "My list",
+				UpdateOnStart:      true,
 				DetectionTimeout:   5 * time.Second,
 			},
 			ok: true,
 			expected: &config.Config{ //nolint:exhaustruct
-				UpdateOnStart: true,
 				Provider: map[ipnet.Type]provider.Provider{
 					ipnet.IP6: provider.NewCloudflareTrace(),
 				},
 				Domains: map[ipnet.Type][]domain.Domain{
 					ipnet.IP6: {domain.FQDN("a.b.c")},
 				},
-				ProxiedTemplate: "true",
+				IP6PrefixLen:     64,
+				IP6HostID:        map[domain.Domain]ipnet.HostID{},
+				WAFListPrefixLen: map[ipnet.Type]int{},
+				UpdateOnStart:    true,
+				ProxiedTemplate:  "true",
 				Proxied: map[domain.Domain]bool{
 					domain.FQDN("a.b.c"): true,
 				},
@@ -352,26 +630,31 @@ func TestNormalize(t *testing.T) {
 		},
 		"proxied": {
 			input: &config.Config{ //nolint:exhaustruct
-				UpdateOnStart: true,
 				Provider: map[ipnet.Type]provider.Provider{
 					ipnet.IP6: provider.NewCloudflareTrace(),
 				},
 				Domains: map[ipnet.Type][]domain.Domain{
 					ipnet.IP6: {domain.FQDN("a.b.c"), domain.FQDN("a.bb.c"), domain.FQDN("a.d.e.f")},
 				},
+				IP6PrefixLen:     64,
+				WAFListPrefixLen: map[ipnet.Type]int{},
+				UpdateOnStart:    true,
 				ProxiedTemplate:  ` true && !is(a.bb.c) `,
 				DetectionTimeout: 5 * time.Second,
 			},
 			ok: true,
 			expected: &config.Config{ //nolint:exhaustruct
-				UpdateOnStart: true,
 				Provider: map[ipnet.Type]provider.Provider{
 					ipnet.IP6: provider.NewCloudflareTrace(),
 				},
 				Domains: map[ipnet.Type][]domain.Domain{
 					ipnet.IP6: {domain.FQDN("a.b.c"), domain.FQDN("a.bb.c"), domain.FQDN("a.d.e.f")},
 				},
-				ProxiedTemplate: ` true && !is(a.bb.c) `,
+				IP6PrefixLen:     64,
+				IP6HostID:        map[domain.Domain]ipnet.HostID{},
+				WAFListPrefixLen: map[ipnet.Type]int{},
+				UpdateOnStart:    true,
+				ProxiedTemplate:  ` true && !is(a.bb.c) `,
 				Proxied: map[domain.Domain]bool{
 					domain.FQDN("a.b.c"):   true,
 					domain.FQDN("a.bb.c"):  false,
@@ -389,13 +672,14 @@ func TestNormalize(t *testing.T) {
 		},
 		"proxied/invalid/1": {
 			input: &config.Config{ //nolint:exhaustruct
-				UpdateOnStart: true,
 				Provider: map[ipnet.Type]provider.Provider{
 					ipnet.IP6: provider.NewCloudflareTrace(),
 				},
 				Domains: map[ipnet.Type][]domain.Domain{
 					ipnet.IP6: {domain.FQDN("a.b.c"), domain.FQDN("a.bb.c"), domain.FQDN("a.d.e.f")},
 				},
+				IP6PrefixLen:    64,
+				UpdateOnStart:   true,
 				ProxiedTemplate: `range`,
 			},
 			ok:       false,
@@ -411,13 +695,14 @@ func TestNormalize(t *testing.T) {
 		},
 		"proxied/invalid/2": {
 			input: &config.Config{ //nolint:exhaustruct
-				UpdateOnStart: true,
 				Provider: map[ipnet.Type]provider.Provider{
 					ipnet.IP6: provider.NewCloudflareTrace(),
 				},
 				Domains: map[ipnet.Type][]domain.Domain{
 					ipnet.IP6: {domain.FQDN("a.b.c")},
 				},
+				IP6PrefixLen:    64,
+				UpdateOnStart:   true,
 				ProxiedTemplate: `999`,
 			},
 			ok:       false,
@@ -433,13 +718,14 @@ func TestNormalize(t *testing.T) {
 		},
 		"proxied/invalid/3": {
 			input: &config.Config{ //nolint:exhaustruct
-				UpdateOnStart: true,
 				Provider: map[ipnet.Type]provider.Provider{
 					ipnet.IP6: provider.NewCloudflareTrace(),
 				},
 				Domains: map[ipnet.Type][]domain.Domain{
 					ipnet.IP6: {domain.FQDN("a.b.c")},
 				},
+				IP6PrefixLen:    64,
+				UpdateOnStart:   true,
 				ProxiedTemplate: `is(12345`,
 			},
 			ok:       false,

--- a/internal/config/env_base.go
+++ b/internal/config/env_base.go
@@ -116,6 +116,30 @@ func ReadTTL(ppfmt pp.PP, key string, field *api.TTL) bool {
 	}
 }
 
+// ReadIP6PrefixLen reads a valid length of IPv6 prefixes (1 to 128).
+func ReadIP6PrefixLen(ppfmt pp.PP, key string, field *int) bool {
+	val := Getenv(key)
+	if val == "" {
+		ppfmt.Infof(pp.EmojiBullet, "Use default %s=%d", key, *field)
+		return true
+	}
+
+	res, err := strconv.Atoi(val)
+	switch {
+	case err != nil:
+		ppfmt.Noticef(pp.EmojiUserError, "%s (%q) is not a number: %v", key, val, err)
+		return false
+
+	case res < 1 || res > 127:
+		ppfmt.Noticef(pp.EmojiUserError, "%s (%d) must be in the range 1 to 127 (inclusive)", key, res)
+		return false
+
+	default:
+		*field = res
+		return true
+	}
+}
+
 // ReadNonnegDuration reads an environment variable and parses it as a time duration.
 func ReadNonnegDuration(ppfmt pp.PP, key string, field *time.Duration) bool {
 	val := Getenv(key)

--- a/internal/config/env_domain.go
+++ b/internal/config/env_domain.go
@@ -11,7 +11,16 @@ import (
 
 // ReadDomains reads an environment variable as a comma-separated list of domains.
 func ReadDomains(ppfmt pp.PP, key string, field *[]domain.Domain) bool {
-	if list, ok := domainexp.ParseList(ppfmt, key, Getenv(key)); ok {
+	if list, ok := domainexp.ParseDomainList(ppfmt, key, Getenv(key)); ok {
+		*field = list
+		return true
+	}
+	return false
+}
+
+// ReadDomainHostIDs reads an environment variable as a comma-separated list of domains with optional IPv6 host IDs.
+func ReadDomainHostIDs(ppfmt pp.PP, key string, field *[]domainexp.DomainHostID) bool {
+	if list, ok := domainexp.ParseDomainHostIDList(ppfmt, key, Getenv(key)); ok {
 		*field = list
 		return true
 	}
@@ -25,24 +34,62 @@ func deduplicate(list []domain.Domain) []domain.Domain {
 	return slices.Compact(list)
 }
 
+func processDomainHostIDMap(ppfmt pp.PP,
+	hostID map[domain.Domain]ipnet.HostID,
+	domainHostIDs []domainexp.DomainHostID,
+) ([]domain.Domain, bool) {
+	domains := make([]domain.Domain, 0, len(domainHostIDs))
+	for _, dh := range domainHostIDs {
+		domains = append(domains, dh.Domain)
+
+		if dh.HostID == nil {
+			continue
+		}
+
+		if val, ok := hostID[dh.Domain]; ok && val != dh.HostID {
+			ppfmt.Noticef(pp.EmojiUserError,
+				"Domain %q is associated with different host IDs %s and %s",
+				dh.Domain.Describe(), val.Describe(), dh.HostID.Describe(),
+			)
+			return nil, false
+		}
+
+		hostID[dh.Domain] = dh.HostID
+	}
+	return domains, true
+}
+
 // ReadDomainMap reads environment variables DOMAINS, IP4_DOMAINS, and IP6_DOMAINS
 // and consolidate the domains into a map.
-func ReadDomainMap(ppfmt pp.PP, field *map[ipnet.Type][]domain.Domain) bool {
-	var domains, ip4Domains, ip6Domains []domain.Domain
-
+func ReadDomainMap(ppfmt pp.PP,
+	fieldDomains *map[ipnet.Type][]domain.Domain,
+	fieldHostID *map[domain.Domain]ipnet.HostID,
+) bool {
+	var (
+		domains          []domain.Domain
+		ip4Domains       []domain.Domain
+		ip6DomainHostIDs []domainexp.DomainHostID
+	)
 	if !ReadDomains(ppfmt, "DOMAINS", &domains) ||
 		!ReadDomains(ppfmt, "IP4_DOMAINS", &ip4Domains) ||
-		!ReadDomains(ppfmt, "IP6_DOMAINS", &ip6Domains) {
+		!ReadDomainHostIDs(ppfmt, "IP6_DOMAINS", &ip6DomainHostIDs) {
+		return false
+	}
+
+	hostID := map[domain.Domain]ipnet.HostID{}
+	ip6Domains, ok := processDomainHostIDMap(ppfmt, hostID, ip6DomainHostIDs)
+	if !ok {
 		return false
 	}
 
 	ip4Domains = deduplicate(append(ip4Domains, domains...))
 	ip6Domains = deduplicate(append(ip6Domains, domains...))
 
-	*field = map[ipnet.Type][]domain.Domain{
+	*fieldDomains = map[ipnet.Type][]domain.Domain{
 		ipnet.IP4: ip4Domains,
 		ipnet.IP6: ip6Domains,
 	}
+	*fieldHostID = hostID
 
 	return true
 }

--- a/internal/config/env_domain_test.go
+++ b/internal/config/env_domain_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/favonia/cloudflare-ddns/internal/config"
 	"github.com/favonia/cloudflare-ddns/internal/domain"
+	"github.com/favonia/cloudflare-ddns/internal/domainexp"
 	"github.com/favonia/cloudflare-ddns/internal/ipnet"
 	"github.com/favonia/cloudflare-ddns/internal/mocks"
 	"github.com/favonia/cloudflare-ddns/internal/pp"
@@ -39,11 +40,11 @@ func TestReadDomains(t *testing.T) {
 				m.EXPECT().Noticef(pp.EmojiUserError, `%s (%q) contains a domain %q that is probably not fully qualified; a fully qualified domain name (FQDN) would look like "*.example.org" or "sub.example.org"`, key, "*", "*")
 			},
 		},
-		"wildcard1": {true, "*.a", ds{}, ds{w("a")}, true, nil},
-		"wildcard2": {true, "*.a.b", ds{}, ds{w("a.b")}, true, nil},
-		"test1":     {true, "書.org ,  Bücher.org  ", ds{f("random.org")}, ds{f("xn--rov.org"), f("xn--bcher-kva.org")}, true, nil},
-		"test2":     {true, "  \txn--rov.org    ,   xn--Bcher-kva.org  ", ds{f("random.org")}, ds{f("xn--rov.org"), f("xn--bcher-kva.org")}, true, nil},
-		"illformed1": {
+		"wildcard/1": {true, "*.a", ds{}, ds{w("a")}, true, nil},
+		"wildcard/2": {true, "*.a.b", ds{}, ds{w("a.b")}, true, nil},
+		"idn/1":      {true, "書.org ,  Bücher.org  ", ds{f("random.org")}, ds{f("xn--rov.org"), f("xn--bcher-kva.org")}, true, nil},
+		"idn/2":      {true, "  \txn--rov.org    ,   xn--Bcher-kva.org  ", ds{f("random.org")}, ds{f("xn--rov.org"), f("xn--bcher-kva.org")}, true, nil},
+		"ill-formed/1": {
 			true, "xn--:D.org,a.org",
 			ds{f("random.org")},
 			ds{f("random.org")},
@@ -52,7 +53,7 @@ func TestReadDomains(t *testing.T) {
 				m.EXPECT().Noticef(pp.EmojiUserError, "%s (%q) contains an ill-formed domain %q: %v", key, "xn--:D.org,a.org", "xn--:d.org", gomock.Any())
 			},
 		},
-		"illformed2": {
+		"ill-formed/2": {
 			true, "*.xn--:D.org,a.org",
 			ds{f("random.org")},
 			ds{f("random.org")},
@@ -61,7 +62,7 @@ func TestReadDomains(t *testing.T) {
 				m.EXPECT().Noticef(pp.EmojiUserError, "%s (%q) contains an ill-formed domain %q: %v", key, "*.xn--:D.org,a.org", "*.xn--:d.org", gomock.Any())
 			},
 		},
-		"illformed3": {
+		"ill-formed/3": {
 			true, "hi.org,(",
 			ds{},
 			ds{},
@@ -70,7 +71,7 @@ func TestReadDomains(t *testing.T) {
 				m.EXPECT().Noticef(pp.EmojiUserError, "%s (%q) has unexpected token %q", key, "hi.org,(", "(")
 			},
 		},
-		"illformed4": {
+		"ill-formed/4": {
 			true, ")",
 			ds{},
 			ds{},
@@ -97,29 +98,138 @@ func TestReadDomains(t *testing.T) {
 }
 
 //nolint:paralleltest // environment vars are global
-func TestReadDomainMap(t *testing.T) {
+func TestReadDomainHostIDs(t *testing.T) {
+	key := keyPrefix + "IP6_DOMAINS"
+	type h = ipnet.HostID
+	dh := func(d domain.Domain, h h) domainexp.DomainHostID { return domainexp.DomainHostID{Domain: d, HostID: h} }
+	type dhs = []domainexp.DomainHostID
+	type f = domain.FQDN
+	type w = domain.Wildcard
 	for name, tc := range map[string]struct {
-		domains       string
-		ip4Domains    string
-		ip6Domains    string
-		expected      map[ipnet.Type][]domain.Domain
+		set           bool
+		val           string
+		oldField      dhs
+		newField      dhs
 		ok            bool
 		prepareMockPP func(*mocks.MockPP)
 	}{
+		"nil":   {false, "", dhs{dh(f("test.org"), nil)}, dhs{}, true, nil},
+		"empty": {true, "", dhs{dh(f("test.org"), nil)}, dhs{}, true, nil},
+		"star": {
+			true, "*[::1]",
+			dhs{},
+			dhs{},
+			false,
+			func(m *mocks.MockPP) {
+				m.EXPECT().Noticef(pp.EmojiUserError, `%s (%q) contains a domain %q that is probably not fully qualified; a fully qualified domain name (FQDN) would look like "*.example.org" or "sub.example.org"`, key, "*[::1]", "*")
+			},
+		},
+		"wildcard/1": {true, "*.a", dhs{}, dhs{dh(w("a"), nil)}, true, nil},
+		"wildcard/1/host": {
+			true, "*.a[::2]",
+			dhs{},
+			dhs{dh(w("a"), ipnet.IP6Suffix{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0x02})},
+			true, nil,
+		},
+		"wildcard/2": {true, "*.a.b", dhs{}, dhs{dh(w("a.b"), nil)}, true, nil},
+		"idn/1":      {true, "書.org ,  Bücher.org  ", dhs{dh(f("random.org"), nil)}, dhs{dh(f("xn--rov.org"), nil), dh(f("xn--bcher-kva.org"), nil)}, true, nil},
+		"idn/1/host": {
+			true, "書.org [ 01:02:03:04:05:06 ],  Bücher.org [ 0a:0b:0c:0d:0e:0f ] ",
+			dhs{dh(f("random.org"), ipnet.EUI48{0x00, 0x00, 0x00, 0x00, 0x00, 0x00})},
+			dhs{
+				dh(f("xn--rov.org"), ipnet.EUI48{0x01, 0x02, 0x03, 0x04, 0x05, 0x06}),
+				dh(f("xn--bcher-kva.org"), ipnet.EUI48{0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f}),
+			},
+			true, nil,
+		},
+		"idn/2": {true, "  \txn--rov.org    ,   xn--Bcher-kva.org  ", dhs{dh(f("random.org"), nil)}, dhs{dh(f("xn--rov.org"), nil), dh(f("xn--bcher-kva.org"), nil)}, true, nil},
+		"ill-formed/1": {
+			true, "xn--:D.org,a.org",
+			dhs{dh(f("random.org"), nil)},
+			dhs{dh(f("random.org"), nil)},
+			false,
+			func(m *mocks.MockPP) {
+				m.EXPECT().Noticef(pp.EmojiUserError, "%s (%q) contains an ill-formed domain %q: %v", key, "xn--:D.org,a.org", "xn--:d.org", gomock.Any())
+			},
+		},
+		"ill-formed/2": {
+			true, "*.xn--:D.org,a.org",
+			dhs{},
+			dhs{},
+			false,
+			func(m *mocks.MockPP) {
+				m.EXPECT().Noticef(pp.EmojiUserError, "%s (%q) contains an ill-formed domain %q: %v", key, "*.xn--:D.org,a.org", "*.xn--:d.org", gomock.Any())
+			},
+		},
+		"ill-formed/3": {
+			true, "hi.org,(",
+			dhs{},
+			dhs{},
+			false,
+			func(m *mocks.MockPP) {
+				m.EXPECT().Noticef(pp.EmojiUserError, "%s (%q) has unexpected token %q", key, "hi.org,(", "(")
+			},
+		},
+		"ill-formed/4": {
+			true, ")",
+			dhs{},
+			dhs{},
+			false,
+			func(m *mocks.MockPP) {
+				m.EXPECT().Noticef(pp.EmojiUserError, "%s (%q) has unexpected token %q", key, ")", ")")
+			},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			set(t, key, tc.set, tc.val)
+			field := tc.oldField
+			mockCtrl := gomock.NewController(t)
+			mockPP := mocks.NewMockPP(mockCtrl)
+			if tc.prepareMockPP != nil {
+				tc.prepareMockPP(mockPP)
+			}
+
+			ok := config.ReadDomainHostIDs(mockPP, key, &field)
+			require.Equal(t, tc.ok, ok)
+			require.Equal(t, tc.newField, field)
+		})
+	}
+}
+
+//nolint:paralleltest // environment vars are global
+func TestReadDomainMap(t *testing.T) {
+	type h = ipnet.HostID
+	type f = domain.FQDN
+	type w = domain.Wildcard
+	for name, tc := range map[string]struct {
+		domains        string
+		ip4Domains     string
+		ip6Domains     string
+		expectedDomain map[ipnet.Type][]domain.Domain
+		expectedHostID map[domain.Domain]h
+		ok             bool
+		prepareMockPP  func(*mocks.MockPP)
+	}{
 		"full": {
-			"  a1.com, a2.com", "b1.com,  b2.com,b2.com", "c1.com,c2.com",
+			"  a1.com, a2.com", "b1.com,  b2.com,b2.com", "c1.com,c2.com[::1]",
 			map[ipnet.Type][]domain.Domain{
-				ipnet.IP4: {domain.FQDN("a1.com"), domain.FQDN("a2.com"), domain.FQDN("b1.com"), domain.FQDN("b2.com")},
-				ipnet.IP6: {domain.FQDN("a1.com"), domain.FQDN("a2.com"), domain.FQDN("c1.com"), domain.FQDN("c2.com")},
+				ipnet.IP4: {f("a1.com"), f("a2.com"), f("b1.com"), f("b2.com")},
+				ipnet.IP6: {f("a1.com"), f("a2.com"), f("c1.com"), f("c2.com")},
+			},
+			map[domain.Domain]h{
+				f("c2.com"): ipnet.IP6Suffix{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0x01},
 			},
 			true,
 			nil,
 		},
 		"duplicate": {
-			"  a1.com, a1.com", "a1.com,  a1.com,a1.com", "*.a1.com,a1.com,*.a1.com,*.a1.com",
+			"  a1.com, a1.com", "a1.com,  a1.com,a1.com", "*.a1.com,a1.com,*.a1.com[::2],*.a1.com[::0:2]",
 			map[ipnet.Type][]domain.Domain{
-				ipnet.IP4: {domain.FQDN("a1.com")},
-				ipnet.IP6: {domain.FQDN("a1.com"), domain.Wildcard("a1.com")},
+				ipnet.IP4: {f("a1.com")},
+				ipnet.IP6: {f("a1.com"), w("a1.com")},
+			},
+			map[domain.Domain]h{
+				w("a1.com"): ipnet.IP6Suffix{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0x02},
 			},
 			true,
 			nil,
@@ -130,13 +240,20 @@ func TestReadDomainMap(t *testing.T) {
 				ipnet.IP4: {},
 				ipnet.IP6: {},
 			},
+			map[domain.Domain]h{},
 			true,
 			nil,
 		},
 		"ill-formed": {
-			" ", "   ", "*.*", nil, false,
+			" ", "   ", "*.*", nil, nil, false,
 			func(m *mocks.MockPP) {
 				m.EXPECT().Noticef(pp.EmojiUserError, "%s (%q) contains an ill-formed domain %q: %v", "IP6_DOMAINS", "*.*", "*.*", gomock.Any())
+			},
+		},
+		"ill-formed/different-host-ids": {
+			" ", "   ", "a.com[::1],a.com[::2]", nil, nil, false,
+			func(m *mocks.MockPP) {
+				m.EXPECT().Noticef(pp.EmojiUserError, "Domain %q is associated with different host IDs %s and %s", "a.com", "::1", "::2")
 			},
 		},
 	} {
@@ -147,15 +264,17 @@ func TestReadDomainMap(t *testing.T) {
 			store(t, "IP4_DOMAINS", tc.ip4Domains)
 			store(t, "IP6_DOMAINS", tc.ip6Domains)
 
-			var field map[ipnet.Type][]domain.Domain
+			var fieldDomain map[ipnet.Type][]domain.Domain
+			var fieldHostID map[domain.Domain]h
 			mockPP := mocks.NewMockPP(mockCtrl)
 			if tc.prepareMockPP != nil {
 				tc.prepareMockPP(mockPP)
 			}
-			ok := config.ReadDomainMap(mockPP, &field)
+			ok := config.ReadDomainMap(mockPP, &fieldDomain, &fieldHostID)
 			require.Equal(t, tc.ok, ok)
-			require.ElementsMatch(t, tc.expected[ipnet.IP4], field[ipnet.IP4])
-			require.ElementsMatch(t, tc.expected[ipnet.IP6], field[ipnet.IP6])
+			require.ElementsMatch(t, tc.expectedDomain[ipnet.IP4], fieldDomain[ipnet.IP4])
+			require.ElementsMatch(t, tc.expectedDomain[ipnet.IP6], fieldDomain[ipnet.IP6])
+			require.Equal(t, tc.expectedHostID, fieldHostID)
 		})
 	}
 }

--- a/internal/config/env_monitor_test.go
+++ b/internal/config/env_monitor_test.go
@@ -66,7 +66,7 @@ func TestReadAndAppendHealthchecksURL(t *testing.T) {
 				)
 			},
 		},
-		"illformed/not-url": {
+		"ill-formed/not-url": {
 			true, "\001",
 			nil,
 			nil, false,
@@ -74,7 +74,7 @@ func TestReadAndAppendHealthchecksURL(t *testing.T) {
 				m.EXPECT().Noticef(pp.EmojiUserError, `Failed to parse the Healthchecks URL (redacted)`)
 			},
 		},
-		"illformed/not-abs": {
+		"ill-formed/not-abs": {
 			true, "/1234?hello=123",
 			nil,
 			nil, false,
@@ -154,7 +154,7 @@ func TestReadAndAppendUptimeKumaURL(t *testing.T) {
 				m.EXPECT().Noticef(pp.EmojiUserError, `The Uptime Kuma URL (redacted) contains an unexpected query %s=... and it will be ignored`, "hello")
 			},
 		},
-		"illformed/not-url": {
+		"ill-formed/not-url": {
 			true, "\001",
 			nil,
 			nil, false,
@@ -162,7 +162,7 @@ func TestReadAndAppendUptimeKumaURL(t *testing.T) {
 				m.EXPECT().Noticef(pp.EmojiUserError, `Failed to parse the Uptime Kuma URL (redacted)`)
 			},
 		},
-		"illformed/not-abs": {
+		"ill-formed/not-abs": {
 			true, "/1234?hello=123",
 			nil,
 			nil, false,

--- a/internal/domainexp/host.go
+++ b/internal/domainexp/host.go
@@ -1,0 +1,12 @@
+package domainexp
+
+import (
+	"github.com/favonia/cloudflare-ddns/internal/domain"
+	"github.com/favonia/cloudflare-ddns/internal/ipnet"
+)
+
+// DomainHostID is a domain with an (optional) host ID.
+type DomainHostID struct {
+	domain.Domain
+	ipnet.HostID
+}

--- a/internal/domainexp/lexer.go
+++ b/internal/domainexp/lexer.go
@@ -59,7 +59,7 @@ func splitter(data []byte, atEOF bool) (int, []byte, error) {
 			switch {
 			case unicode.IsSpace(ch):
 				startIndex += size
-			case strings.ContainsRune("(),!", ch):
+			case strings.ContainsRune("()[],!", ch):
 				return returnToken()
 			case ch == '&':
 				state = StateAnd0
@@ -79,7 +79,7 @@ func splitter(data []byte, atEOF bool) (int, []byte, error) {
 			}
 			return returnToken()
 		case StateOther:
-			if unicode.IsSpace(ch) || strings.ContainsRune("(),!&|", ch) {
+			if unicode.IsSpace(ch) || strings.ContainsRune("()[],!&|", ch) {
 				if err = reader.UnreadRune(); err != nil {
 					return startIndex, nil, fmt.Errorf("reader.UnreadRune: %w", err)
 				}

--- a/internal/domainexp/parser.go
+++ b/internal/domainexp/parser.go
@@ -6,30 +6,95 @@ import (
 	"strings"
 
 	"github.com/favonia/cloudflare-ddns/internal/domain"
+	"github.com/favonia/cloudflare-ddns/internal/ipnet"
 	"github.com/favonia/cloudflare-ddns/internal/pp"
 )
 
 func scanList(ppfmt pp.PP, key string, input string, tokens []string) ([]string, []string) {
 	var list []string
-	readyForNext := true
+	expectingElement := true
 	for len(tokens) > 0 {
 		switch tokens[0] {
 		case ",":
-			readyForNext = true
+			expectingElement = true
+			tokens = tokens[1:]
 		case ")":
 			return list, tokens
-		case "(", "&&", "||", "!":
+		case "[", "]", "(", "&&", "||", "!":
 			ppfmt.Noticef(pp.EmojiUserError, `%s (%q) has unexpected token %q`, key, input, tokens[0])
 			return nil, nil
 		default:
-			if !readyForNext {
+			if !expectingElement {
 				ppfmt.Noticef(pp.EmojiUserError, `%s (%q) is missing a comma "," before %q`, key, input, tokens[0])
 			}
 			list = append(list, tokens[0])
-			readyForNext = false
+			expectingElement = false
+			tokens = tokens[1:]
 		}
+	}
+	return list, tokens
+}
 
-		tokens = tokens[1:]
+type taggedItem struct {
+	Element string
+	Tag     string
+}
+
+func scanTaggedList(ppfmt pp.PP, key string, input string, tokens []string) ([]taggedItem, []string) {
+	var list []taggedItem
+	expectingElement := true
+	for len(tokens) > 0 {
+		switch tokens[0] {
+		case ",":
+			expectingElement = true
+			tokens = tokens[1:]
+		case ")":
+			return list, tokens
+		case "[":
+			ppfmt.Noticef(pp.EmojiUserError, `%s (%q) is missing a domain before the opening bracket %q`, key, input, tokens[0])
+			return nil, nil
+		case "]", "(", "&&", "||", "!":
+			ppfmt.Noticef(pp.EmojiUserError, `%s (%q) has unexpected token %q`, key, input, tokens[0])
+			return nil, nil
+		default:
+			if !expectingElement {
+				ppfmt.Noticef(pp.EmojiUserError, `%s (%q) is missing a comma "," before %q`, key, input, tokens[0])
+			}
+			domain := tokens[0]
+
+			host := ""
+			switch {
+			case len(tokens) == 1, tokens[1] != "[":
+				tokens = tokens[1:]
+			case len(tokens) == 2: // 'domain', '['
+				ppfmt.Noticef(pp.EmojiUserError, `%s (%q) has unclosed "[" at the end`, key, input)
+				return nil, nil
+			default: // 'domain', '[', ?
+				switch tokens[2] {
+				case "]", ",", "(", ")", "&&", "||", "!":
+					ppfmt.Noticef(pp.EmojiUserError, `%s (%q) has unexpected token %q when a host ID is expected`,
+						key, input, tokens[0])
+					return nil, nil
+				default:
+					switch {
+					case len(tokens) == 3: // 'domain', '[', 'host'
+						ppfmt.Noticef(pp.EmojiUserError, `%s (%q) has unclosed "[" at the end`, key, input)
+						return nil, nil
+					case tokens[3] != "]":
+						ppfmt.Noticef(pp.EmojiUserError,
+							`%s (%q) has unexpected token %q when %q is expected`,
+							key, input, tokens[2], "]")
+						return nil, nil
+					default: // 'domain', '[', 'host', ']'
+						host = tokens[2]
+						tokens = tokens[4:]
+					}
+				}
+			}
+			list = append(list, taggedItem{Element: domain, Tag: host})
+
+			expectingElement = false
+		}
 	}
 	return list, tokens
 }
@@ -43,25 +108,67 @@ func scanASCIIDomainList(ppfmt pp.PP, key string, input string, tokens []string)
 	return domains, tokens
 }
 
+func parseDomain(ppfmt pp.PP, key string, input string, s string) (domain.Domain, bool) {
+	d, err := domain.New(s)
+	if err != nil {
+		if errors.Is(err, domain.ErrNotFQDN) {
+			ppfmt.Noticef(pp.EmojiUserError,
+				`%s (%q) contains a domain %q that is probably not fully qualified; a fully qualified domain name (FQDN) would look like "*.example.org" or "sub.example.org"`, //nolint:lll
+				key, input, d.Describe())
+			return nil, false
+		}
+		ppfmt.Noticef(pp.EmojiUserError,
+			"%s (%q) contains an ill-formed domain %q: %v",
+			key, input, d.Describe(), err)
+		return nil, false
+	}
+	return d, true
+}
+
+func parseHost(ppfmt pp.PP, key string, input string, s string) (ipnet.HostID, bool) {
+	if s == "" {
+		return nil, true
+	}
+
+	h, err := ipnet.ParseHost(s)
+	if err != nil {
+		ppfmt.Noticef(pp.EmojiUserError,
+			"%s (%q) contains an ill-formed host ID %q: %v",
+			key, input, s, err)
+		return nil, false
+	}
+
+	return h, true
+}
+
 func scanDomainList(ppfmt pp.PP, key string, input string, tokens []string) ([]domain.Domain, []string) {
 	list, tokens := scanList(ppfmt, key, input, tokens)
 	domains := make([]domain.Domain, 0, len(list))
 	for _, raw := range list {
-		d, err := domain.New(raw)
-		if err != nil {
-			if errors.Is(err, domain.ErrNotFQDN) {
-				ppfmt.Noticef(pp.EmojiUserError,
-					`%s (%q) contains a domain %q that is probably not fully qualified; a fully qualified domain name (FQDN) would look like "*.example.org" or "sub.example.org"`, //nolint:lll
-					key, input, d.Describe())
-				return nil, nil
-			} else {
-				ppfmt.Noticef(pp.EmojiUserError,
-					"%s (%q) contains an ill-formed domain %q: %v",
-					key, input, d.Describe(), err)
-				return nil, nil
-			}
+		d, ok := parseDomain(ppfmt, key, input, raw)
+		if !ok {
+			return nil, nil
 		}
 		domains = append(domains, d)
+	}
+	return domains, tokens
+}
+
+func scanDomainHostIDList(ppfmt pp.PP, key string, input string, tokens []string) (
+	[]DomainHostID, []string,
+) {
+	list, tokens := scanTaggedList(ppfmt, key, input, tokens)
+	domains := make([]DomainHostID, 0, len(list))
+	for _, raw := range list {
+		d, ok := parseDomain(ppfmt, key, input, raw.Element)
+		if !ok {
+			return nil, nil
+		}
+		h, ok := parseHost(ppfmt, key, input, raw.Tag)
+		if !ok {
+			return nil, nil
+		}
+		domains = append(domains, DomainHostID{Domain: d, HostID: h})
 	}
 	return domains, tokens
 }
@@ -231,22 +338,36 @@ func scanExpression(ppfmt pp.PP, key string, input string, tokens []string) (pre
 	return nil, nil
 }
 
-// ParseList parses a list of comma-separated domains. Internationalized domain names are fully supported.
-func ParseList(ppfmt pp.PP, key string, input string) ([]domain.Domain, bool) {
+// Parse takes a scanner and return the result.
+func Parse[T any](ppfmt pp.PP, key string, input string,
+	scan func(pp.PP, string, string, []string) (T, []string),
+) (T, bool) {
+	var zero T
+
 	tokens, ok := tokenize(ppfmt, key, input)
 	if !ok {
-		return nil, false
+		return zero, false
 	}
 
-	list, tokens := scanDomainList(ppfmt, key, input, tokens)
+	result, tokens := scan(ppfmt, key, input, tokens)
 	if tokens == nil {
-		return nil, false
+		return zero, false
 	} else if len(tokens) > 0 {
 		ppfmt.Noticef(pp.EmojiUserError, `%s (%q) has unexpected token %q`, key, input, tokens[0])
-		return nil, false
+		return zero, false
 	}
 
-	return list, true
+	return result, true
+}
+
+// ParseDomainHostIDList parses a list of comma-separated domains. Internationalized domain names are fully supported.
+func ParseDomainHostIDList(ppfmt pp.PP, key string, input string) ([]DomainHostID, bool) {
+	return Parse(ppfmt, key, input, scanDomainHostIDList)
+}
+
+// ParseDomainList parses a list of comma-separated domains. Internationalized domain names are fully supported.
+func ParseDomainList(ppfmt pp.PP, key string, input string) ([]domain.Domain, bool) {
+	return Parse(ppfmt, key, input, scanDomainList)
 }
 
 // ParseExpression parses a boolean expression containing domains. Internationalized domain names are fully supported.
@@ -264,18 +385,5 @@ func ParseList(ppfmt pp.PP, key string, input string) ([]domain.Domain, bool) {
 //
 // One can use parentheses to group expressions, such as !(is(hello.org) && (is(hello.io) || is(hello.me))).
 func ParseExpression(ppfmt pp.PP, key string, input string) (predicate, bool) {
-	tokens, ok := tokenize(ppfmt, key, input)
-	if !ok {
-		return nil, false
-	}
-
-	pred, tokens := scanExpression(ppfmt, key, input, tokens)
-	if tokens == nil {
-		return nil, false
-	} else if len(tokens) > 0 {
-		ppfmt.Noticef(pp.EmojiUserError, "%s (%q) has unexpected token %q", key, input, tokens[0])
-		return nil, false
-	}
-
-	return pred, true
+	return Parse(ppfmt, key, input, scanExpression)
 }

--- a/internal/ipnet/host.go
+++ b/internal/ipnet/host.go
@@ -1,0 +1,169 @@
+package ipnet
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"net/netip"
+
+	"github.com/favonia/cloudflare-ddns/internal/domain"
+	"github.com/favonia/cloudflare-ddns/internal/pp"
+)
+
+// HostID is the host part of an IPv6 address.
+type HostID interface {
+	// Describe prints the HostID.
+	Describe() string
+
+	Normalize(ppfmt pp.PP, domain domain.Domain, prefixLen int) (HostID, bool)
+
+	// WithPrefix calculates the new address with a prefix.
+	WithPrefix(prefix netip.Prefix) netip.Addr
+}
+
+// mask gives a bitwise mask:
+// - mask(0): 11111111.
+// - mask(1): 01111111.
+// - mask(2): 00111111.
+// - mask(3): 00011111.
+// - mask(4): 00001111.
+// - mask(5): 00000111.
+// - mask(6): 00000011.
+// - mask(7): 00000001.
+func mask(s int) byte {
+	return ^byte(0) >> s
+}
+
+// IP6Suffix represents a suffix of an IPv6 address.
+type IP6Suffix [16]byte
+
+// Describe prints the suffix as an IPv6 address.
+func (r IP6Suffix) Describe() string { return netip.AddrFrom16(r).String() }
+
+func (r IP6Suffix) mask(prefixLen int) IP6Suffix {
+	for i := range prefixLen / 8 {
+		r[i] = 0
+	}
+	if prefixLen%8 > 0 {
+		r[prefixLen/8] &= mask(prefixLen % 8)
+	}
+	return r
+}
+
+// Normalize masks the suffix with the given prefix length.
+func (r IP6Suffix) Normalize(ppfmt pp.PP, domain domain.Domain, prefixLen int) (HostID, bool) {
+	if prefixLen < 0 || prefixLen > 128 {
+		ppfmt.Noticef(pp.EmojiImpossible, "IP6_PREFIX_LEN (%d) should be in the range 0 to 128", prefixLen)
+		return nil, false
+	}
+	normalized := r.mask(prefixLen)
+	if normalized != r {
+		ppfmt.Infof(pp.EmojiTruncate, "The host ID %q of %q was truncated to %q (with %d higher bits removed)",
+			r.Describe(), domain.Describe(), normalized.Describe(), prefixLen)
+	}
+	return normalized, true
+}
+
+// WithPrefix combines a prefix and a host ID to construct an IPv6 address.
+func (r IP6Suffix) WithPrefix(prefix netip.Prefix) netip.Addr {
+	ip := r.mask(prefix.Bits())
+	prefixAsBytes := prefix.Masked().Addr().As16()
+	for i := range 128 / 8 {
+		ip[i] |= prefixAsBytes[i]
+	}
+	return netip.AddrFrom16(ip)
+}
+
+// EUI48 represents a MAC (EUI-48) address.
+type EUI48 [6]byte
+
+// Describe prints the suffix as a MAC address.
+func (e EUI48) Describe() string { return net.HardwareAddr(e[:]).String() }
+
+// Normalize masks the suffix with the given prefix length.
+func (e EUI48) Normalize(ppfmt pp.PP, domain domain.Domain, prefixLen int) (HostID, bool) {
+	if prefixLen < 0 || prefixLen > 128 {
+		ppfmt.Noticef(pp.EmojiImpossible, "IP6_PREFIX_LEN (%d) should be in the range 0 to 128", prefixLen)
+		return nil, false
+	}
+	if prefixLen > 64 {
+		ppfmt.Noticef(pp.EmojiUserError, "IP6_PREFIX_LEN (%d) is too large (> 64) to use the MAC (EUI-48) address %q as the IPv6 host ID of %q. Converting a MAC address to a host ID requires IPv6 Stateless Address Auto-configuration (SLAAC), which necessitates an IPv6 range of size at least /64 (represented by a prefix length at most 64).", //nolint:lll
+			prefixLen, e.Describe(), domain.Describe())
+		return nil, false
+	}
+	return e, true
+}
+
+// WithPrefix combines a prefix and a host ID to construct an IPv6 address.
+func (e EUI48) WithPrefix(prefix netip.Prefix) netip.Addr {
+	if prefix.Bits() > 64 {
+		return netip.Addr{}
+	}
+	prefixAsBytes := prefix.Masked().Addr().As16()
+
+	bytes := [16]byte{
+		prefixAsBytes[0],
+		prefixAsBytes[1],
+		prefixAsBytes[2],
+		prefixAsBytes[3],
+		prefixAsBytes[4],
+		prefixAsBytes[5],
+		prefixAsBytes[6],
+		prefixAsBytes[7],
+		e[0] ^ 0x02, // flip the global-local bit
+		e[1],
+		e[2],
+		0xff,
+		0xfe,
+		e[3],
+		e[4],
+		e[5],
+	}
+	return netip.AddrFrom16(bytes)
+}
+
+// Errors from ParseHost.
+var (
+	ErrHostIDHasIP6Zone   = errors.New("an IPv6 address as a host ID must not have an IPv6 zone")
+	ErrIP4AddressAsHostID = errors.New("cannot use IPv4 address as a host ID")
+	ErrEUI64AsHostID      = errors.New("cannot use EUI-64 address as a host ID")
+	ErrIPOIBAsHostID      = errors.New("cannot use IP address over InfiniBand as a host ID")
+)
+
+// ParseHost parses a host ID for an IPv6 address.
+func ParseHost(s string) (HostID, error) {
+	if s == "" {
+		return nil, nil //nolint:nilnil
+	}
+
+	ip, errIP := netip.ParseAddr(s)
+	if errIP == nil {
+		if !ip.Is6() {
+			return nil, ErrIP4AddressAsHostID
+		}
+		if ip.Zone() != "" {
+			return nil, ErrHostIDHasIP6Zone
+		}
+
+		return IP6Suffix(ip.As16()), nil
+	}
+
+	// Possible formats for MAC (EUI-48)
+	// 00:00:5e:00:53:01
+	// 00-00-5e-00-53-01
+	// 0000.5e00.5301
+	mac, errMAC := net.ParseMAC(s)
+	if errMAC != nil {
+		return nil, fmt.Errorf("not an IPv6 address (%w) and not a MAC (EUI-48) address (%w)", errIP, errMAC)
+	}
+	switch len(mac) {
+	case 6:
+		return EUI48(mac), nil
+	case 8:
+		return nil, ErrEUI64AsHostID
+	case 20:
+		return nil, ErrIPOIBAsHostID
+	default:
+		return nil, fmt.Errorf("not an IPv6 address (%w) and not a MAC (EUI-48) address", errIP)
+	}
+}

--- a/internal/ipnet/host_test.go
+++ b/internal/ipnet/host_test.go
@@ -1,0 +1,214 @@
+// vim: nowrap
+package ipnet_test
+
+import (
+	"net/netip"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
+	"github.com/favonia/cloudflare-ddns/internal/domain"
+	"github.com/favonia/cloudflare-ddns/internal/ipnet"
+	"github.com/favonia/cloudflare-ddns/internal/mocks"
+	"github.com/favonia/cloudflare-ddns/internal/pp"
+)
+
+func TestHostIDDescribe(t *testing.T) {
+	t.Parallel()
+	for name, tc := range map[string]struct {
+		input    ipnet.HostID
+		expected string
+	}{
+		"ip6suffix": {
+			ipnet.IP6Suffix{0x00, 0x00, 0x00, 0x00, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff},
+			"::4455:6677:8899:aabb:ccdd:eeff",
+		},
+		"mac": {
+			ipnet.EUI48{0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff},
+			"aa:bb:cc:dd:ee:ff",
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tc.expected, tc.input.Describe())
+		})
+	}
+}
+
+func TestNormalize(t *testing.T) {
+	t.Parallel()
+	domain := domain.FQDN("a.b.c")
+	for name, tc := range map[string]struct {
+		input        ipnet.HostID
+		prefixLen    int
+		ok           bool
+		expected     ipnet.HostID
+		prepareMocks func(*mocks.MockPP)
+	}{
+		"ip6suffix/0": {
+			ipnet.IP6Suffix{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15},
+			0,
+			true,
+			ipnet.IP6Suffix{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15},
+			nil,
+		},
+		"ip6suffix/128": {
+			ipnet.IP6Suffix{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15},
+			128,
+			true,
+			ipnet.IP6Suffix{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+			func(ppfmt *mocks.MockPP) {
+				ppfmt.EXPECT().Infof(pp.EmojiTruncate, "The host ID %q of %q was truncated to %q (with %d higher bits removed)", "1:203:405:607:809:a0b:c0d:e0f", "a.b.c", "::", 128)
+			},
+		},
+		"ip6suffix/-1": {
+			ipnet.IP6Suffix{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15},
+			-1,
+			false,
+			nil,
+			func(ppfmt *mocks.MockPP) {
+				ppfmt.EXPECT().Noticef(pp.EmojiImpossible, "IP6_PREFIX_LEN (%d) should be in the range 0 to 128", -1)
+			},
+		},
+		"ip6suffix/129": {
+			ipnet.IP6Suffix{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14},
+			129,
+			false,
+			nil,
+			func(ppfmt *mocks.MockPP) {
+				ppfmt.EXPECT().Noticef(pp.EmojiImpossible, "IP6_PREFIX_LEN (%d) should be in the range 0 to 128", 129)
+			},
+		},
+		"mac/0": {
+			ipnet.EUI48{0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff},
+			0,
+			true,
+			ipnet.EUI48{0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff},
+			nil,
+		},
+		"mac/128": {
+			ipnet.EUI48{0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff},
+			128,
+			false,
+			nil,
+			func(ppfmt *mocks.MockPP) {
+				ppfmt.EXPECT().Noticef(pp.EmojiUserError, "IP6_PREFIX_LEN (%d) is too large (> 64) to use the MAC (EUI-48) address %q as the IPv6 host ID of %q. Converting a MAC address to a host ID requires IPv6 Stateless Address Auto-configuration (SLAAC), which necessitates an IPv6 range of size at least /64 (represented by a prefix length at most 64).", 128, "aa:bb:cc:dd:ee:ff", "a.b.c")
+			},
+		},
+		"mac/-1": {
+			ipnet.EUI48{0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff},
+			-1,
+			false,
+			nil,
+			func(ppfmt *mocks.MockPP) {
+				ppfmt.EXPECT().Noticef(pp.EmojiImpossible, "IP6_PREFIX_LEN (%d) should be in the range 0 to 128", -1)
+			},
+		},
+		"mac/96": {
+			ipnet.EUI48{0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff},
+			96,
+			false,
+			nil,
+			func(ppfmt *mocks.MockPP) {
+				ppfmt.EXPECT().Noticef(pp.EmojiUserError, "IP6_PREFIX_LEN (%d) is too large (> 64) to use the MAC (EUI-48) address %q as the IPv6 host ID of %q. Converting a MAC address to a host ID requires IPv6 Stateless Address Auto-configuration (SLAAC), which necessitates an IPv6 range of size at least /64 (represented by a prefix length at most 64).", 96, "aa:bb:cc:dd:ee:ff", "a.b.c")
+			},
+		},
+		"mac/64": {
+			ipnet.EUI48{0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff},
+			64,
+			true,
+			ipnet.EUI48{0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff},
+			nil,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			mockCtrl := gomock.NewController(t)
+			mockPP := mocks.NewMockPP(mockCtrl)
+			if tc.prepareMocks != nil {
+				tc.prepareMocks(mockPP)
+			}
+
+			result, ok := tc.input.Normalize(mockPP, domain, tc.prefixLen)
+			require.Equal(t, tc.ok, ok)
+			require.Equal(t, tc.expected, result)
+		})
+	}
+}
+
+func TestHostIDWithPrefix(t *testing.T) {
+	t.Parallel()
+	for name, tc := range map[string]struct {
+		input  ipnet.HostID
+		prefix netip.Prefix
+		addr   netip.Addr
+	}{
+		"ip6suffix": {
+			ipnet.IP6Suffix{0x00, 0x00, 0x00, 0x00, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff},
+			netip.MustParsePrefix("1122::/40"),
+			netip.MustParseAddr("1122::55:6677:8899:aabb:ccdd:eeff"),
+		},
+		"mac": {
+			ipnet.EUI48{0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff},
+			netip.MustParsePrefix("1122::/24"),
+			netip.MustParseAddr("1122::a8bb:ccff:fedd:eeff"),
+		},
+		"mac/96": {
+			ipnet.EUI48{0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff},
+			netip.MustParsePrefix("1122::/96"),
+			netip.Addr{},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			addr := tc.input.WithPrefix(tc.prefix)
+			require.Equal(t, tc.addr, addr)
+		})
+	}
+}
+
+func TestParseHostID(t *testing.T) {
+	t.Parallel()
+	for name, tc := range map[string]struct {
+		input  string
+		err    error
+		hostID ipnet.HostID
+	}{
+		"empty": {"", nil, nil},
+		"ip6": {
+			"11:2233:4455:6677:8899:aabb:ccdd:eeff",
+			nil,
+			ipnet.IP6Suffix{0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff},
+		},
+		"ip6/zone": {
+			"11:2233:4455:6677:8899:aabb:ccdd:eeff%eth0",
+			ipnet.ErrHostIDHasIP6Zone,
+			nil,
+		},
+		"mac": {
+			"aa:bb:cc:dd:ee:ff",
+			nil,
+			ipnet.EUI48{0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff},
+		},
+		"ip4":          {"1.1.1.1", ipnet.ErrIP4AddressAsHostID, nil},
+		"eui64":        {"01-02-03-04-05-06-07-08", ipnet.ErrEUI64AsHostID, nil},
+		"ipoib":        {"01-02-03-04-05-06-07-08-09-0A-0B-0C-0D-0E-0F-10-11-12-13-14", ipnet.ErrIPOIBAsHostID, nil},
+		"ill-formed/1": {"1:1:1:1", nil, nil},
+		"ill-formed/2": {"01-02-03-04-05-06-07-08-09", nil, nil},
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			hostID, err := ipnet.ParseHost(tc.input)
+			require.Equal(t, tc.hostID, hostID)
+			if tc.input == "" || hostID != nil {
+				require.NoError(t, err)
+			} else {
+				require.Error(t, err)
+				if tc.err != nil {
+					require.ErrorIs(t, err, tc.err)
+				}
+			}
+		})
+	}
+}

--- a/internal/ipnet/host_test.go
+++ b/internal/ipnet/host_test.go
@@ -46,12 +46,30 @@ func TestNormalize(t *testing.T) {
 		expected     ipnet.HostID
 		prepareMocks func(*mocks.MockPP)
 	}{
+		"ip6suffix/-1": {
+			ipnet.IP6Suffix{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15},
+			-1,
+			false,
+			nil,
+			func(ppfmt *mocks.MockPP) {
+				ppfmt.EXPECT().Noticef(pp.EmojiImpossible, "IP6_PREFIX_LEN (%d) should be in the range 0 to 128", -1)
+			},
+		},
 		"ip6suffix/0": {
 			ipnet.IP6Suffix{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15},
 			0,
 			true,
 			ipnet.IP6Suffix{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15},
 			nil,
+		},
+		"ip6suffix/22": {
+			ipnet.IP6Suffix{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15},
+			22,
+			true,
+			ipnet.IP6Suffix{0, 0, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15},
+			func(ppfmt *mocks.MockPP) {
+				ppfmt.EXPECT().Infof(pp.EmojiTruncate, "The host ID %q of %q was truncated to %q (with %d higher bits removed)", "1:203:405:607:809:a0b:c0d:e0f", "a.b.c", "0:203:405:607:809:a0b:c0d:e0f", 22)
+			},
 		},
 		"ip6suffix/128": {
 			ipnet.IP6Suffix{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15},
@@ -60,15 +78,6 @@ func TestNormalize(t *testing.T) {
 			ipnet.IP6Suffix{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
 			func(ppfmt *mocks.MockPP) {
 				ppfmt.EXPECT().Infof(pp.EmojiTruncate, "The host ID %q of %q was truncated to %q (with %d higher bits removed)", "1:203:405:607:809:a0b:c0d:e0f", "a.b.c", "::", 128)
-			},
-		},
-		"ip6suffix/-1": {
-			ipnet.IP6Suffix{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15},
-			-1,
-			false,
-			nil,
-			func(ppfmt *mocks.MockPP) {
-				ppfmt.EXPECT().Noticef(pp.EmojiImpossible, "IP6_PREFIX_LEN (%d) should be in the range 0 to 128", -1)
 			},
 		},
 		"ip6suffix/129": {

--- a/internal/ipnet/prefix.go
+++ b/internal/ipnet/prefix.go
@@ -23,6 +23,12 @@ func ParsePrefixOrIP(ppfmt pp.PP, s string) (netip.Prefix, bool) {
 	return p, true
 }
 
+// ContainsPrefix checks whether a network represented by a prefix contains
+// another network (as a subnet) represented also represented by a prefix.
+func ContainsPrefix(large, small netip.Prefix) bool {
+	return large.Contains(small.Addr()) && large.Bits() <= small.Bits()
+}
+
 // DescribePrefixOrIP is similar to [netip.Prefix.String] but prints out
 // the IP directly if the input range only contains one IP.
 func DescribePrefixOrIP(p netip.Prefix) string {

--- a/internal/mocks/mock_setter.go
+++ b/internal/mocks/mock_setter.go
@@ -159,7 +159,7 @@ func (c *SetterSetCall) DoAndReturn(f func(context.Context, pp.PP, ipnet.Type, d
 }
 
 // SetWAFList mocks base method.
-func (m *MockSetter) SetWAFList(arg0 context.Context, arg1 pp.PP, arg2 api.WAFList, arg3 string, arg4 map[ipnet.Type]netip.Addr, arg5 string) setter.ResponseCode {
+func (m *MockSetter) SetWAFList(arg0 context.Context, arg1 pp.PP, arg2 api.WAFList, arg3 string, arg4 map[ipnet.Type]netip.Prefix, arg5 string) setter.ResponseCode {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SetWAFList", arg0, arg1, arg2, arg3, arg4, arg5)
 	ret0, _ := ret[0].(setter.ResponseCode)
@@ -185,13 +185,13 @@ func (c *SetterSetWAFListCall) Return(arg0 setter.ResponseCode) *SetterSetWAFLis
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *SetterSetWAFListCall) Do(f func(context.Context, pp.PP, api.WAFList, string, map[ipnet.Type]netip.Addr, string) setter.ResponseCode) *SetterSetWAFListCall {
+func (c *SetterSetWAFListCall) Do(f func(context.Context, pp.PP, api.WAFList, string, map[ipnet.Type]netip.Prefix, string) setter.ResponseCode) *SetterSetWAFListCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *SetterSetWAFListCall) DoAndReturn(f func(context.Context, pp.PP, api.WAFList, string, map[ipnet.Type]netip.Addr, string) setter.ResponseCode) *SetterSetWAFListCall {
+func (c *SetterSetWAFListCall) DoAndReturn(f func(context.Context, pp.PP, api.WAFList, string, map[ipnet.Type]netip.Prefix, string) setter.ResponseCode) *SetterSetWAFListCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/internal/pp/emoji.go
+++ b/internal/pp/emoji.go
@@ -15,6 +15,7 @@ const (
 	EmojiDisabled     Emoji = "🚫" // feature is disabled
 	EmojiExperimental Emoji = "🧪" // experimental features
 	EmojiSwitch       Emoji = "🔀" // the happy eyeballs algorithm chose the alternative
+	EmojiTruncate     Emoji = "🪚" // Truncate IPv6 host IDs
 
 	EmojiCreation Emoji = "🐣" // adding new DNS records
 	EmojiDeletion Emoji = "💀" // deleting DNS records

--- a/internal/pp/queued.go
+++ b/internal/pp/queued.go
@@ -1,0 +1,81 @@
+package pp
+
+// QueuedPP is a pretty printer that queues all printing operations
+// (but executes non-printing operations immediately).
+// [QueuedPP.Flush] will then execute all queued printing operations.
+//
+// QueuePP itself is not goroute-safe, but can be used to queue printing
+// operations from different goroutines to achieve goroutine-safety.
+type QueuedPP struct {
+	upstream PP
+	queue    *[]func()
+}
+
+// NewQueued creates a new pretty printer that queues all printing operations.
+// It is assumed that [PP.IsShowing] and [PP.Indent] do not induce race conditions.
+func NewQueued(pp PP) QueuedPP {
+	var empty []func()
+	return QueuedPP{upstream: pp, queue: &empty}
+}
+
+// IsShowing calls [PP.IsShowing] of the upstream.
+func (b QueuedPP) IsShowing(v Verbosity) bool {
+	return b.upstream.IsShowing(v)
+}
+
+// Indent calls [PP.Indent] and return a new batch printer with a new upstream.
+// The call queue is shared with the original batch printer.
+func (b QueuedPP) Indent() PP {
+	b.upstream = b.upstream.Indent()
+	return b
+}
+
+// BlankLineIfVerbose queues a call to [PP.BlankLineIfVerbose] of the upstream.
+func (b QueuedPP) BlankLineIfVerbose() {
+	// It's important to save the current upstream because [Indent] may change it.
+	upstream := b.upstream
+	*b.queue = append(*b.queue, func() { upstream.BlankLineIfVerbose() })
+}
+
+// Infof queues a call to [PP.Infof] of the upstream.
+func (b QueuedPP) Infof(emoji Emoji, format string, args ...any) {
+	// It's important to save the current upstream because [Indent] may change it.
+	upstream := b.upstream
+	*b.queue = append(*b.queue, func() { upstream.Infof(emoji, format, args...) })
+}
+
+// Noticef queues a call to [PP.Noticef] of the upstream.
+func (b QueuedPP) Noticef(emoji Emoji, format string, args ...any) {
+	// It's important to save the current upstream because [Indent] may change it.
+	upstream := b.upstream
+	*b.queue = append(*b.queue, func() { upstream.Noticef(emoji, format, args...) })
+}
+
+// Suppress queues a call to [PP.Suppress] of the upstream.
+func (b QueuedPP) Suppress(id ID) {
+	// It's important to save the current upstream because [Indent] may change it.
+	upstream := b.upstream
+	*b.queue = append(*b.queue, func() { upstream.Suppress(id) })
+}
+
+// InfoOncef queues a call to [PP.InfoOncef] of the upstream.
+func (b QueuedPP) InfoOncef(id ID, emoji Emoji, format string, args ...any) {
+	// It's important to save the current upstream because [Indent] may change it.
+	upstream := b.upstream
+	*b.queue = append(*b.queue, func() { upstream.InfoOncef(id, emoji, format, args...) })
+}
+
+// NoticeOncef queues a call to [PP.NoticeOncef] of the upstream.
+func (b QueuedPP) NoticeOncef(id ID, emoji Emoji, format string, args ...any) {
+	// It's important to save the current upstream because [Indent] may change it.
+	upstream := b.upstream
+	*b.queue = append(*b.queue, func() { upstream.NoticeOncef(id, emoji, format, args...) })
+}
+
+// Flush executes all queued function calls.
+func (b QueuedPP) Flush() {
+	for _, f := range *b.queue {
+		f()
+	}
+	*b.queue = nil
+}

--- a/internal/pp/queued_test.go
+++ b/internal/pp/queued_test.go
@@ -1,0 +1,61 @@
+package pp_test
+
+import (
+	"testing"
+
+	"go.uber.org/mock/gomock"
+
+	"github.com/favonia/cloudflare-ddns/internal/mocks"
+	"github.com/favonia/cloudflare-ddns/internal/pp"
+)
+
+func TestQueued(t *testing.T) {
+	t.Parallel()
+
+	for name, tc := range map[string]struct {
+		run          func(pp.QueuedPP)
+		prepareMocks func(ppfmt *mocks.MockPP, inner *mocks.MockPP)
+	}{
+		"flushed": {
+			func(queued pp.QueuedPP) {
+				var ppfmt pp.PP = queued
+				if ppfmt.IsShowing(pp.Info) {
+					ppfmt.Infof(pp.EmojiBullet, "Test")
+					ppfmt = ppfmt.Indent()
+				}
+				ppfmt.Noticef(pp.EmojiNotify, "some message")
+				ppfmt.Suppress(pp.MessageDetectionTimeouts)
+				ppfmt.BlankLineIfVerbose()
+				ppfmt.InfoOncef(pp.MessageIP6DetectionFails, pp.EmojiHint, "cannot do IPv6")
+				ppfmt.NoticeOncef(pp.MessageIP4DetectionFails, pp.EmojiHint, "cannot do IPv4")
+
+				queued.Flush()
+			},
+			func(ppfmt, inner *mocks.MockPP) {
+				ppfmt.EXPECT().Indent().Return(inner)
+				ppfmt.EXPECT().IsShowing(gomock.Any()).Return(true)
+				gomock.InOrder(
+					ppfmt.EXPECT().Infof(pp.EmojiBullet, "Test"),
+					inner.EXPECT().Noticef(pp.EmojiNotify, "some message"),
+					inner.EXPECT().Suppress(pp.MessageDetectionTimeouts),
+					inner.EXPECT().BlankLineIfVerbose(),
+					inner.EXPECT().InfoOncef(pp.MessageIP6DetectionFails, pp.EmojiHint, "cannot do IPv6"),
+					inner.EXPECT().NoticeOncef(pp.MessageIP4DetectionFails, pp.EmojiHint, "cannot do IPv4"),
+				)
+			},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			mockCtrl := gomock.NewController(t)
+			mockPP := mocks.NewMockPP(mockCtrl)
+			mockPPInner := mocks.NewMockPP(mockCtrl)
+			if tc.prepareMocks != nil {
+				tc.prepareMocks(mockPP, mockPPInner)
+			}
+
+			tc.run(pp.NewQueued(mockPP))
+		})
+	}
+}

--- a/internal/provider/protocol/doh_test.go
+++ b/internal/provider/protocol/doh_test.go
@@ -133,7 +133,7 @@ func TestDNSOverHTTPSGetIP(t *testing.T) {
 			ip4,
 			nil,
 		},
-		"illformed-query": {
+		"ill-formed/query": {
 			ipnet.IP4, ipnet.IP4, "test",
 			dnsmessage.ClassCHAOS,
 			true,
@@ -415,7 +415,7 @@ func TestDNSOverHTTPSGetIP(t *testing.T) {
 			ip4,
 			nil,
 		},
-		"illformed-ip": {
+		"ill-formed/ip": {
 			ipnet.IP4, ipnet.IP4, "test.",
 			dnsmessage.ClassCHAOS,
 			true,

--- a/internal/provider/protocol/http_test.go
+++ b/internal/provider/protocol/http_test.go
@@ -89,14 +89,14 @@ func TestHTTPGetIP(t *testing.T) {
 				m.EXPECT().Noticef(pp.EmojiError, "Detected IP address %s is not a valid IPv4 address", ip6.String())
 			},
 		},
-		"4/illformed": {
+		"4/ill-formed": {
 			false,
 			ipnet.IP4, illformed4.URL, ipnet.IP4, invalidIP,
 			func(m *mocks.MockPP) {
 				m.EXPECT().Noticef(pp.EmojiError, `Failed to parse the IP address in the response of %q (%q)`, illformed4.URL, "hello")
 			},
 		},
-		"6/illformed": {
+		"6/ill-formed": {
 			false,
 			ipnet.IP6, illformed6.URL, ipnet.IP6, invalidIP,
 			func(m *mocks.MockPP) {

--- a/internal/provider/protocol/local_auto_test.go
+++ b/internal/provider/protocol/local_auto_test.go
@@ -47,7 +47,7 @@ func TestExtractUDPAddr(t *testing.T) {
 			true, netip.MustParseAddr("::1%123"),
 			nil,
 		},
-		"udpaddr/illformed": {
+		"udpaddr/ill-formed": {
 			&net.UDPAddr{IP: net.IP([]byte{0x01, 0x02}), Zone: "", Port: 123},
 			false, invalidIP,
 			func(ppfmt *mocks.MockPP) {

--- a/internal/provider/protocol/local_iface_test.go
+++ b/internal/provider/protocol/local_iface_test.go
@@ -55,7 +55,7 @@ func TestExtractInterfaceAddr(t *testing.T) {
 			true, netip.MustParseAddr("::1%123"),
 			nil,
 		},
-		"ipaddr/illformed": {
+		"ipaddr/ill-formed": {
 			&net.IPAddr{IP: net.IP([]byte{0x01, 0x02}), Zone: ""},
 			false, invalidIP,
 			func(ppfmt *mocks.MockPP) {
@@ -67,7 +67,7 @@ func TestExtractInterfaceAddr(t *testing.T) {
 			true, netip.MustParseAddr("1.2.3.4"),
 			nil,
 		},
-		"ipnet/illformed": {
+		"ipnet/ill-formed": {
 			&net.IPNet{IP: net.IP([]byte{0x01, 0x02}), Mask: net.CIDRMask(10, 22)},
 			false, invalidIP,
 			func(ppfmt *mocks.MockPP) {

--- a/internal/setter/base.go
+++ b/internal/setter/base.go
@@ -45,7 +45,7 @@ type Setter interface {
 		ppfmt pp.PP,
 		list api.WAFList,
 		listDescription string,
-		detected map[ipnet.Type]netip.Addr,
+		detectedRange map[ipnet.Type]netip.Prefix,
 		itemComment string,
 	) ResponseCode
 

--- a/internal/setter/setter_test.go
+++ b/internal/setter/setter_test.go
@@ -390,9 +390,9 @@ func TestSetWAFList(t *testing.T) {
 	var (
 		invalid     = netip.PrefixFrom(netip.Addr{}, -1)
 		prefix4     = netip.MustParsePrefix("10.0.0.1/32")
-		prefix6     = netip.MustParsePrefix("2001:0db8::/64")
+		prefix6     = netip.MustParsePrefix("2001:0db8::/56")
 		item4       = api.WAFListItem{Prefix: netip.MustParsePrefix("10.0.0.1/32"), ID: "pre4"}
-		item6       = api.WAFListItem{Prefix: netip.MustParsePrefix("2001:0db8::/64"), ID: "pre6"}
+		item6       = api.WAFListItem{Prefix: netip.MustParsePrefix("2001:0db8::/56"), ID: "pre6"}
 		item4range1 = api.WAFListItem{Prefix: netip.MustParsePrefix("10.0.0.0/16"), ID: "ip4-16"}
 		item4range2 = api.WAFListItem{Prefix: netip.MustParsePrefix("10.0.0.0/20"), ID: "ip4-20"}
 		item4range3 = api.WAFListItem{Prefix: netip.MustParsePrefix("10.0.0.0/24"), ID: "ip4-24"}
@@ -402,6 +402,7 @@ func TestSetWAFList(t *testing.T) {
 		item6range1 = api.WAFListItem{Prefix: netip.MustParsePrefix("2001:db8::/32"), ID: "ip6-32"}
 		item6range2 = api.WAFListItem{Prefix: netip.MustParsePrefix("2001:db8::/40"), ID: "ip6-40"}
 		item6range3 = api.WAFListItem{Prefix: netip.MustParsePrefix("2001:db8::/48"), ID: "ip6-48"}
+		item6range4 = api.WAFListItem{Prefix: netip.MustParsePrefix("2001:db8::/64"), ID: "ip6-64"}
 		item6wrong1 = api.WAFListItem{Prefix: netip.MustParsePrefix("4001:db8::/32"), ID: "ip6-32"}
 		item6wrong2 = api.WAFListItem{Prefix: netip.MustParsePrefix("4001:db8::/40"), ID: "ip6-40"}
 		item6wrong3 = api.WAFListItem{Prefix: netip.MustParsePrefix("4001:db8::/48"), ID: "ip6-48"}
@@ -424,7 +425,7 @@ func TestSetWAFList(t *testing.T) {
 					p.EXPECT().Noticef(pp.EmojiCreation, "Created a new list %s", wafListDescribed),
 					m.EXPECT().CreateWAFListItems(ctx, p, wafList, listDescription, []netip.Prefix{item4.Prefix, item6.Prefix}, "").Return(true),
 					p.EXPECT().Noticef(pp.EmojiCreation, "Added %s to the list %s", "10.0.0.1", wafListDescribed),
-					p.EXPECT().Noticef(pp.EmojiCreation, "Added %s to the list %s", "2001:db8::/64", wafListDescribed),
+					p.EXPECT().Noticef(pp.EmojiCreation, "Added %s to the list %s", "2001:db8::/56", wafListDescribed),
 					m.EXPECT().DeleteWAFListItems(ctx, p, wafList, listDescription, []api.ID{}).Return(true),
 				)
 			},
@@ -481,6 +482,7 @@ func TestSetWAFList(t *testing.T) {
 						item4wrong2,
 						item6range2,
 						item6range3,
+						item6range4,
 						item4range2,
 						item4range3,
 						item6wrong2,
@@ -523,7 +525,7 @@ func TestSetWAFList(t *testing.T) {
 					}, true, false, true),
 					m.EXPECT().CreateWAFListItems(ctx, p, wafList, listDescription, []netip.Prefix{item4.Prefix, item6.Prefix}, "").Return(true),
 					p.EXPECT().Noticef(pp.EmojiCreation, "Added %s to the list %s", "10.0.0.1", wafListDescribed),
-					p.EXPECT().Noticef(pp.EmojiCreation, "Added %s to the list %s", "2001:db8::/64", wafListDescribed),
+					p.EXPECT().Noticef(pp.EmojiCreation, "Added %s to the list %s", "2001:db8::/56", wafListDescribed),
 					m.EXPECT().DeleteWAFListItems(ctx, p, wafList, listDescription, gomock.InAnyOrder([]api.ID{
 						item4wrong2.ID,
 						item6wrong2.ID,
@@ -562,6 +564,7 @@ func TestSetWAFList(t *testing.T) {
 						item4wrong2,
 						item6range2,
 						item6range3,
+						item6range4,
 						item4range2,
 						item4range3,
 						item6wrong2,

--- a/test/fuzzer/fuzzer_test.go
+++ b/test/fuzzer/fuzzer_test.go
@@ -27,8 +27,8 @@ func (m ErrorMatcher) String() string {
 
 const key string = "KEY"
 
-// FuzzParseList fuzz test [domainexp.ParseList].
-func FuzzParseList(f *testing.F) {
+// FuzzParseDomainList fuzz test [domainexp.ParseList].
+func FuzzParseDomainList(f *testing.F) {
 	f.Fuzz(func(t *testing.T, input string) {
 		mockCtrl := gomock.NewController(t)
 		mockPP := mocks.NewMockPP(mockCtrl)
@@ -40,7 +40,28 @@ func FuzzParseList(f *testing.F) {
 		mockPP.EXPECT().Noticef(pp.EmojiUserError, `%s (%q) contains a domain %q that is probably not fully qualified; a fully qualified domain name (FQDN) would look like "*.example.org" or "sub.example.org"`, key, input, gomock.Any()).AnyTimes()
 		mockPP.EXPECT().Noticef(pp.EmojiUserError, `%s (%q) is missing a comma "," before %q`, key, input, gomock.Any()).AnyTimes()
 
-		_, _ = domainexp.ParseList(mockPP, key, input)
+		_, _ = domainexp.ParseDomainList(mockPP, key, input)
+	})
+}
+
+// FuzzParseDomainHostIDList fuzz test [domainexp.ParseDomainHostIDList].
+func FuzzParseDomainHostIDList(f *testing.F) {
+	f.Fuzz(func(t *testing.T, input string) {
+		mockCtrl := gomock.NewController(t)
+		mockPP := mocks.NewMockPP(mockCtrl)
+		mockPP.EXPECT().Noticef(pp.EmojiUserError, `%s (%q) is ill-formed: %v`, key, input, domainexp.ErrSingleAnd).AnyTimes()
+		mockPP.EXPECT().Noticef(pp.EmojiUserError, `%s (%q) is ill-formed: %v`, key, input, domainexp.ErrSingleOr).AnyTimes()
+		mockPP.EXPECT().Noticef(pp.EmojiUserError, "%s (%q) is ill-formed: %v", key, input, ErrorMatcher{domainexp.ErrUTF8}).AnyTimes()
+		mockPP.EXPECT().Noticef(pp.EmojiUserError, `%s (%q) has unexpected token %q`, key, input, gomock.Any()).AnyTimes()
+		mockPP.EXPECT().Noticef(pp.EmojiUserError, `%s (%q) contains an ill-formed domain %q: %v`, key, input, gomock.Any(), gomock.Any()).AnyTimes()
+		mockPP.EXPECT().Noticef(pp.EmojiUserError, `%s (%q) contains a domain %q that is probably not fully qualified; a fully qualified domain name (FQDN) would look like "*.example.org" or "sub.example.org"`, key, input, gomock.Any()).AnyTimes()
+		mockPP.EXPECT().Noticef(pp.EmojiUserError, `%s (%q) is missing a comma "," before %q`, key, input, gomock.Any()).AnyTimes()
+		mockPP.EXPECT().Noticef(pp.EmojiUserError, `%s (%q) has unclosed "[" at the end`, key, input).AnyTimes()
+		mockPP.EXPECT().Noticef(pp.EmojiUserError, `%s (%q) is missing a domain before the opening bracket %q`, key, input, gomock.Any()).AnyTimes()
+		mockPP.EXPECT().Noticef(pp.EmojiUserError, `%s (%q) has unexpected token %q when %q is expected`, key, input, gomock.Any(), gomock.Any()).AnyTimes()
+		mockPP.EXPECT().Noticef(pp.EmojiUserError, `%s (%q) has unexpected token %q when a host ID is expected`, key, input, gomock.Any()).AnyTimes()
+
+		_, _ = domainexp.ParseDomainHostIDList(mockPP, key, input)
 	})
 }
 


### PR DESCRIPTION
Close #764.

Current design:

- `IP6_PREFIX_LEN=56`
- ~~`IP6_DOMAINS=test1.example.org[::00:01],test2.example.org[::02]`~~ This is bad syntax; will re-design

TODO:

- [x] `Config.Normalize` to detect uncommon settings
- [x] Actually use new addresses
- [x] Use correct prefix length for WAF lists 
- [x] Display host IDs
- [ ] Update notification messages with the correct IPs