### PR TITLE
fix: Add default BUILDPLATFORM argument in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 # syntax=docker/dockerfile:1.7-labs
 # We use cross-compilation because QEMU is slow.
+ARG BUILDPLATFORM=linux/amd64
 FROM --platform=${BUILDPLATFORM} golang:1.24.3-alpine3.20@sha256:9f98e9893fbc798c710f3432baa1e0ac6127799127c3101d2c263c3a954f0abe AS build
 
 ARG GIT_DESCRIBE


### PR DESCRIPTION
## Summary

This PR adds a default value for the `BUILDPLATFORM` build argument in the Dockerfile to prevent build failures when the platform is not explicitly specified.

## Changes

- Added `ARG BUILDPLATFORM=linux/amd64` before the FROM instruction to provide a sensible default

## Why This Fix is Needed

The Dockerfile uses `--platform=${BUILDPLATFORM}` in the FROM instruction for cross-compilation, but the `BUILDPLATFORM` argument was not defined with a default value. This causes build failures in environments where the build platform is not automatically set.

By providing a default value of `linux/amd64`, the Dockerfile will build successfully even when `BUILDPLATFORM` is not explicitly passed as a build argument, while still allowing it to be overridden when needed.

## Testing

- Verified the Dockerfile builds successfully without specifying `--build-arg BUILDPLATFORM`
- Confirmed the existing build behavior is preserved when `BUILDPLATFORM` is explicitly provided