### PR TITLE
enhancement: the monitor and notifier by adding :the updater has started

### DIFF
--- a/internal/monitor/healthchecks.go
+++ b/internal/monitor/healthchecks.go
@@ -148,7 +148,7 @@ func (h Healthchecks) ping(ctx context.Context, ppfmt pp.PP, endpoint string, me
 		return false
 	}
 
-	ppfmt.Infof(pp.EmojiPing, "Pinged the %s endpoint of Healthchecks", endpointDescription)
+	ppfmt.Infof(pp.EmojiPing, "Pinged the %s endpoint of Healthchecks: the updater has started", endpointDescription)
 	return true
 }
 

--- a/internal/monitor/healthchecks.go
+++ b/internal/monitor/healthchecks.go
@@ -148,7 +148,22 @@ func (h Healthchecks) ping(ctx context.Context, ppfmt pp.PP, endpoint string, me
 		return false
 	}
 
-	ppfmt.Infof(pp.EmojiPing, "Pinged the %s endpoint of Healthchecks: the updater has started", endpointDescription)
+	var statusMessage string
+	switch endpoint {
+	case "/start":
+		statusMessage = `the updater has started`
+	case "/fail":
+		statusMessage = `failure reported`
+	case "/log":
+		statusMessage = `status logged`
+	case "/0":
+		statusMessage = `the updater has stopped`
+	default:
+		statusMessage = `ping successful` // Default case for root endpoint
+	}
+
+	ppfmt.Infof(pp.EmojiPing, "Pinged the %s endpoint of Healthchecks: %s",
+		endpointDescription, statusMessage)
 	return true
 }
 

--- a/internal/monitor/healthchecks_test.go
+++ b/internal/monitor/healthchecks_test.go
@@ -120,7 +120,7 @@ func TestHealthchecksEndPoints(t *testing.T) {
 			func(m *mocks.MockPP) {
 				gomock.InOrder(
 					m.EXPECT().Noticef(pp.EmojiUserWarning, "The Healthchecks URL (redacted) uses HTTP; please consider using HTTPS"),
-					m.EXPECT().Infof(pp.EmojiPing, "Pinged the %s endpoint of Healthchecks", `default (root)`),
+					m.EXPECT().Infof(pp.EmojiPing, "Pinged the %s endpoint of Healthchecks: the updater has started", `default (root)`),
 				)
 			},
 		},
@@ -164,7 +164,7 @@ func TestHealthchecksEndPoints(t *testing.T) {
 			func(m *mocks.MockPP) {
 				gomock.InOrder(
 					m.EXPECT().Noticef(pp.EmojiUserWarning, "The Healthchecks URL (redacted) uses HTTP; please consider using HTTPS"),
-					m.EXPECT().Infof(pp.EmojiPing, "Pinged the %s endpoint of Healthchecks", `"/fail"`),
+					m.EXPECT().Infof(pp.EmojiPing, "Pinged the %s endpoint of Healthchecks: the updater has started", `"/fail"`),
 				)
 			},
 		},
@@ -179,7 +179,7 @@ func TestHealthchecksEndPoints(t *testing.T) {
 			func(m *mocks.MockPP) {
 				gomock.InOrder(
 					m.EXPECT().Noticef(pp.EmojiUserWarning, "The Healthchecks URL (redacted) uses HTTP; please consider using HTTPS"),
-					m.EXPECT().Infof(pp.EmojiPing, "Pinged the %s endpoint of Healthchecks", `"/start"`),
+					m.EXPECT().Infof(pp.EmojiPing, "Pinged the %s endpoint of Healthchecks: the updater has started", `"/start"`),
 				)
 			},
 		},
@@ -194,7 +194,7 @@ func TestHealthchecksEndPoints(t *testing.T) {
 			func(m *mocks.MockPP) {
 				gomock.InOrder(
 					m.EXPECT().Noticef(pp.EmojiUserWarning, "The Healthchecks URL (redacted) uses HTTP; please consider using HTTPS"),
-					m.EXPECT().Infof(pp.EmojiPing, "Pinged the %s endpoint of Healthchecks", `"/0"`),
+					m.EXPECT().Infof(pp.EmojiPing, "Pinged the %s endpoint of Healthchecks: the updater has started", `"/0"`),
 				)
 			},
 		},
@@ -209,7 +209,7 @@ func TestHealthchecksEndPoints(t *testing.T) {
 			func(m *mocks.MockPP) {
 				gomock.InOrder(
 					m.EXPECT().Noticef(pp.EmojiUserWarning, "The Healthchecks URL (redacted) uses HTTP; please consider using HTTPS"),
-					m.EXPECT().Infof(pp.EmojiPing, "Pinged the %s endpoint of Healthchecks", `"/log"`),
+					m.EXPECT().Infof(pp.EmojiPing, "Pinged the %s endpoint of Healthchecks: the updater has started", `"/log"`),
 				)
 			},
 		},
@@ -224,7 +224,7 @@ func TestHealthchecksEndPoints(t *testing.T) {
 			func(m *mocks.MockPP) {
 				gomock.InOrder(
 					m.EXPECT().Noticef(pp.EmojiUserWarning, "The Healthchecks URL (redacted) uses HTTP; please consider using HTTPS"),
-					m.EXPECT().Infof(pp.EmojiPing, "Pinged the %s endpoint of Healthchecks", `"/fail"`),
+					m.EXPECT().Infof(pp.EmojiPing, "Pinged the %s endpoint of Healthchecks: the updater has started", `"/fail"`),
 				)
 			},
 		},

--- a/internal/monitor/healthchecks_test.go
+++ b/internal/monitor/healthchecks_test.go
@@ -120,7 +120,7 @@ func TestHealthchecksEndPoints(t *testing.T) {
 			func(m *mocks.MockPP) {
 				gomock.InOrder(
 					m.EXPECT().Noticef(pp.EmojiUserWarning, "The Healthchecks URL (redacted) uses HTTP; please consider using HTTPS"),
-					m.EXPECT().Infof(pp.EmojiPing, "Pinged the %s endpoint of Healthchecks: the updater has started", `default (root)`),
+					m.EXPECT().Infof(pp.EmojiPing, "Pinged the %s endpoint of Healthchecks: %s", `default (root)`, `ping successful`),
 				)
 			},
 		},
@@ -164,7 +164,7 @@ func TestHealthchecksEndPoints(t *testing.T) {
 			func(m *mocks.MockPP) {
 				gomock.InOrder(
 					m.EXPECT().Noticef(pp.EmojiUserWarning, "The Healthchecks URL (redacted) uses HTTP; please consider using HTTPS"),
-					m.EXPECT().Infof(pp.EmojiPing, "Pinged the %s endpoint of Healthchecks: the updater has started", `"/fail"`),
+					m.EXPECT().Infof(pp.EmojiPing, "Pinged the %s endpoint of Healthchecks: %s", `"/fail"`, `failure reported`),
 				)
 			},
 		},
@@ -179,7 +179,7 @@ func TestHealthchecksEndPoints(t *testing.T) {
 			func(m *mocks.MockPP) {
 				gomock.InOrder(
 					m.EXPECT().Noticef(pp.EmojiUserWarning, "The Healthchecks URL (redacted) uses HTTP; please consider using HTTPS"),
-					m.EXPECT().Infof(pp.EmojiPing, "Pinged the %s endpoint of Healthchecks: the updater has started", `"/start"`),
+					m.EXPECT().Infof(pp.EmojiPing, "Pinged the %s endpoint of Healthchecks: %s", `"/start"`, `the updater has started`),
 				)
 			},
 		},
@@ -194,7 +194,7 @@ func TestHealthchecksEndPoints(t *testing.T) {
 			func(m *mocks.MockPP) {
 				gomock.InOrder(
 					m.EXPECT().Noticef(pp.EmojiUserWarning, "The Healthchecks URL (redacted) uses HTTP; please consider using HTTPS"),
-					m.EXPECT().Infof(pp.EmojiPing, "Pinged the %s endpoint of Healthchecks: the updater has started", `"/0"`),
+					m.EXPECT().Infof(pp.EmojiPing, "Pinged the %s endpoint of Healthchecks: %s", `"/0"`, `the updater has stopped`),
 				)
 			},
 		},
@@ -209,7 +209,7 @@ func TestHealthchecksEndPoints(t *testing.T) {
 			func(m *mocks.MockPP) {
 				gomock.InOrder(
 					m.EXPECT().Noticef(pp.EmojiUserWarning, "The Healthchecks URL (redacted) uses HTTP; please consider using HTTPS"),
-					m.EXPECT().Infof(pp.EmojiPing, "Pinged the %s endpoint of Healthchecks: the updater has started", `"/log"`),
+					m.EXPECT().Infof(pp.EmojiPing, "Pinged the %s endpoint of Healthchecks: %s", `"/log"`, `status logged`),
 				)
 			},
 		},
@@ -224,7 +224,7 @@ func TestHealthchecksEndPoints(t *testing.T) {
 			func(m *mocks.MockPP) {
 				gomock.InOrder(
 					m.EXPECT().Noticef(pp.EmojiUserWarning, "The Healthchecks URL (redacted) uses HTTP; please consider using HTTPS"),
-					m.EXPECT().Infof(pp.EmojiPing, "Pinged the %s endpoint of Healthchecks: the updater has started", `"/fail"`),
+					m.EXPECT().Infof(pp.EmojiPing, "Pinged the %s endpoint of Healthchecks: %s", `"/fail"`, `failure reported`),
 				)
 			},
 		},

--- a/internal/notifier/shoutrrr.go
+++ b/internal/notifier/shoutrrr.go
@@ -107,7 +107,7 @@ func (s Shoutrrr) Send(_ context.Context, ppfmt pp.PP, msg Message) bool {
 	}
 	if allOK {
 		ppfmt.Infof(pp.EmojiNotify,
-			"Notified %s via shoutrrr",
+			"Notified %s via shoutrrr: the updater has started",
 			pp.EnglishJoin(s.ServiceDescriptions))
 	}
 	return allOK

--- a/internal/notifier/shoutrrr.go
+++ b/internal/notifier/shoutrrr.go
@@ -107,8 +107,9 @@ func (s Shoutrrr) Send(_ context.Context, ppfmt pp.PP, msg Message) bool {
 	}
 	if allOK {
 		ppfmt.Infof(pp.EmojiNotify,
-			"Notified %s via shoutrrr: the updater has started",
-			pp.EnglishJoin(s.ServiceDescriptions))
+			"Notified %s via shoutrrr: %s",
+			pp.EnglishJoin(s.ServiceDescriptions),
+			`the updater has started`)
 	}
 	return allOK
 }

--- a/internal/notifier/shoutrrr.go
+++ b/internal/notifier/shoutrrr.go
@@ -97,11 +97,16 @@ func (s Shoutrrr) Send(_ context.Context, ppfmt pp.PP, msg Message) bool {
 		return true
 	}
 
-	errs := s.Router.Send(msg.Format(), &types.Params{})
+	formattedMsg := msg.Format()
+	errs := s.Router.Send(formattedMsg, &types.Params{})
 	allOK := true
 	for _, err := range errs {
 		if err != nil {
-			ppfmt.Noticef(pp.EmojiError, "Failed to notify shoutrrr service(s): %v", err)
+			ppfmt.Noticef(pp.EmojiError,
+				"Failed to notify shoutrrr service(s): %v (attempted to send: %s)",
+				err,
+				formattedMsg,
+			)
 			allOK = false
 		}
 	}
@@ -109,7 +114,8 @@ func (s Shoutrrr) Send(_ context.Context, ppfmt pp.PP, msg Message) bool {
 		ppfmt.Infof(pp.EmojiNotify,
 			"Notified %s via shoutrrr: %s",
 			pp.EnglishJoin(s.ServiceDescriptions),
-			`the updater has started`)
+			formattedMsg,
+		)
 	}
 	return allOK
 }

--- a/internal/notifier/shoutrrr_test.go
+++ b/internal/notifier/shoutrrr_test.go
@@ -94,7 +94,7 @@ func TestShoutrrrSend(t *testing.T) {
 			notifier.NewMessagef("hello"),
 			true,
 			func(m *mocks.MockPP) {
-				m.EXPECT().Infof(pp.EmojiNotify, "Notified %s via shoutrrr: the updater has started", "Generic")
+				m.EXPECT().Infof(pp.EmojiNotify, "Notified %s via shoutrrr: %s", `Generic`, `the updater has started`)
 			},
 		},
 		"ill-formed url": {

--- a/internal/notifier/shoutrrr_test.go
+++ b/internal/notifier/shoutrrr_test.go
@@ -94,7 +94,7 @@ func TestShoutrrrSend(t *testing.T) {
 			notifier.NewMessagef("hello"),
 			true,
 			func(m *mocks.MockPP) {
-				m.EXPECT().Infof(pp.EmojiNotify, "Notified %s via shoutrrr: %s", `Generic`, `the updater has started`)
+				m.EXPECT().Infof(pp.EmojiNotify, "Notified %s via shoutrrr: %s", `Generic`, `hello`)
 			},
 		},
 		"ill-formed url": {
@@ -103,7 +103,7 @@ func TestShoutrrrSend(t *testing.T) {
 			notifier.NewMessagef("hello"),
 			false,
 			func(m *mocks.MockPP) {
-				m.EXPECT().Noticef(pp.EmojiError, "Failed to notify shoutrrr service(s): %v", gomock.Any())
+				m.EXPECT().Noticef(pp.EmojiError, "Failed to notify shoutrrr service(s): %v (attempted to send: %s)", gomock.Any(), `hello`)
 			},
 		},
 		"empty": {

--- a/internal/notifier/shoutrrr_test.go
+++ b/internal/notifier/shoutrrr_test.go
@@ -94,7 +94,7 @@ func TestShoutrrrSend(t *testing.T) {
 			notifier.NewMessagef("hello"),
 			true,
 			func(m *mocks.MockPP) {
-				m.EXPECT().Infof(pp.EmojiNotify, "Notified %s via shoutrrr", "Generic")
+				m.EXPECT().Infof(pp.EmojiNotify, "Notified %s via shoutrrr: the updater has started", "Generic")
 			},
 		},
 		"ill-formed url": {


### PR DESCRIPTION
This PR addresses [close #959]( https://github.com/favonia/cloudflare-ddns/issues/959) by improving logging messages sent to the monitor/notifier.