### PR TITLE
fix: keep SetupPP usable on parse failure

### DIFF
--- a/.github/workflows/smoke-test.yaml
+++ b/.github/workflows/smoke-test.yaml
@@ -1,0 +1,59 @@
+name: Smoke Test
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  binary-smoke-test:
+    name: Binary Smoke Test
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: 🛡️ Harden Runner
+        uses: step-security/harden-runner@58077d3c7e43986b6b15fba718e8ea69e387dfcc # v2.15.1
+        with:
+          egress-policy: audit
+          disable-sudo: true
+          policy: test
+
+      - name: 🚚 Check out the repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - name: 🏗️ Set up Go
+        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
+        with:
+          go-version: stable
+      - name: 🧪 Run covered `cmd/ddns` shell smoke test
+        run: |
+          tmpdir="$(mktemp -d)"
+          go build -cover -o "${tmpdir}/ddns" ./cmd/ddns
+          mkdir "${tmpdir}/gocover"
+
+          set +e
+          output="$(
+            EMOJI=invalid \
+            GOCOVERDIR="${tmpdir}/gocover" \
+            "${tmpdir}/ddns" 2>&1
+          )"
+          exit_code=$?
+          set -e
+
+          test "${exit_code}" -eq 1
+          printf '%s\n' "${output}" | grep -F 'EMOJI ("invalid") is not a boolean'
+          printf '%s\n' "${output}" | grep -F 'Bye!'
+          go tool covdata textfmt -i "${tmpdir}/gocover" -o integration-coverage.txt
+      - name: ☂️ Report smoke-test coverage to Codecov
+        uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.2
+        with:
+          fail_ci_if_error: true # default: false
+          file: ./integration-coverage.txt
+          flags: binarytests
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/cmd/ddns/ddns.go
+++ b/cmd/ddns/ddns.go
@@ -88,10 +88,12 @@ func realMain() int {
 	sig := signal.Setup()
 	ctxWithSignals, _ := signal.NotifyContext(ctx)
 
-	// Set up pretty printer
+	// Set up pretty printer. SetupPP intentionally still returns a usable
+	// printer on failure so this top-level path can report a final message
+	// after the concrete parse error.
 	ppfmt, ok := config.SetupPP(os.Stdout)
 	if !ok {
-		ppfmt.Infof(pp.EmojiUserError, "Bye!")
+		ppfmt.Infof(pp.EmojiBye, "Bye!")
 		return 1
 	}
 

--- a/cmd/ddns/ddns_test.go
+++ b/cmd/ddns/ddns_test.go
@@ -158,6 +158,13 @@ func TestRealMainReporterFailure(t *testing.T) {
 	require.Equal(t, 1, realMain())
 }
 
+func TestRealMainSetupPPFailure(t *testing.T) {
+	resetInitConfigEnv(t)
+	t.Setenv("EMOJI", "invalid")
+
+	require.Equal(t, 1, realMain())
+}
+
 //nolint:paralleltest // Version is a global linker-injected variable
 func TestFormatName(t *testing.T) {
 	oldVersion := Version

--- a/internal/config/setup_pp.go
+++ b/internal/config/setup_pp.go
@@ -15,6 +15,12 @@ import (
 //
 // Omitting these settings is semantically equivalent to EMOJI=true and
 // QUIET=false.
+//
+// Even when it returns ok=false, it still returns a usable pretty printer that
+// reflects the formatting state resolved up to the point of failure. This is an
+// intentional deviation from the more common Go convention of returning the
+// zero value on failure: the caller still needs a printer for top-level startup
+// messages such as the final "Bye!" after reporting the concrete parse error.
 func SetupPP(output io.Writer) (pp.PP, bool) {
 	emoji, verbosity := true, pp.Verbose
 
@@ -22,18 +28,20 @@ func SetupPP(output io.Writer) (pp.PP, bool) {
 
 	if valEmoji != "" {
 		b, err := strconv.ParseBool(valEmoji)
+		ppfmt := pp.New(output, emoji, verbosity)
 		if err != nil {
-			pp.New(output, emoji, verbosity).Noticef(pp.EmojiUserError, "EMOJI (%q) is not a boolean: %v", valEmoji, err)
-			return nil, false
+			ppfmt.Noticef(pp.EmojiUserError, "EMOJI (%q) is not a boolean: %v", valEmoji, err)
+			return ppfmt, false
 		}
 		emoji = b
 	}
 
 	if valQuiet != "" {
 		b, err := strconv.ParseBool(valQuiet)
+		ppfmt := pp.New(output, emoji, verbosity)
 		if err != nil {
-			pp.New(output, emoji, verbosity).Noticef(pp.EmojiUserError, "QUIET (%q) is not a boolean: %v", valQuiet, err)
-			return nil, false
+			ppfmt.Noticef(pp.EmojiUserError, "QUIET (%q) is not a boolean: %v", valQuiet, err)
+			return ppfmt, false
 		}
 
 		if b {

--- a/internal/config/setup_pp_test.go
+++ b/internal/config/setup_pp_test.go
@@ -39,16 +39,20 @@ func TestSetupPP(t *testing.T) {
 			var buf strings.Builder
 			ppfmt, ok := config.SetupPP(&buf)
 			require.Equal(t, tc.ok, ok)
+			require.NotZero(t, ppfmt)
 
 			switch {
 			case ok:
-				require.NotZero(t, ppfmt)
 				ppfmt.Infof(pp.EmojiStar, "info")
 				ppfmt.Noticef(pp.EmojiStar, "notice")
 				require.Equal(t, tc.output, buf.String())
 			case !ok:
-				require.Zero(t, ppfmt)
-				require.Equal(t, tc.output, buf.String())
+				ppfmt.Infof(pp.EmojiBye, "Bye!")
+				if tc.valEmoji == "false" {
+					require.Equal(t, tc.output+"Bye!\n", buf.String())
+				} else {
+					require.Equal(t, tc.output+"👋 Bye!\n", buf.String())
+				}
 			}
 		})
 	}


### PR DESCRIPTION
Most users will never trigger this and the impact (if triggered) is extremely small, but let's fix it anyway.

The new tests will detect this bug in the future.