### PR TITLE
fix(api): retry zone lookups after semantic zone resolution failures

### DIFF
--- a/internal/api/cloudflare_records.go
+++ b/internal/api/cloudflare_records.go
@@ -203,8 +203,23 @@ zoneSearch:
 			ppfmt.Noticef(pp.EmojiImpossible,
 				"Found multiple active zones named %s (IDs: %s); please report this at %s",
 				zoneName, pp.EnglishJoinMap(ID.String, ids), pp.IssueReportingURL)
+			// The suffix walk reached a semantic dead end at zoneName. Retry the
+			// traversed suffixes up to and including that boundary next cycle.
+			for cachedZoneName := range domain.Zones {
+				h.cache.listZones.Delete(cachedZoneName)
+				if cachedZoneName == zoneName {
+					break
+				}
+			}
 			return zero, false
 		}
+	}
+
+	// The suffix walk found no usable zone. Clear all candidate suffix caches so
+	// new or recovered zones are retried on the next cycle instead of waiting for
+	// the full zone-list cache TTL.
+	for zoneName := range domain.Zones {
+		h.cache.listZones.Delete(zoneName)
 	}
 
 	ppfmt.Noticef(pp.EmojiError, "Failed to find the zone of %s", domain.Describe())

--- a/internal/api/cloudflare_records_zone_test.go
+++ b/internal/api/cloudflare_records_zone_test.go
@@ -282,6 +282,94 @@ func TestZoneIDOfDomainCache(t *testing.T) {
 	assertHandlersExhausted(t, zh)
 }
 
+func TestZoneIDOfDomainClearsEmptyZoneCacheAfterFailedLookup(t *testing.T) {
+	t.Parallel()
+
+	f := newCloudflareHarness(t)
+	zoneStatuses := map[string][]string{}
+	zh := newZonesHandler(t, f.serveMux, zoneStatuses)
+
+	zh.setRequestLimit(3)
+	mockPP := f.newPP()
+	mockPP.EXPECT().Noticef(pp.EmojiError, "Failed to find the zone of %s", "sub.test.org")
+	zoneID, ok := f.cfHandle.ZoneIDOfDomain(context.Background(), mockPP, domain.FQDN("sub.test.org"))
+	require.False(t, ok)
+	require.Zero(t, zoneID)
+	assertHandlersExhausted(t, zh)
+
+	zoneStatuses["test.org"] = []string{"active"}
+
+	zh.setRequestLimit(2)
+	zoneID, ok = f.cfHandle.ZoneIDOfDomain(context.Background(), f.newPP(), domain.FQDN("sub.test.org"))
+	require.True(t, ok)
+	require.Equal(t, mockID("test.org", 0), zoneID)
+	assertHandlersExhausted(t, zh)
+}
+
+func TestZoneIDOfDomainFailedLookupDoesNotKeepEmptySuffixCache(t *testing.T) {
+	t.Parallel()
+
+	f := newCloudflareHarness(t)
+	zh := newZonesHandler(t, f.serveMux, map[string][]string{})
+
+	zh.setRequestLimit(3)
+	mockPP := f.newPP()
+	mockPP.EXPECT().Noticef(pp.EmojiError, "Failed to find the zone of %s", "sub.test.org")
+	zoneID, ok := f.cfHandle.ZoneIDOfDomain(context.Background(), mockPP, domain.FQDN("sub.test.org"))
+	require.False(t, ok)
+	require.Zero(t, zoneID)
+	assertHandlersExhausted(t, zh)
+
+	zh.setRequestLimit(3)
+	mockPP = f.newPP()
+	mockPP.EXPECT().Noticef(pp.EmojiError, "Failed to find the zone of %s", "sub.test.org")
+	zoneID, ok = f.cfHandle.ZoneIDOfDomain(context.Background(), mockPP, domain.FQDN("sub.test.org"))
+	require.False(t, ok)
+	require.Zero(t, zoneID)
+	assertHandlersExhausted(t, zh)
+}
+
+func TestZoneIDOfDomainClearsZoneCacheAfterDuplicateZoneFailure(t *testing.T) {
+	t.Parallel()
+
+	f := newCloudflareHarness(t)
+	zoneStatuses := map[string][]string{
+		"test.org": {"active", "active"},
+		"org":      {},
+	}
+	zh := newZonesHandler(t, f.serveMux, zoneStatuses)
+
+	zh.setRequestLimit(1)
+	output, ok := f.cfHandle.ListZones(context.Background(), f.newPP(), "org")
+	require.True(t, ok)
+	require.Empty(t, output)
+	assertHandlersExhausted(t, zh)
+
+	zh.setRequestLimit(2)
+	mockPP := f.newPP()
+	mockPP.EXPECT().Noticef(pp.EmojiImpossible,
+		"Found multiple active zones named %s (IDs: %s); please report this at %s",
+		"test.org", pp.EnglishJoin(mockIDsAsStrings("test.org", 0, 1)), pp.IssueReportingURL)
+	zoneID, ok := f.cfHandle.ZoneIDOfDomain(context.Background(), mockPP, domain.FQDN("sub.test.org"))
+	require.False(t, ok)
+	require.Zero(t, zoneID)
+	assertHandlersExhausted(t, zh)
+
+	zoneStatuses["test.org"] = []string{"active"}
+
+	zh.setRequestLimit(0)
+	output, ok = f.cfHandle.ListZones(context.Background(), f.newPP(), "org")
+	require.True(t, ok)
+	require.Empty(t, output)
+	assertHandlersExhausted(t, zh)
+
+	zh.setRequestLimit(2)
+	zoneID, ok = f.cfHandle.ZoneIDOfDomain(context.Background(), f.newPP(), domain.FQDN("sub.test.org"))
+	require.True(t, ok)
+	require.Equal(t, mockID("test.org", 0), zoneID)
+	assertHandlersExhausted(t, zh)
+}
+
 func TestZoneIDOfDomainInvalid(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Close #1036. Close #1038.