### PR TITLE
ci: doc-watch is working!

### DIFF
--- a/scripts/github-actions/cloudflare-doc-watch/config/waf-list-deletion-rule.json
+++ b/scripts/github-actions/cloudflare-doc-watch/config/waf-list-deletion-rule.json
@@ -3,15 +3,15 @@
   "repo": "cloudflare/cloudflare-docs",
   "ref": "production",
   "path": "src/content/docs/waf/tools/lists/index.mdx",
-  "snapshot_date": "2026-03-22",
+  "snapshot_date": "2026-03-24",
   "history_url": "https://github.com/cloudflare/cloudflare-docs/commits/production/src/content/docs/waf/tools/lists/index.mdx",
   "page_url": "https://developers.cloudflare.com/waf/tools/lists/index.md",
   "watched_heading": "## Final remarks",
   "line_filters": [
-    "^You can only delete a list when there are no rules"
+    "^You can only delete a list"
   ],
   "expected_lines": [
-    "You can only delete a list when there are no rules (enabled or disabled) that reference that list."
+    "You can only delete a list when no rules (enabled or disabled) reference it."
   ],
   "watch_label": "Watched list-deletion rule",
   "reminders": [


### PR DESCRIPTION
Wow! This is very exciting, the doc-watch script is working! It correctly detected the documentation drift. :smile: