### PR TITLE
feat: canonical domain String() with root-aware Describe()

### DIFF
--- a/docs/designs/guides/naming-conventions.markdown
+++ b/docs/designs/guides/naming-conventions.markdown
@@ -37,7 +37,6 @@ This keeps diagnostics quoting syntax operators can copy back while summaries st
 
 - `String()` is the round-trippable syntax a user writes and diagnostics quote back (`hostid6.Derivation.String()` → `preserve`; `hostid6.Set.String()` → `[::1,::2]`).
 - `Describe()` is human prose that may add annotations not meant to be parsed (`hostid6.Derivation.Describe()` → `preserve (using detected)`); keep such annotations out of any value an error quotes as the syntax to edit.
-- With a single rendering, name by intent; a `Describe()` that is also valid syntax (`api.WAFList.Describe()` → `account/name`) is fine when no separate human form exists.
 
 ## Scope Boundary
 

--- a/internal/domain/base.go
+++ b/internal/domain/base.go
@@ -6,6 +6,9 @@ type Domain interface {
 	// DNSNameASCII gives a name suitable for accessing the Cloudflare API
 	DNSNameASCII() string
 
+	// String gives the canonical, round-trippable text form of the domain.
+	String() string
+
 	// Describe gives the most human-readable domain name that is still unambiguous
 	Describe() string
 

--- a/internal/domain/fqdn.go
+++ b/internal/domain/fqdn.go
@@ -8,9 +8,22 @@ type FQDN string
 // DNSNameASCII retruns the ASCII form of the FQDN.
 func (f FQDN) DNSNameASCII() string { return string(f) }
 
-// Describe gives a human-readible representation of the FQDN.
-func (f FQDN) Describe() string {
+// String gives the canonical, round-trippable form of the FQDN. The empty
+// FQDN is the root domain, rendered as ".".
+func (f FQDN) String() string {
+	if f == "" {
+		return "."
+	}
 	return safelyToUnicode(string(f))
+}
+
+// Describe gives the human-readable form: String with an annotation where one
+// helps, so an empty value never renders blank.
+func (f FQDN) Describe() string {
+	if f == "" {
+		return ". (root)"
+	}
+	return f.String()
 }
 
 // Zones starts from a.b.c for the domain a.b.c.

--- a/internal/domain/fqdn_test.go
+++ b/internal/domain/fqdn_test.go
@@ -56,6 +56,20 @@ func TestFQDNDescribe(t *testing.T) {
 	}
 }
 
+func TestFQDNStringDescribe(t *testing.T) {
+	t.Parallel()
+	require.Equal(t, ".", domain.FQDN("").String())
+	require.Equal(t, ". (root)", domain.FQDN("").Describe())
+	require.Equal(t, "example.org", domain.FQDN("example.org").String())
+	require.Equal(t, "example.org", domain.FQDN("example.org").Describe())
+
+	// An IDN renders Unicode via String(), distinct from the ASCII/Punycode form.
+	d, err := domain.New("café.example")
+	require.NoError(t, err)
+	require.Equal(t, d.String(), d.Describe())
+	require.NotEqual(t, d.DNSNameASCII(), d.String())
+}
+
 func TestFQDNZones(t *testing.T) {
 	t.Parallel()
 	type r = string

--- a/internal/domain/wildcard.go
+++ b/internal/domain/wildcard.go
@@ -24,7 +24,8 @@ func (w Wildcard) String() string {
 	return "*." + safelyToUnicode(string(w))
 }
 
-// Describe gives a human-readible representation of the wildcard domain.
+// Describe gives the human-readable form. The wildcard carries no annotation,
+// so it equals String.
 func (w Wildcard) Describe() string {
 	return w.String()
 }

--- a/internal/domain/wildcard.go
+++ b/internal/domain/wildcard.go
@@ -15,13 +15,18 @@ func (w Wildcard) DNSNameASCII() string {
 	return "*." + string(w)
 }
 
-// Describe gives a human-readible representation of the wildcard domain.
-func (w Wildcard) Describe() string {
+// String gives the canonical, round-trippable form of the wildcard domain.
+func (w Wildcard) String() string {
 	if string(w) == "" {
 		return "*"
 	}
 
 	return "*." + safelyToUnicode(string(w))
+}
+
+// Describe gives a human-readible representation of the wildcard domain.
+func (w Wildcard) Describe() string {
+	return w.String()
 }
 
 // Zones starts from a.b.c for the wildcard domain *.a.b.c.

--- a/internal/domain/wildcard_test.go
+++ b/internal/domain/wildcard_test.go
@@ -69,6 +69,14 @@ func TestWildcardDescribe(t *testing.T) {
 	}
 }
 
+func TestWildcardStringDescribe(t *testing.T) {
+	t.Parallel()
+	require.Equal(t, "*", domain.Wildcard("").String())
+	require.Equal(t, "*", domain.Wildcard("").Describe())
+	require.Equal(t, "*.example.org", domain.Wildcard("example.org").String())
+	require.Equal(t, "*.example.org", domain.Wildcard("example.org").Describe())
+}
+
 func TestWildcardZones(t *testing.T) {
 	t.Parallel()
 	type r = string

--- a/internal/domainexp/list.go
+++ b/internal/domainexp/list.go
@@ -65,12 +65,12 @@ func ParseList(ppfmt pp.PP, key string, input string) ([]domain.Domain, bool) {
 					pp.EmojiUserError,
 					`The %s domain in %s (%q) is %q, but it does not appear to be fully qualified; `+
 						`a fully qualified domain name (FQDN) would look like "*.example.org" or "sub.example.org"`,
-					pp.Ordinal(i+1), key, input, d.Describe(),
+					pp.Ordinal(i+1), key, input, d.String(),
 				)
 				return nil, false
 			}
 			ppfmt.Noticef(pp.EmojiUserError, "The %s domain in %s (%q) is %q, but it is malformed: %v",
-				pp.Ordinal(i+1), key, input, d.Describe(), domainErr)
+				pp.Ordinal(i+1), key, input, d.String(), domainErr)
 			return nil, false
 		}
 		domains = append(domains, d)

--- a/internal/domainexp/list_string_test.go
+++ b/internal/domainexp/list_string_test.go
@@ -1,0 +1,23 @@
+package domainexp_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
+	"github.com/favonia/cloudflare-ddns/internal/domainexp"
+	"github.com/favonia/cloudflare-ddns/internal/mocks"
+	"github.com/favonia/cloudflare-ddns/internal/pp"
+)
+
+func TestParseListRootQuotesString(t *testing.T) {
+	t.Parallel()
+	mockCtrl := gomock.NewController(t)
+	ppfmt := mocks.NewMockPP(mockCtrl)
+	// The not-fully-qualified message quotes the domain (4th vararg) as "." not "".
+	ppfmt.EXPECT().Noticef(pp.EmojiUserError, gomock.Any(), "1st", "DOMAINS", ".", ".")
+
+	_, ok := domainexp.ParseList(ppfmt, "DOMAINS", ".")
+	require.False(t, ok)
+}


### PR DESCRIPTION
Gives domain.Domain a canonical, round-trippable String() (the root domain renders as ".") and reframes Describe() as the human form that adds an annotation only where it helps (the root renders as ". (root)"), with Wildcard.Describe() equalling its String(). The domainexp.ParseList rejection path now quotes String() instead of Describe(), so rejecting DOMAINS=. reports the offending value as "." rather than an empty quote; all other human-summary Describe() callers are unchanged.