### PR TITLE
ux: warn about env files and polish auth error messages

### DIFF
--- a/internal/config/config_read_test.go
+++ b/internal/config/config_read_test.go
@@ -85,7 +85,7 @@ func TestReadEnvEmpty(t *testing.T) {
 		mockPP.EXPECT().Infof(pp.EmojiEnvVars, "Reading settings . . ."),
 		mockPP.EXPECT().Indent().Return(innerMockPP),
 		innerMockPP.EXPECT().Noticef(pp.EmojiUserError,
-			"Requires either %s or %s", "CLOUDFLARE_API_TOKEN", "CLOUDFLARE_API_TOKEN_FILE"),
+			"Either %s or %s must be set", "CLOUDFLARE_API_TOKEN", "CLOUDFLARE_API_TOKEN_FILE"),
 	)
 	ok := cfg.ReadEnv(mockPP)
 	require.False(t, ok)

--- a/internal/config/env_auth.go
+++ b/internal/config/env_auth.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"regexp"
+	"strings"
 
 	"github.com/favonia/cloudflare-ddns/internal/api"
 	"github.com/favonia/cloudflare-ddns/internal/file"
@@ -37,21 +38,42 @@ func tokenHasMatchingQuotes(token string) bool {
 	}
 }
 
-func ensureTokenNotQuoted(ppfmt pp.PP, token, tokenKey string) bool {
-	if !tokenHasMatchingQuotes(token) {
-		return true
+func sanityCheckToken(ppfmt pp.PP, tokenKey string, fromFile bool, token string) bool {
+	// foolproof check: the sample value in README
+	if token == "YOUR-CLOUDFLARE-API-TOKEN" {
+		ppfmt.Noticef(pp.EmojiUserError, "You need to provide a real API token as the value of %s", tokenKey)
+		return false
 	}
 
-	ppfmt.Noticef(pp.EmojiUserError,
-		"The token provided by %s appears to include surrounding quotation marks; remove the extra quotes", tokenKey)
-	return false
+	// Some setups, including NixOS modules, pass an environment file as the token file.
+	if fromFile {
+		switch {
+		case strings.HasPrefix(token, "CLOUDFLARE_API_TOKEN="):
+			ppfmt.Noticef(pp.EmojiUserError,
+				`The token file appears to be an environment file with "CLOUDFLARE_API_TOKEN=..."; `+
+					`the file should contain only the token itself`)
+			return false
+		case strings.HasPrefix(token, "CF_API_TOKEN="):
+			ppfmt.Noticef(pp.EmojiUserError,
+				`The token file appears to be an environment file with "CF_API_TOKEN=..."; `+
+					`the file should contain only the token itself`)
+			return false
+		}
+	}
+
+	if tokenHasMatchingQuotes(token) {
+		ppfmt.Noticef(pp.EmojiUserError,
+			"The value of %s appears to include surrounding quotation marks; remove the extra quotes", tokenKey)
+		return false
+	}
+
+	return true
 }
 
-func readPlainAuthTokens(ppfmt pp.PP) (string, string, bool) {
+func readPlainAuthTokens(ppfmt pp.PP) (tokenKey, token string, ok bool) {
 	token1 := getenv(tokenKey1)
 	token2 := getenv(tokenKey2)
 
-	var token, tokenKey string
 	switch {
 	case token1 == "" && token2 == "":
 		return "", "", true
@@ -60,23 +82,17 @@ func readPlainAuthTokens(ppfmt pp.PP) (string, string, bool) {
 			"The values of %s and %s do not match; they must specify the same token", tokenKey1, tokenKey2)
 		return "", "", false
 	case token1 != "":
-		token, tokenKey = token1, tokenKey1
+		tokenKey, token = tokenKey1, token1
 	case token2 != "":
 		ppfmt.NoticeOncef(pp.MessageAuthTokenNewPrefix, pp.EmojiHint, hintAuthTokenNewPrefix)
-		token, tokenKey = token2, tokenKey2
+		tokenKey, token = tokenKey2, token2
 	}
 
-	// foolproof check: the sample value in README
-	if token == "YOUR-CLOUDFLARE-API-TOKEN" {
-		ppfmt.Noticef(pp.EmojiUserError, "You need to provide a real API token as %s", tokenKey)
+	if !sanityCheckToken(ppfmt, tokenKey, false, token) {
 		return "", "", false
 	}
 
-	if !ensureTokenNotQuoted(ppfmt, token, tokenKey) {
-		return "", "", false
-	}
-
-	return token, tokenKey, true
+	return tokenKey, token, true
 }
 
 func readAuthTokenFile(ppfmt pp.PP, key string) (string, bool) {
@@ -95,14 +111,14 @@ func readAuthTokenFile(ppfmt pp.PP, key string) (string, bool) {
 		return "", false
 	}
 
-	if !ensureTokenNotQuoted(ppfmt, token, key) {
+	if !sanityCheckToken(ppfmt, key, true, token) {
 		return "", false
 	}
 
 	return token, true
 }
 
-func readAuthTokenFiles(ppfmt pp.PP) (string, string, bool) {
+func readAuthTokenFiles(ppfmt pp.PP) (tokenKey, token string, ok bool) {
 	token1, ok := readAuthTokenFile(ppfmt, tokenFileKey1)
 	if !ok {
 		return "", "", false
@@ -116,42 +132,42 @@ func readAuthTokenFiles(ppfmt pp.PP) (string, string, bool) {
 	switch {
 	case token1 != "" && token2 != "" && token1 != token2:
 		ppfmt.Noticef(pp.EmojiUserError,
-			"The files specified by %s and %s have conflicting tokens; their content must match", tokenFileKey1, tokenFileKey2)
+			"The files specified by %s and %s have different tokens; their content must match", tokenFileKey1, tokenFileKey2)
 		return "", "", false
 	case token1 != "":
-		return token1, tokenFileKey1, true
+		return tokenFileKey1, token1, true
 	case token2 != "":
 		ppfmt.NoticeOncef(pp.MessageAuthTokenNewPrefix, pp.EmojiHint, hintAuthTokenNewPrefix)
-		return token2, tokenFileKey2, true
+		return tokenFileKey2, token2, true
 	default:
 		return "", "", true
 	}
 }
 
 func readAuthToken(ppfmt pp.PP) (string, bool) {
-	tokenPlain, tokenPlainKey, ok := readPlainAuthTokens(ppfmt)
+	tokenPlainKey, tokenPlain, ok := readPlainAuthTokens(ppfmt)
 	if !ok {
 		return "", false
 	}
 
-	tokenFile, tokenFileKey, ok := readAuthTokenFiles(ppfmt)
+	tokenFromFileKey, tokenFromFile, ok := readAuthTokenFiles(ppfmt)
 	if !ok {
 		return "", false
 	}
 
 	var token string
 	switch {
-	case tokenPlain != "" && tokenFile != "" && tokenPlain != tokenFile:
+	case tokenPlain != "" && tokenFromFile != "" && tokenPlain != tokenFromFile:
 		ppfmt.Noticef(pp.EmojiUserError,
 			"The value of %s does not match the token found in the file specified by %s; they must specify the same token",
-			tokenPlainKey, tokenFileKey)
+			tokenPlainKey, tokenFromFileKey)
 		return "", false
 	case tokenPlain != "":
 		token = tokenPlain
-	case tokenFile != "":
-		token = tokenFile
+	case tokenFromFile != "":
+		token = tokenFromFile
 	default:
-		ppfmt.Noticef(pp.EmojiUserError, "Requires either %s or %s", tokenKey1, tokenFileKey1)
+		ppfmt.Noticef(pp.EmojiUserError, "Either %s or %s must be set", tokenKey1, tokenFileKey1)
 		return "", false
 	}
 

--- a/internal/config/env_auth_test.go
+++ b/internal/config/env_auth_test.go
@@ -44,7 +44,7 @@ func TestReadAuth(t *testing.T) {
 			"", "", "", "", "",
 			false, "",
 			func(m *mocks.MockPP) {
-				m.EXPECT().Noticef(pp.EmojiUserError, "Requires either %s or %s", "CLOUDFLARE_API_TOKEN", "CLOUDFLARE_API_TOKEN_FILE")
+				m.EXPECT().Noticef(pp.EmojiUserError, "Either %s or %s must be set", "CLOUDFLARE_API_TOKEN", "CLOUDFLARE_API_TOKEN_FILE")
 			},
 		},
 		"conflicting": {
@@ -82,7 +82,7 @@ func TestReadAuth(t *testing.T) {
 			false, "",
 			func(m *mocks.MockPP) {
 				m.EXPECT().Noticef(pp.EmojiUserError,
-					"The token provided by %s appears to include surrounding quotation marks; remove the extra quotes",
+					"The value of %s appears to include surrounding quotation marks; remove the extra quotes",
 					"CLOUDFLARE_API_TOKEN")
 			},
 		},
@@ -99,7 +99,7 @@ func TestReadAuth(t *testing.T) {
 			"YOUR-CLOUDFLARE-API-TOKEN", "", "", "", "",
 			false, "",
 			func(m *mocks.MockPP) {
-				m.EXPECT().Noticef(pp.EmojiUserError, "You need to provide a real API token as %s", "CLOUDFLARE_API_TOKEN")
+				m.EXPECT().Noticef(pp.EmojiUserError, "You need to provide a real API token as the value of %s", "CLOUDFLARE_API_TOKEN")
 			},
 		},
 		"file/success": {
@@ -121,7 +121,7 @@ func TestReadAuth(t *testing.T) {
 			false, "",
 			func(m *mocks.MockPP) {
 				m.EXPECT().Noticef(pp.EmojiUserError,
-					"The token provided by %s appears to include surrounding quotation marks; remove the extra quotes",
+					"The value of %s appears to include surrounding quotation marks; remove the extra quotes",
 					"CLOUDFLARE_API_TOKEN_FILE")
 			},
 		},
@@ -130,7 +130,7 @@ func TestReadAuth(t *testing.T) {
 			"", "", "/token1.txt", "/token2.txt", "",
 			false, "",
 			func(m *mocks.MockPP) {
-				m.EXPECT().Noticef(pp.EmojiUserError, "The files specified by %s and %s have conflicting tokens; their content must match", "CLOUDFLARE_API_TOKEN_FILE", "CF_API_TOKEN_FILE")
+				m.EXPECT().Noticef(pp.EmojiUserError, "The files specified by %s and %s have different tokens; their content must match", "CLOUDFLARE_API_TOKEN_FILE", "CF_API_TOKEN_FILE")
 			},
 		},
 		"file/conflicting/non-file": {
@@ -173,6 +173,30 @@ func TestReadAuth(t *testing.T) {
 			false, "",
 			func(m *mocks.MockPP) {
 				m.EXPECT().Noticef(pp.EmojiUserError, "Failed to read %s: %v", "/wrong.txt", gomock.Any())
+			},
+		},
+		"file/copycat": {
+			map[string]string{"token.txt": "YOUR-CLOUDFLARE-API-TOKEN"},
+			"", "", "/token.txt", "", "",
+			false, "",
+			func(m *mocks.MockPP) {
+				m.EXPECT().Noticef(pp.EmojiUserError, "You need to provide a real API token as the value of %s", "CLOUDFLARE_API_TOKEN_FILE")
+			},
+		},
+		"file/env-file/cloudflare": {
+			map[string]string{"token.txt": "CLOUDFLARE_API_TOKEN=hello"},
+			"", "", "/token.txt", "", "",
+			false, "",
+			func(m *mocks.MockPP) {
+				m.EXPECT().Noticef(pp.EmojiUserError, `The token file appears to be an environment file with "CLOUDFLARE_API_TOKEN=..."; the file should contain only the token itself`)
+			},
+		},
+		"file/env-file/cf": {
+			map[string]string{"token.txt": "CF_API_TOKEN=hello"},
+			"", "", "/token.txt", "", "",
+			false, "",
+			func(m *mocks.MockPP) {
+				m.EXPECT().Noticef(pp.EmojiUserError, `The token file appears to be an environment file with "CF_API_TOKEN=..."; the file should contain only the token itself`)
 			},
 		},
 		"file/invalid-directory": {

--- a/scripts/github-actions/smoke-test/cases.go
+++ b/scripts/github-actions/smoke-test/cases.go
@@ -67,7 +67,7 @@ var allCases = []smokeCase{
 		Env:              map[string]string{"QUIET": "true"},
 		ExpectedExitCode: 1,
 		OrderedFragments: []string{
-			"Requires either CLOUDFLARE_API_TOKEN or CLOUDFLARE_API_TOKEN_FILE",
+			"Either CLOUDFLARE_API_TOKEN or CLOUDFLARE_API_TOKEN_FILE must be set",
 		},
 	},
 }


### PR DESCRIPTION
I learned from the discussions in https://github.com/NixOS/nixpkgs/pull/505505 that the current NixOS module for this updater is passing an environment file as the token file.