### PR TITLE
ci: Add GitHub Container Registry (ghcr.io) publishing

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -24,6 +24,7 @@ jobs:
     permissions:
       id-token: write # for cosign keyless signing via GitHub OIDC
       contents: read
+      packages: write # for pushing images to GitHub Container Registry (ghcr.io)
     steps:
       - name: 🛡️ Harden Runner
         uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
@@ -49,6 +50,13 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: 🔑 Log in to GitHub Container Registry
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+        if: ${{ github.event_name != 'pull_request' }}
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: 🏷️ Fetch git tags for `git describe`
         run: "git fetch --force --prune --unshallow --tags"
       - name: 📝 Run `git describe` and save its output
@@ -58,7 +66,9 @@ jobs:
         uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6.0.0
         id: meta
         with:
-          images: ${{ github.repository }}
+          images: |
+            ${{ github.repository }}
+            ghcr.io/${{ github.repository }}
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}
@@ -96,7 +106,9 @@ jobs:
         uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6.0.0
         id: meta-alpine
         with:
-          images: ${{ github.repository }}
+          images: |
+            ${{ github.repository }}
+            ghcr.io/${{ github.repository }}
           tags: |
             type=edge,suffix=-alpine
           annotations: |


### PR DESCRIPTION
## Summary
This PR adds GitHub Container Registry (ghcr.io) as an additional publishing target alongside Docker Hub.

## Motivation
Docker Hub's rate limiting (100 pulls/6hrs anonymous, 200 free) increasingly impacts CI/CD and self-hosted infrastructure. ghcr.io provides no rate limits for public images, a unified code+containers ecosystem, needs no extra secrets (uses the existing GITHUB_TOKEN), and reuses the same build — just an additional registry target.

## Changes
In `.github/workflows/build.yaml`:
- Added `packages: write` to the `docker` job `permissions` (alongside the existing `id-token: write` and `contents: read`) so the workflow can push to ghcr.io.
- Added a `Log in to GitHub Container Registry` step (docker/login-action, `registry: ghcr.io`, `username: ${{ github.actor }}`, `password: ${{ secrets.GITHUB_TOKEN }}`) right after the existing Docker Hub login, mirroring its `if: ${{ github.event_name != 'pull_request' }}` guard.
- Added `ghcr.io/${{ github.repository }}` to the `images:` list in both metadata-action steps (`meta` and `meta-alpine`), so every existing tag is mirrored to ghcr.io with no change to the tag strategy or multi-arch platform set.

## Backward Compatibility
Fully backward compatible — Docker Hub publishing is unchanged; this only adds an additional registry target. Build args, platforms, context, cache, cosign signing, and existing Docker Hub tags are untouched.

## Note on Previous Discussion
I saw this was discussed previously and declined due to Docker Sponsored OSS status. I wanted to revisit because: (1) many users run private CI/CD that doesn't benefit from Docker Sponsored OSS exemptions; (2) self-hosted environments (Kubernetes, Docker Swarm) still hit rate limits; (3) ghcr.io adds redundancy if Docker Hub has availability issues. Completely understand if the answer is still no — happy to close if not wanted.

## Testing
- [x] Workflow YAML validated
- [ ] Builds in maintainer CI on merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)
---

### 🔧 One-time maintainer step: make the GHCR package public

Heads-up for maintainers: the first time this workflow publishes to `ghcr.io/favonia/cloudflare-ddns`, GitHub creates the package as **private** by default. To let users `docker pull` it without authentication, a maintainer needs to set its visibility to **Public** once:

> Repo **Packages** → the new `cloudflare-ddns` package → **Package settings** → **Danger Zone** → **Change visibility** → **Public**

It's a one-time action — subsequent pushes inherit the setting. (Flagged by an automated reviewer; surfacing it here so the rollout is smooth.)

<!-- ghcr-visibility-note -->