### PR TITLE
fix: attempt all composed reporters

### DIFF
--- a/internal/heartbeat/composite.go
+++ b/internal/heartbeat/composite.go
@@ -40,44 +40,49 @@ func (hs Composed) Describe(yield func(name string, params string) bool) {
 
 // Ping calls [Heartbeat.Ping] for each service in the group.
 func (hs Composed) Ping(ctx context.Context, ppfmt pp.PP, message Message) bool {
-	ok := true
+	allOK := true
 	for _, hb := range hs {
-		ok = ok && hb.Ping(ctx, ppfmt, message)
+		childOK := hb.Ping(ctx, ppfmt, message)
+		allOK = allOK && childOK
 	}
-	return ok
+	return allOK
 }
 
 // Start calls [Heartbeat.Start] for each service in the group.
 func (hs Composed) Start(ctx context.Context, ppfmt pp.PP, message string) bool {
-	ok := true
+	allOK := true
 	for _, hb := range hs {
 		if extended, okType := hb.(Heartbeat); okType {
-			ok = ok && extended.Start(ctx, ppfmt, message)
+			childOK := extended.Start(ctx, ppfmt, message)
+			allOK = allOK && childOK
 		}
 	}
-	return ok
+	return allOK
 }
 
 // Exit calls [Heartbeat.Exit] for each service in the group.
 func (hs Composed) Exit(ctx context.Context, ppfmt pp.PP, message string) bool {
-	ok := true
+	allOK := true
 	for _, hb := range hs {
 		if extended, okType := hb.(Heartbeat); okType {
-			ok = ok && extended.Exit(ctx, ppfmt, message)
+			childOK := extended.Exit(ctx, ppfmt, message)
+			allOK = allOK && childOK
 		}
 	}
-	return ok
+	return allOK
 }
 
 // Log calls [Heartbeat.Log] for each service in the group.
 func (hs Composed) Log(ctx context.Context, ppfmt pp.PP, msg Message) bool {
-	ok := true
+	allOK := true
 	for _, hb := range hs {
 		if extended, okType := hb.(Heartbeat); okType {
-			ok = ok && extended.Log(ctx, ppfmt, msg)
+			childOK := extended.Log(ctx, ppfmt, msg)
+			allOK = allOK && childOK
 		} else if !msg.OK {
-			ok = ok && hb.Ping(ctx, ppfmt, msg)
+			childOK := hb.Ping(ctx, ppfmt, msg)
+			allOK = allOK && childOK
 		}
 	}
-	return ok
+	return allOK
 }

--- a/internal/heartbeat/composite_test.go
+++ b/internal/heartbeat/composite_test.go
@@ -107,6 +107,24 @@ func TestComposedPing(t *testing.T) {
 	}
 }
 
+func TestComposedPingContinuesAfterFailure(t *testing.T) {
+	t.Parallel()
+
+	mockCtrl := gomock.NewController(t)
+	mockPP := mocks.NewMockPP(mockCtrl)
+	first := mocks.NewMockBasicHeartbeat(mockCtrl)
+	second := mocks.NewMockBasicHeartbeat(mockCtrl)
+	message := heartbeat.NewMessagef(false, "failure")
+
+	gomock.InOrder(
+		first.EXPECT().Ping(context.Background(), mockPP, message).Return(false),
+		second.EXPECT().Ping(context.Background(), mockPP, message).Return(true),
+	)
+
+	ok := heartbeat.NewComposed(first, second).Ping(context.Background(), mockPP, message)
+	require.False(t, ok)
+}
+
 func TestComposedStart(t *testing.T) {
 	t.Parallel()
 
@@ -127,6 +145,24 @@ func TestComposedStart(t *testing.T) {
 	require.True(t, ok)
 }
 
+func TestComposedStartContinuesAfterFailure(t *testing.T) {
+	t.Parallel()
+
+	mockCtrl := gomock.NewController(t)
+	mockPP := mocks.NewMockPP(mockCtrl)
+	first := mocks.NewMockHeartbeat(mockCtrl)
+	second := mocks.NewMockHeartbeat(mockCtrl)
+	message := "starting"
+
+	gomock.InOrder(
+		first.EXPECT().Start(context.Background(), mockPP, message).Return(false),
+		second.EXPECT().Start(context.Background(), mockPP, message).Return(true),
+	)
+
+	ok := heartbeat.NewComposed(first, second).Start(context.Background(), mockPP, message)
+	require.False(t, ok)
+}
+
 func TestComposedExit(t *testing.T) {
 	t.Parallel()
 
@@ -145,6 +181,24 @@ func TestComposedExit(t *testing.T) {
 
 	ok := heartbeat.NewComposed(ms...).Exit(context.Background(), mockPP, message)
 	require.True(t, ok)
+}
+
+func TestComposedExitContinuesAfterFailure(t *testing.T) {
+	t.Parallel()
+
+	mockCtrl := gomock.NewController(t)
+	mockPP := mocks.NewMockPP(mockCtrl)
+	first := mocks.NewMockHeartbeat(mockCtrl)
+	second := mocks.NewMockHeartbeat(mockCtrl)
+	message := "exiting"
+
+	gomock.InOrder(
+		first.EXPECT().Exit(context.Background(), mockPP, message).Return(false),
+		second.EXPECT().Exit(context.Background(), mockPP, message).Return(true),
+	)
+
+	ok := heartbeat.NewComposed(first, second).Exit(context.Background(), mockPP, message)
+	require.False(t, ok)
 }
 
 func TestComposedLog(t *testing.T) {
@@ -194,4 +248,22 @@ func TestComposedLog(t *testing.T) {
 			})
 		}
 	}
+}
+
+func TestComposedLogContinuesAfterFailure(t *testing.T) {
+	t.Parallel()
+
+	mockCtrl := gomock.NewController(t)
+	mockPP := mocks.NewMockPP(mockCtrl)
+	first := mocks.NewMockHeartbeat(mockCtrl)
+	second := mocks.NewMockBasicHeartbeat(mockCtrl)
+	message := heartbeat.NewMessagef(false, "failure")
+
+	gomock.InOrder(
+		first.EXPECT().Log(context.Background(), mockPP, message).Return(false),
+		second.EXPECT().Ping(context.Background(), mockPP, message).Return(true),
+	)
+
+	ok := heartbeat.NewComposed(first, second).Log(context.Background(), mockPP, message)
+	require.False(t, ok)
 }

--- a/internal/notifier/composite.go
+++ b/internal/notifier/composite.go
@@ -40,9 +40,10 @@ func (ns Composed) Describe(yield func(name string, params string) bool) {
 
 // Send calls [Notifier.Send] for each notifier in the group.
 func (ns Composed) Send(ctx context.Context, ppfmt pp.PP, msg Message) bool {
-	ok := true
+	allOK := true
 	for _, n := range ns {
-		ok = ok && n.Send(ctx, ppfmt, msg)
+		childOK := n.Send(ctx, ppfmt, msg)
+		allOK = allOK && childOK
 	}
-	return ok
+	return allOK
 }

--- a/internal/notifier/composite_test.go
+++ b/internal/notifier/composite_test.go
@@ -74,3 +74,21 @@ func TestComposedSend(t *testing.T) {
 		})
 	}
 }
+
+func TestComposedSendContinuesAfterFailure(t *testing.T) {
+	t.Parallel()
+
+	mockCtrl := gomock.NewController(t)
+	mockPP := mocks.NewMockPP(mockCtrl)
+	first := mocks.NewMockNotifier(mockCtrl)
+	second := mocks.NewMockNotifier(mockCtrl)
+	message := notifier.NewMessagef("notification")
+
+	gomock.InOrder(
+		first.EXPECT().Send(context.Background(), mockPP, message).Return(false),
+		second.EXPECT().Send(context.Background(), mockPP, message).Return(true),
+	)
+
+	ok := notifier.NewComposed(first, second).Send(context.Background(), mockPP, message)
+	require.False(t, ok)
+}


### PR DESCRIPTION
A failed Healthchecks request could short-circuit heartbeat composition and prevent a later Uptime Kuma update; the same aggregation pattern also affected composed notifiers. This change evaluates every applicable child before aggregating the results, so later reporters are still attempted while the overall result continues to report any failure. Focused regressions cover `Ping`, `Start`, `Exit`, `Log`, and `Send`, and the full Go suite and linter pass. Fixes #1248.