### PR TITLE
fix: add proportional jitter to reduce synchronized API calls

### DIFF
--- a/cmd/ddns/ddns.go
+++ b/cmd/ddns/ddns.go
@@ -153,6 +153,10 @@ func realMain() int {
 		if first && !lifecycleConfig.UpdateOnStart {
 			hb.Ping(ctx, ppfmt, heartbeat.NewMessagef(true, "Started (no updates performed yet)"))
 		} else {
+			// Spread API calls across clients sharing the same nominal interval to
+			// reduce synchronized traffic spikes at Cloudflare's DNS API.
+			time.Sleep(cron.JitterDuration(time.Until(next)))
+
 			// Improve readability of the logging by separating each round of checks with blank lines.
 			ppfmt.BlankLineIfVerbose()
 

--- a/internal/cron/jitter.go
+++ b/internal/cron/jitter.go
@@ -1,0 +1,17 @@
+package cron
+
+import (
+	"math/rand"
+	"time"
+)
+
+// JitterDuration returns a random duration in [0, interval/5) to spread
+// API calls across clients that share the same nominal update interval.
+// This reduces synchronized traffic spikes at Cloudflare's DNS API.
+// Returns 0 for intervals too small to divide meaningfully (< 5ns).
+func JitterDuration(interval time.Duration) time.Duration {
+	if divisor := int64(interval) / 5; divisor > 0 {
+		return time.Duration(rand.Int63n(divisor)) //nolint:gosec // non-cryptographic jitter
+	}
+	return 0
+}

--- a/internal/cron/jitter_test.go
+++ b/internal/cron/jitter_test.go
@@ -1,0 +1,55 @@
+package cron_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/favonia/cloudflare-ddns/internal/cron"
+)
+
+func TestJitterDuration(t *testing.T) {
+	t.Parallel()
+
+	for name, tc := range map[string]struct {
+		interval time.Duration
+		wantMin  time.Duration
+		wantMax  time.Duration
+	}{
+		"5min": {
+			interval: 5 * time.Minute,
+			wantMin:  0,
+			wantMax:  60 * time.Second, // interval/5 = 60s, range is [0, 60s)
+		},
+		"1hour": {
+			interval: time.Hour,
+			wantMin:  0,
+			wantMax:  12 * time.Minute, // interval/5 = 12m, range is [0, 12m)
+		},
+		"sub5ns": {
+			interval: 4 * time.Nanosecond,
+			wantMin:  0,
+			wantMax:  0, // divisor = 0, must return 0
+		},
+		"zero": {
+			interval: 0,
+			wantMin:  0,
+			wantMax:  0,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			// Run several iterations to exercise the random range.
+			const iterations = 100
+			for range iterations {
+				got := cron.JitterDuration(tc.interval)
+				require.GreaterOrEqual(t, got, tc.wantMin,
+					"JitterDuration(%v) = %v, want >= %v", tc.interval, got, tc.wantMin)
+				require.LessOrEqual(t, got, tc.wantMax,
+					"JitterDuration(%v) = %v, want <= %v", tc.interval, got, tc.wantMax)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Hello, I'm a product manager at @Cloudflare who oversees our API platform. Our logs show that we get millions of clients calling our DDNS endpoints every 5 minutes. This is a noticeable increase over our typical baseline, and contributes to performance degradation. We would like to smooth out the API traffic so that the spikes aren't so prominent, and we have identified your project as one to reach out to.

I added some code that introduces proportional jitter to the DDNS update interval, which should help reduce synchronized API calls and improve performance for us and all the other services that you're using.

Let me know if you have any questions on this, happy to take your suggestions on this as well!