### PR TITLE
refactor: introduce domain.Suffix type and rename ErrNotFQDN to ErrTooFewLabels

### DIFF
--- a/internal/api/cloudflare_records.go
+++ b/internal/api/cloudflare_records.go
@@ -185,7 +185,7 @@ func (h cloudflareHandle) zoneMetaOfDomain(ctx context.Context, ppfmt pp.PP, dom
 
 zoneSearch:
 	for zoneName := range domain.Zones {
-		zones, ok := h.listZoneMeta(ctx, ppfmt, zoneName)
+		zones, ok := h.listZoneMeta(ctx, ppfmt, zoneName.DNSNameASCII())
 		if !ok {
 			return zero, false
 		}
@@ -204,11 +204,11 @@ zoneSearch:
 			}
 			ppfmt.Noticef(pp.EmojiImpossible,
 				"Found multiple active zones named %s (IDs: %s); please report this at %s",
-				zoneName, pp.EnglishJoinMapOrEmptyLabel(ID.String, ids, "(none)"), pp.IssueReportingURL)
+				zoneName.DNSNameASCII(), pp.EnglishJoinMapOrEmptyLabel(ID.String, ids, "(none)"), pp.IssueReportingURL)
 			// The suffix walk reached a semantic dead end at zoneName. Retry the
 			// traversed suffixes up to and including that boundary next cycle.
 			for cachedZoneName := range domain.Zones {
-				h.cache.listZones.Delete(cachedZoneName)
+				h.cache.listZones.Delete(cachedZoneName.DNSNameASCII())
 				if cachedZoneName == zoneName {
 					break
 				}
@@ -221,7 +221,7 @@ zoneSearch:
 	// new or recovered zones are retried on the next cycle instead of waiting for
 	// the full zone-list cache TTL.
 	for zoneName := range domain.Zones {
-		h.cache.listZones.Delete(zoneName)
+		h.cache.listZones.Delete(zoneName.DNSNameASCII())
 	}
 
 	ppfmt.Noticef(pp.EmojiError, "Failed to find the zone for %s; will try again", domain.Describe())

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -180,12 +180,12 @@ func TestReadEnvDomainDiagnostics(t *testing.T) {
 			value: ",good.example bad.example,localhost",
 			expected: "DOMAINS (\",good.example bad.example,localhost\") contains extra commas; this is accepted for now but will be rejected in version 2.0.0\n" +
 				"DOMAINS (\",good.example bad.example,localhost\") is missing commas; this is accepted for now but will be rejected in version 2.0.0\n" +
-				"DOMAINS (\",good.example bad.example,localhost\") has invalid domain \"localhost\": not fully qualified\n",
+				"DOMAINS (\",good.example bad.example,localhost\") has invalid domain \"localhost\": too few labels\n",
 		},
 		"ordered-recovered-semantic-errors": {
 			key:   "DOMAINS",
 			value: "localhost,good.example,example.org{unknown=::1},example.net{hostid6=192.0.2.1},example.com{hostid6=mac(bad)}",
-			expected: "DOMAINS (\"localhost,good.example,example.org{unknown=::1},example.net{hostid6=192.0.2.1},example.com{hostid6=mac(bad)}\") has invalid domain \"localhost\": not fully qualified\n" +
+			expected: "DOMAINS (\"localhost,good.example,example.org{unknown=::1},example.net{hostid6=192.0.2.1},example.com{hostid6=mac(bad)}\") has invalid domain \"localhost\": too few labels\n" +
 				"DOMAINS (\"localhost,good.example,example.org{unknown=::1},example.net{hostid6=192.0.2.1},example.com{hostid6=mac(bad)}\") has unknown domain field \"unknown\"\n" +
 				"DOMAINS (\"localhost,good.example,example.org{unknown=::1},example.net{hostid6=192.0.2.1},example.com{hostid6=mac(bad)}\") has invalid hostid6 value \"192.0.2.1\": host-ID literal must be an unzoned IPv6 address\n" +
 				"DOMAINS (\"localhost,good.example,example.org{unknown=::1},example.net{hostid6=192.0.2.1},example.com{hostid6=mac(bad)}\") has invalid hostid6 MAC address \"bad\": invalid 48-bit MAC address\n",
@@ -243,7 +243,7 @@ func TestReadEnvDomainDiagnosticSeverityAndOrder(t *testing.T) {
 	require.Equal(t,
 		"😦 DOMAINS (\",good.example bad.example,localhost\") contains extra commas; this is accepted for now but will be rejected in version 2.0.0\n"+
 			"😦 DOMAINS (\",good.example bad.example,localhost\") is missing commas; this is accepted for now but will be rejected in version 2.0.0\n"+
-			"😡 DOMAINS (\",good.example bad.example,localhost\") has invalid domain \"localhost\": not fully qualified\n",
+			"😡 DOMAINS (\",good.example bad.example,localhost\") has invalid domain \"localhost\": too few labels\n",
 		output.String(),
 	)
 }

--- a/internal/config/env_domain_test.go
+++ b/internal/config/env_domain_test.go
@@ -139,7 +139,7 @@ func TestReadDomainsReportsSemanticDiagnosticsInSourceOrder(t *testing.T) {
 	field := oldField
 	mockPP := mocks.NewMockPP(gomock.NewController(t))
 	gomock.InOrder(
-		mockPP.EXPECT().Noticef(pp.EmojiUserError, `%s (%q) has %s`, "DOMAINS", value, `invalid domain "localhost": not fully qualified`),
+		mockPP.EXPECT().Noticef(pp.EmojiUserError, `%s (%q) has %s`, "DOMAINS", value, `invalid domain "localhost": too few labels`),
 		mockPP.EXPECT().Noticef(pp.EmojiUserError, `%s (%q) has %s`, "DOMAINS", value, `unknown domain field "unknown"`),
 		mockPP.EXPECT().Noticef(pp.EmojiUserError, `%s (%q) has %s`, "DOMAINS", value, `invalid hostid6 value "192.0.2.1": host-ID literal must be an unzoned IPv6 address`),
 		mockPP.EXPECT().Noticef(pp.EmojiUserError, `%s (%q) has %s`, "DOMAINS", value, `invalid hostid6 MAC address "bad": invalid 48-bit MAC address`),
@@ -160,7 +160,7 @@ func TestReadDomainsReportsCompatibilityWarningsBeforeLaterRecoveredSemanticErro
 	gomock.InOrder(
 		mockPP.EXPECT().Noticef(pp.EmojiUserWarning, `%s (%s) contains extra commas; this is accepted for now but will be rejected in version 2.0.0`, "DOMAINS", `",good.example bad.example,localhost"`),
 		mockPP.EXPECT().Noticef(pp.EmojiUserWarning, `%s (%s) is missing commas; this is accepted for now but will be rejected in version 2.0.0`, "DOMAINS", `",good.example bad.example,localhost"`),
-		mockPP.EXPECT().Noticef(pp.EmojiUserError, `%s (%q) has %s`, "DOMAINS", value, `invalid domain "localhost": not fully qualified`),
+		mockPP.EXPECT().Noticef(pp.EmojiUserError, `%s (%q) has %s`, "DOMAINS", value, `invalid domain "localhost": too few labels`),
 	)
 
 	ok := readDomains(mockPP, "DOMAINS", nil, &field)

--- a/internal/domain/base.go
+++ b/internal/domain/base.go
@@ -16,5 +16,5 @@ type Domain interface {
 	HasStrictSuffix(s Suffix) bool
 
 	// Zones iterates from the smallest possible zone to largest ones (the root).
-	Zones(yield func(ZoneNameASCII string) bool)
+	Zones(yield func(Suffix) bool)
 }

--- a/internal/domain/base.go
+++ b/internal/domain/base.go
@@ -12,6 +12,9 @@ type Domain interface {
 	// Describe gives the most human-readable domain name that is still unambiguous
 	Describe() string
 
+	// HasStrictSuffix reports whether the domain is strictly under the suffix s.
+	HasStrictSuffix(s Suffix) bool
+
 	// Zones iterates from the smallest possible zone to largest ones (the root).
 	Zones(yield func(ZoneNameASCII string) bool)
 }

--- a/internal/domain/domain.go
+++ b/internal/domain/domain.go
@@ -51,8 +51,10 @@ func StringToASCII(domain string) string {
 	return normalized
 }
 
-// ErrNotFQDN means a domain name is not fully qualified.
-var ErrNotFQDN error = errors.New("not fully qualified")
+// ErrTooFewLabels means a domain name has fewer than two labels after
+// normalization — a single label (com, localhost), the empty/root name (.),
+// or a bare "*". Such a name cannot be a reasonable target domain name.
+var ErrTooFewLabels error = errors.New("too few labels")
 
 // New normalizes a domain to its ASCII form and then stores
 // the normalized domain in its Unicode form when the round trip
@@ -67,9 +69,9 @@ func New(domain string) (Domain, error) {
 	if strings.IndexByte(normalized, '.') == -1 {
 		// Special case: "*"
 		if normalized == "*" {
-			return Wildcard(""), ErrNotFQDN
+			return Wildcard(""), ErrTooFewLabels
 		} else {
-			return FQDN(normalized), ErrNotFQDN
+			return FQDN(normalized), ErrTooFewLabels
 		}
 	}
 

--- a/internal/domain/domain_test.go
+++ b/internal/domain/domain_test.go
@@ -96,10 +96,10 @@ func TestNew(t *testing.T) {
 		{"*.A......", w("a"), true, ""},
 		{"*｡A｡｡｡｡｡", w("a"), true, ""},
 		{"*.*.*", w("*.*"), false, `idna: disallowed rune U+002A`},
-		{"*......", w(""), false, "not fully qualified"},
-		{"*｡｡｡｡｡｡", w(""), false, "not fully qualified"},
-		{"......", f(""), false, "not fully qualified"},
-		{"｡｡｡｡｡｡", f(""), false, "not fully qualified"},
+		{"*......", w(""), false, "too few labels"},
+		{"*｡｡｡｡｡｡", w(""), false, "too few labels"},
+		{"......", f(""), false, "too few labels"},
+		{"｡｡｡｡｡｡", f(""), false, "too few labels"},
 	} {
 		t.Run(tc.input, func(t *testing.T) {
 			t.Parallel()
@@ -111,6 +111,17 @@ func TestNew(t *testing.T) {
 			} else {
 				require.EqualError(t, err, tc.errString)
 			}
+		})
+	}
+}
+
+func TestNewTooFewLabels(t *testing.T) {
+	t.Parallel()
+	for _, input := range [...]string{"com", "localhost", "org", "hello.", ".", "*"} {
+		t.Run(input, func(t *testing.T) {
+			t.Parallel()
+			_, err := domain.New(input)
+			require.ErrorIs(t, err, domain.ErrTooFewLabels)
 		})
 	}
 }

--- a/internal/domain/fqdn.go
+++ b/internal/domain/fqdn.go
@@ -32,10 +32,10 @@ func (f FQDN) HasStrictSuffix(s Suffix) bool {
 }
 
 // Zones starts from a.b.c for the domain a.b.c.
-func (f FQDN) Zones(yield func(ZoneNameASCII string) bool) {
+func (f FQDN) Zones(yield func(Suffix) bool) {
 	domain := string(f)
 	for {
-		if !yield(domain) {
+		if !yield(Suffix(domain)) {
 			return
 		}
 		if i := strings.IndexRune(domain, '.'); i == -1 {

--- a/internal/domain/fqdn.go
+++ b/internal/domain/fqdn.go
@@ -26,6 +26,11 @@ func (f FQDN) Describe() string {
 	return f.String()
 }
 
+// HasStrictSuffix reports whether the FQDN is strictly under the suffix s.
+func (f FQDN) HasStrictSuffix(s Suffix) bool {
+	return hasStrictSuffixASCII(f.DNSNameASCII(), s.DNSNameASCII())
+}
+
 // Zones starts from a.b.c for the domain a.b.c.
 func (f FQDN) Zones(yield func(ZoneNameASCII string) bool) {
 	domain := string(f)

--- a/internal/domain/fqdn_test.go
+++ b/internal/domain/fqdn_test.go
@@ -70,6 +70,27 @@ func TestFQDNStringDescribe(t *testing.T) {
 	require.NotEqual(t, d.DNSNameASCII(), d.String())
 }
 
+func TestFQDNHasStrictSuffix(t *testing.T) {
+	t.Parallel()
+	for _, tc := range [...]struct {
+		input    domain.FQDN
+		suffix   domain.Suffix
+		expected bool
+	}{
+		{"a.b.c", "c", true},
+		{"a.b.c", "b.c", true},
+		{"c", "c", false},     // strict: not under itself
+		{"a.b.c", "", true},   // under the root
+		{"c", "", true},       // single label under the root
+		{"a.b.c", "x.c", false},
+	} {
+		t.Run(string(tc.input)+"/"+string(tc.suffix), func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tc.expected, tc.input.HasStrictSuffix(tc.suffix))
+		})
+	}
+}
+
 func TestFQDNZones(t *testing.T) {
 	t.Parallel()
 	type r = string

--- a/internal/domain/fqdn_test.go
+++ b/internal/domain/fqdn_test.go
@@ -93,7 +93,7 @@ func TestFQDNHasStrictSuffix(t *testing.T) {
 
 func TestFQDNZones(t *testing.T) {
 	t.Parallel()
-	type r = string
+	type r = domain.Suffix
 	for _, tc := range [...]struct {
 		input    string
 		expected []r

--- a/internal/domain/fqdn_test.go
+++ b/internal/domain/fqdn_test.go
@@ -79,9 +79,9 @@ func TestFQDNHasStrictSuffix(t *testing.T) {
 	}{
 		{"a.b.c", "c", true},
 		{"a.b.c", "b.c", true},
-		{"c", "c", false},     // strict: not under itself
-		{"a.b.c", "", true},   // under the root
-		{"c", "", true},       // single label under the root
+		{"c", "c", false},   // strict: not under itself
+		{"a.b.c", "", true}, // under the root
+		{"c", "", true},     // single label under the root
 		{"a.b.c", "x.c", false},
 	} {
 		t.Run(string(tc.input)+"/"+string(tc.suffix), func(t *testing.T) {

--- a/internal/domain/suffix.go
+++ b/internal/domain/suffix.go
@@ -1,5 +1,7 @@
 package domain
 
+import "strings"
+
 // Suffix is a fully-qualified, dot-delimited domain tail in ASCII form, such as
 // example.com or org, with "" representing the root. Unlike Domain, a Suffix can
 // be a single label or the root, but it is never a wildcard.
@@ -16,4 +18,21 @@ func (s Suffix) String() string {
 		return "."
 	}
 	return safelyToUnicode(string(s))
+}
+
+// hasStrictSuffixASCII reports whether suffix is a proper (strict) dot-delimited
+// suffix of s, both in ASCII form. The root suffix "" is a strict suffix of every
+// non-root name; the dot-boundary arithmetic below cannot express that, so it is
+// special-cased.
+func hasStrictSuffixASCII(s, suffix string) bool {
+	if suffix == "" {
+		return s != ""
+	}
+	return strings.HasSuffix(s, suffix) && len(s) > len(suffix) && s[len(s)-len(suffix)-1] == '.'
+}
+
+// HasStrictSuffix reports whether s is strictly under t — t is a proper suffix of
+// s. b.c HasStrictSuffix c is true; c HasStrictSuffix c is false.
+func (s Suffix) HasStrictSuffix(t Suffix) bool {
+	return hasStrictSuffixASCII(s.DNSNameASCII(), t.DNSNameASCII())
 }

--- a/internal/domain/suffix.go
+++ b/internal/domain/suffix.go
@@ -1,0 +1,19 @@
+package domain
+
+// Suffix is a fully-qualified, dot-delimited domain tail in ASCII form, such as
+// example.com or org, with "" representing the root. Unlike Domain, a Suffix can
+// be a single label or the root, but it is never a wildcard.
+type Suffix string
+
+// DNSNameASCII gives the ASCII name used for matching, the Cloudflare zone name,
+// and cache keys. The root suffix yields "".
+func (s Suffix) DNSNameASCII() string { return string(s) }
+
+// String gives the canonical, round-trippable text form. The root suffix
+// renders as ".".
+func (s Suffix) String() string {
+	if s == "" {
+		return "."
+	}
+	return safelyToUnicode(string(s))
+}

--- a/internal/domain/suffix.go
+++ b/internal/domain/suffix.go
@@ -10,36 +10,6 @@ import (
 // be a single label or the root, but it is never a wildcard.
 type Suffix string
 
-// DNSNameASCII gives the ASCII name used for matching, the Cloudflare zone name,
-// and cache keys. The root suffix yields "".
-func (s Suffix) DNSNameASCII() string { return string(s) }
-
-// String gives the canonical, round-trippable text form. The root suffix
-// renders as ".".
-func (s Suffix) String() string {
-	if s == "" {
-		return "."
-	}
-	return safelyToUnicode(string(s))
-}
-
-// hasStrictSuffixASCII reports whether suffix is a proper (strict) dot-delimited
-// suffix of s, both in ASCII form. The root suffix "" is a strict suffix of every
-// non-root name; the dot-boundary arithmetic below cannot express that, so it is
-// special-cased.
-func hasStrictSuffixASCII(s, suffix string) bool {
-	if suffix == "" {
-		return s != ""
-	}
-	return strings.HasSuffix(s, suffix) && len(s) > len(suffix) && s[len(s)-len(suffix)-1] == '.'
-}
-
-// HasStrictSuffix reports whether s is strictly under t — t is a proper suffix of
-// s. b.c HasStrictSuffix c is true; c HasStrictSuffix c is false.
-func (s Suffix) HasStrictSuffix(t Suffix) bool {
-	return hasStrictSuffixASCII(s.DNSNameASCII(), t.DNSNameASCII())
-}
-
 // ErrWildcardSuffix means a suffix argument was a wildcard. A wildcard has no
 // strict subdomains, so it cannot be a suffix.
 var ErrWildcardSuffix error = errors.New("wildcard cannot be a suffix")
@@ -67,4 +37,34 @@ func NewSuffix(suffix string) (Suffix, error) {
 		return Suffix(normalized), err
 	}
 	return Suffix(normalized), nil
+}
+
+// DNSNameASCII gives the ASCII name used for matching, the Cloudflare zone name,
+// and cache keys. The root suffix yields "".
+func (s Suffix) DNSNameASCII() string { return string(s) }
+
+// String gives the canonical, round-trippable text form. The root suffix
+// renders as ".".
+func (s Suffix) String() string {
+	if s == "" {
+		return "."
+	}
+	return safelyToUnicode(string(s))
+}
+
+// HasStrictSuffix reports whether s is strictly under t — t is a proper suffix of
+// s. b.c HasStrictSuffix c is true; c HasStrictSuffix c is false.
+func (s Suffix) HasStrictSuffix(t Suffix) bool {
+	return hasStrictSuffixASCII(s.DNSNameASCII(), t.DNSNameASCII())
+}
+
+// hasStrictSuffixASCII reports whether suffix is a proper (strict) dot-delimited
+// suffix of s, both in ASCII form. The root suffix "" is a strict suffix of every
+// non-root name; the dot-boundary arithmetic below cannot express that, so it is
+// special-cased.
+func hasStrictSuffixASCII(s, suffix string) bool {
+	if suffix == "" {
+		return s != ""
+	}
+	return strings.HasSuffix(s, suffix) && len(s) > len(suffix) && s[len(s)-len(suffix)-1] == '.'
 }

--- a/internal/domain/suffix.go
+++ b/internal/domain/suffix.go
@@ -1,6 +1,9 @@
 package domain
 
-import "strings"
+import (
+	"errors"
+	"strings"
+)
 
 // Suffix is a fully-qualified, dot-delimited domain tail in ASCII form, such as
 // example.com or org, with "" representing the root. Unlike Domain, a Suffix can
@@ -35,4 +38,33 @@ func hasStrictSuffixASCII(s, suffix string) bool {
 // s. b.c HasStrictSuffix c is true; c HasStrictSuffix c is false.
 func (s Suffix) HasStrictSuffix(t Suffix) bool {
 	return hasStrictSuffixASCII(s.DNSNameASCII(), t.DNSNameASCII())
+}
+
+// ErrWildcardSuffix means a suffix argument was a wildcard. A wildcard has no
+// strict subdomains, so it cannot be a suffix.
+var ErrWildcardSuffix error = errors.New("wildcard cannot be a suffix")
+
+// NewSuffix parses a domain suffix. It is its own parser, parallel to New
+// (not layered on it): it is looser — it accepts a single label (org) and the
+// root (. or "") — and stricter — it rejects any wildcard (* or *.example.org).
+// It applies the same IDNA normalization New uses for the ASCII form.
+func NewSuffix(suffix string) (Suffix, error) {
+	normalized, err := profileDroppingLeadingDots.ToASCII(suffix)
+
+	// Remove the final dot for consistency, matching New.
+	normalized = strings.TrimRight(normalized, ".")
+
+	// A wildcard has no strict subdomains, so it cannot be a suffix. Detect it on
+	// the normalized form, exactly where New detects it.
+	if normalized == "*" {
+		return "", ErrWildcardSuffix
+	}
+	if _, ok := strings.CutPrefix(normalized, "*."); ok {
+		return "", ErrWildcardSuffix
+	}
+
+	if err != nil {
+		return Suffix(normalized), err
+	}
+	return Suffix(normalized), nil
 }

--- a/internal/domain/suffix_test.go
+++ b/internal/domain/suffix_test.go
@@ -41,3 +41,27 @@ func TestSuffixString(t *testing.T) {
 		})
 	}
 }
+
+func TestSuffixHasStrictSuffix(t *testing.T) {
+	t.Parallel()
+	for _, tc := range [...]struct {
+		s        domain.Suffix
+		t        domain.Suffix
+		expected bool
+	}{
+		{"b.c", "c", true},     // b.c is strictly under c
+		{"c", "c", false},      // strict: not under itself
+		{"a.b.c", "c", true},   // multi-label
+		{"a.b.c", "b.c", true}, // multi-label deeper suffix
+		{"a.b.c", "", true},    // every non-root name is under the root
+		{"", "", false},        // root is not strictly under the root
+		{"c", "", true},        // single label is under the root
+		{"example.com", "org", false},
+		{"xc", "c", false}, // "c" is a substring suffix but not on a dot boundary
+	} {
+		t.Run(string(tc.s)+"/"+string(tc.t), func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tc.expected, tc.s.HasStrictSuffix(tc.t))
+		})
+	}
+}

--- a/internal/domain/suffix_test.go
+++ b/internal/domain/suffix_test.go
@@ -75,9 +75,9 @@ func TestNewSuffix(t *testing.T) {
 	}{
 		{"example.org", "example.org", true},
 		{"org", "org", true},                  // single label accepted (looser than New)
-		{".", "", true},                        // root accepted
-		{"", "", true},                         // empty is the root
-		{"example.org.", "example.org", true},  // trailing dot trimmed
+		{".", "", true},                       // root accepted
+		{"", "", true},                        // empty is the root
+		{"example.org.", "example.org", true}, // trailing dot trimmed
 		{"tHe.CaPiTaL.cAsE", "the.capital.case", true},
 		{"*", "", false},             // wildcard rejected
 		{"*.example.org", "", false}, // wildcard rejected
@@ -100,4 +100,3 @@ func TestNewSuffixWildcardError(t *testing.T) {
 	_, err := domain.NewSuffix("*.example.org")
 	require.ErrorIs(t, err, domain.ErrWildcardSuffix)
 }
-

--- a/internal/domain/suffix_test.go
+++ b/internal/domain/suffix_test.go
@@ -79,6 +79,7 @@ func TestNewSuffix(t *testing.T) {
 		{"", "", true},                        // empty is the root
 		{"example.org.", "example.org", true}, // trailing dot trimmed
 		{"tHe.CaPiTaL.cAsE", "the.capital.case", true},
+		{"\u0080.com", "", false},    // malformed: disallowed rune rejected
 		{"*", "", false},             // wildcard rejected
 		{"*.example.org", "", false}, // wildcard rejected
 	} {

--- a/internal/domain/suffix_test.go
+++ b/internal/domain/suffix_test.go
@@ -65,3 +65,39 @@ func TestSuffixHasStrictSuffix(t *testing.T) {
 		})
 	}
 }
+
+func TestNewSuffix(t *testing.T) {
+	t.Parallel()
+	for _, tc := range [...]struct {
+		input    string
+		expected domain.Suffix
+		ok       bool
+	}{
+		{"example.org", "example.org", true},
+		{"org", "org", true},                  // single label accepted (looser than New)
+		{".", "", true},                        // root accepted
+		{"", "", true},                         // empty is the root
+		{"example.org.", "example.org", true},  // trailing dot trimmed
+		{"tHe.CaPiTaL.cAsE", "the.capital.case", true},
+		{"*", "", false},             // wildcard rejected
+		{"*.example.org", "", false}, // wildcard rejected
+	} {
+		t.Run(tc.input, func(t *testing.T) {
+			t.Parallel()
+			got, err := domain.NewSuffix(tc.input)
+			if tc.ok {
+				require.NoError(t, err)
+				require.Equal(t, tc.expected, got)
+			} else {
+				require.Error(t, err)
+			}
+		})
+	}
+}
+
+func TestNewSuffixWildcardError(t *testing.T) {
+	t.Parallel()
+	_, err := domain.NewSuffix("*.example.org")
+	require.ErrorIs(t, err, domain.ErrWildcardSuffix)
+}
+

--- a/internal/domain/suffix_test.go
+++ b/internal/domain/suffix_test.go
@@ -1,0 +1,43 @@
+package domain_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/favonia/cloudflare-ddns/internal/domain"
+)
+
+func TestSuffixDNSNameASCII(t *testing.T) {
+	t.Parallel()
+	for _, tc := range [...]struct {
+		input    domain.Suffix
+		expected string
+	}{
+		{"example.com", "example.com"},
+		{"org", "org"},
+		{"", ""}, // root
+	} {
+		t.Run(string(tc.input), func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tc.expected, tc.input.DNSNameASCII())
+		})
+	}
+}
+
+func TestSuffixString(t *testing.T) {
+	t.Parallel()
+	for _, tc := range [...]struct {
+		input    domain.Suffix
+		expected string
+	}{
+		{"example.com", "example.com"},
+		{"org", "org"},
+		{"", "."}, // root renders as "."
+	} {
+		t.Run(string(tc.input), func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tc.expected, tc.input.String())
+		})
+	}
+}

--- a/internal/domain/wildcard.go
+++ b/internal/domain/wildcard.go
@@ -30,6 +30,13 @@ func (w Wildcard) Describe() string {
 	return w.String()
 }
 
+// HasStrictSuffix reports whether the wildcard domain is strictly under the
+// suffix s. Wildcard("example.org") (i.e. *.example.org) is strictly under
+// example.org.
+func (w Wildcard) HasStrictSuffix(s Suffix) bool {
+	return hasStrictSuffixASCII(w.DNSNameASCII(), s.DNSNameASCII())
+}
+
 // Zones starts from a.b.c for the wildcard domain *.a.b.c.
 func (w Wildcard) Zones(yield func(ZoneNameASCII string) bool) {
 	domain := string(w)

--- a/internal/domain/wildcard.go
+++ b/internal/domain/wildcard.go
@@ -38,10 +38,10 @@ func (w Wildcard) HasStrictSuffix(s Suffix) bool {
 }
 
 // Zones starts from a.b.c for the wildcard domain *.a.b.c.
-func (w Wildcard) Zones(yield func(ZoneNameASCII string) bool) {
+func (w Wildcard) Zones(yield func(Suffix) bool) {
 	domain := string(w)
 	for {
-		if !yield(domain) {
+		if !yield(Suffix(domain)) {
 			return
 		}
 		if i := strings.IndexRune(domain, '.'); i == -1 {

--- a/internal/domain/wildcard_test.go
+++ b/internal/domain/wildcard_test.go
@@ -77,6 +77,26 @@ func TestWildcardStringDescribe(t *testing.T) {
 	require.Equal(t, "*.example.org", domain.Wildcard("example.org").Describe())
 }
 
+func TestWildcardHasStrictSuffix(t *testing.T) {
+	t.Parallel()
+	for _, tc := range [...]struct {
+		input    domain.Wildcard
+		suffix   domain.Suffix
+		expected bool
+	}{
+		{"example.org", "example.org", true}, // *.example.org is strictly under example.org
+		{"example.org", "org", true},         // and under org
+		{"example.org", "", true},            // and under the root
+		{"", "org", false},                   // bare * is not under org
+		{"", "", true},                       // bare * is under the root
+	} {
+		t.Run(string(tc.input)+"/"+string(tc.suffix), func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tc.expected, tc.input.HasStrictSuffix(tc.suffix))
+		})
+	}
+}
+
 func TestWildcardZones(t *testing.T) {
 	t.Parallel()
 	type r = string

--- a/internal/domain/wildcard_test.go
+++ b/internal/domain/wildcard_test.go
@@ -99,7 +99,7 @@ func TestWildcardHasStrictSuffix(t *testing.T) {
 
 func TestWildcardZones(t *testing.T) {
 	t.Parallel()
-	type r = string
+	type r = domain.Suffix
 	for _, tc := range [...]struct {
 		input    string
 		expected []r

--- a/internal/domainentry/entry_test.go
+++ b/internal/domainentry/entry_test.go
@@ -355,7 +355,7 @@ func TestEntryDiagnosticDescriptions(t *testing.T) {
 
 	require.Nil(t, err)
 	require.Equal(t, []string{
-		`invalid domain "localhost": not fully qualified`,
+		`invalid domain "localhost": too few labels`,
 		`unknown domain field "unknown"`,
 		`invalid hostid6 value "192.0.2.1": host-ID literal must be an unzoned IPv6 address`,
 		`invalid hostid6 MAC address "bad": invalid 48-bit MAC address`,

--- a/internal/domainexp/list.go
+++ b/internal/domainexp/list.go
@@ -60,11 +60,11 @@ func ParseList(ppfmt pp.PP, key string, input string) ([]domain.Domain, bool) {
 		d, domainErr := domain.New(token.Text)
 		if domainErr != nil {
 			reportListDiagnostics(ppfmt, key, input, state)
-			if errors.Is(domainErr, domain.ErrNotFQDN) {
+			if errors.Is(domainErr, domain.ErrTooFewLabels) {
 				ppfmt.Noticef(
 					pp.EmojiUserError,
-					`The %s domain in %s (%q) is %q, but it does not appear to be fully qualified; `+
-						`a fully qualified domain name (FQDN) would look like "*.example.org" or "sub.example.org"`,
+					`The %s domain in %s (%q) is %q, but it is too short to be a reasonable target domain name; `+
+						`it should look like "*.example.org" or "sub.example.org"`,
 					pp.Ordinal(i+1), key, input, d.String(),
 				)
 				return nil, false

--- a/internal/domainexp/parser_test.go
+++ b/internal/domainexp/parser_test.go
@@ -88,7 +88,7 @@ func TestParseList(t *testing.T) {
 			"&", false, nil,
 			func(m *mocks.MockPP) {
 				m.EXPECT().Noticef(pp.EmojiUserError,
-					`The %s domain in %s (%q) is %q, but it does not appear to be fully qualified; a fully qualified domain name (FQDN) would look like "*.example.org" or "sub.example.org"`,
+					`The %s domain in %s (%q) is %q, but it is too short to be a reasonable target domain name; it should look like "*.example.org" or "sub.example.org"`,
 					"1st", key, "&", "&")
 			},
 		},
@@ -100,11 +100,11 @@ func TestParseList(t *testing.T) {
 					"1st", key, "xn--:D.org", "xn--:d.org", gomock.Any())
 			},
 		},
-		"not-fqdn": {
+		"too-few-labels": {
 			"localhost", false, nil,
 			func(m *mocks.MockPP) {
 				m.EXPECT().Noticef(pp.EmojiUserError,
-					`The %s domain in %s (%q) is %q, but it does not appear to be fully qualified; a fully qualified domain name (FQDN) would look like "*.example.org" or "sub.example.org"`,
+					`The %s domain in %s (%q) is %q, but it is too short to be a reasonable target domain name; it should look like "*.example.org" or "sub.example.org"`,
 					"1st", key, "localhost", "localhost")
 			},
 		},


### PR DESCRIPTION
Introduces a first-class `domain.Suffix` type (a fully-qualified, dot-delimited ASCII tail, with `""` as the root and never a wildcard) carrying the strict-suffix relation as a method on `Suffix` and the `Domain` interface (`FQDN`/`Wildcard`), an independent `NewSuffix` parser that is looser than `New` (accepts single labels and the root) and stricter (rejects wildcards), and reroutes `Domain.Zones` to yield `Suffix` with the Cloudflare consumers converting at the string boundary. As a first phase it also renames the misnamed `domain.ErrNotFQDN` to `ErrTooFewLabels` ("too few labels") and rewords the corresponding user-facing message in domain-list parsing. This is foundation-only — no behavior change beyond the wording — and the linter/expression-side rework is intentionally left out of scope.