### PR TITLE
ci: drop redundant WAF list-name JSON-object watch

### DIFF
--- a/scripts/github-actions/cloudflare-doc-watch/cases.go
+++ b/scripts/github-actions/cloudflare-doc-watch/cases.go
@@ -306,33 +306,6 @@ var allWatches = []config{
 		},
 	},
 	{
-		Name:           "Cloudflare WAF list JSON-object name rules",
-		Repo:           "cloudflare/cloudflare-docs",
-		Ref:            "production",
-		Path:           "src/content/docs/waf/tools/lists/lists-api/json-object.mdx",
-		SnapshotDate:   "2026-03-27",
-		HistoryURL:     "https://github.com/cloudflare/cloudflare-docs/commits/production/src/content/docs/waf/tools/lists/lists-api/json-object.mdx",
-		PageURL:        "https://developers.cloudflare.com/waf/tools/lists/lists-api/json-object/index.md",
-		WatchedHeading: "## List object structure and properties",
-		LineFilters: []string{
-			"^\\| name String ",
-		},
-		ExpectedLines: []string{
-			"| name String | An informative name for the list. | Maximum length: 50 characters.Only alphanumeric and underscore (\\_) characters are valid.A valid name satisfies this regular expression: ^\\[a-zA-Z0-9\\_\\]+$. |",
-		},
-		WatchLabel: "Watched JSON-object name-rule line",
-		Reminders: []string{
-			"Re-check the documented conflict between the Lists page lowercase-only rule and the JSON-object page alphanumeric rule.",
-			"Re-check whether warnings in internal/config/env_waf.go should stay lowercase-only.",
-			"Re-check whether uppercase list names should be accepted, warned on, or normalized.",
-		},
-		RelatedPaths: []string{
-			"internal/config/env_waf.go",
-			"internal/config/env_waf_test.go",
-			"README.markdown",
-		},
-	},
-	{
 		Name:           "Cloudflare WAF list name rules",
 		Repo:           "cloudflare/cloudflare-docs",
 		Ref:            "production",

--- a/scripts/github-actions/cloudflare-doc-watch/cases.go
+++ b/scripts/github-actions/cloudflare-doc-watch/cases.go
@@ -188,7 +188,7 @@ var allWatches = []config{
 		},
 		WatchLabel: "Watched OpenAPI list-schema values",
 		Reminders: []string{
-			"Re-check the name-rule conflict between the Lists page and the OpenAPI/JSON-object schema if the list-name pattern changes.",
+			"Re-check the name-rule conflict between the Lists page and the OpenAPI schema if the list-name pattern changes.",
 			"Re-check assumptions about available list kinds and the read-only num_referencing_filters field.",
 			"Re-check WAF list create/read handling in internal/api/cloudflare_waf.go if the schema changes.",
 		},


### PR DESCRIPTION
Removes the brittle "Cloudflare WAF list JSON-object name rules" doc-watch case, which matched a rendered published-page table row to re-assert the list-name pattern and 50-char maximum. Those values are already pinned via stable JSON pointers by the OpenAPI lists-schema case, so this was a noisy duplicate of the alphanumeric side of the documented list-name conflict. Both sides of that conflict stay watched (Lists page for `^[a-z0-9_]+$`, OpenAPI schema for `^[a-zA-Z0-9_]+$`), and the `json-object.mdx` page itself remains watched by the IP-ranges case. A follow-up commit tidies the one OpenAPI-case reminder the deletion left pointing at the now-unwatched source.