### PR TITLE
ci: run fuzz targets concurrently

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -73,7 +73,6 @@ jobs:
       cancel-in-progress: true
     strategy:
       fail-fast: false
-      max-parallel: 2
       matrix:
         target:
           - name: "parse list"


### PR DESCRIPTION
Remove the matrix-level two-job cap so all three independent fuzz targets can run concurrently while each target remains limited to one fuzz worker via `-parallel 1`. This reduces fuzz-workflow latency without increasing per-target worker concurrency; the workflow passes YAML parsing and `actionlint`.
