### PR TITLE
ux: clarify reporter delivery logs

### DIFF
--- a/cmd/ddns/ddns.go
+++ b/cmd/ddns/ddns.go
@@ -70,7 +70,7 @@ func stopUpdating(
 	if lifecycleConfig.DeleteOnStop {
 		msg := updater.FinalDeleteIPs(ctx, ppfmt, updateConfig, s)
 		hb.Log(ctx, ppfmt, msg.HeartbeatMessage)
-		nt.Send(ctx, ppfmt, msg.NotifierMessage)
+		nt.Send(ctx, ppfmt, msg.Notification())
 	}
 }
 
@@ -116,8 +116,7 @@ func realMain() int {
 	// Bail out now if initConfig failed
 	if !configOK {
 		hb.Ping(ctx, ppfmt, heartbeat.NewMessagef(false, "Configuration errors"))
-		nt.Send(ctx, ppfmt, notifier.NewMessagef(
-			"Cloudflare DDNS was misconfigured and could not start. Please check the logs for details."))
+		nt.Send(ctx, ppfmt, startupFailureNotification())
 		ppfmt.Infof(pp.EmojiBye, "Bye!")
 		return 1
 	}
@@ -127,7 +126,7 @@ func realMain() int {
 
 	// If UPDATE_CRON is not `@once` (not single-run mode), then send a notification to signal the start.
 	if lifecycleConfig.UpdateCron != nil {
-		nt.Send(ctx, ppfmt, notifier.NewMessagef("Cloudflare DDNS has started."))
+		nt.Send(ctx, ppfmt, startupNotification())
 	}
 
 	// Without the following line, the quiet mode can be too quiet, and some system (Portainer)
@@ -156,7 +155,7 @@ func realMain() int {
 
 			msg := updater.UpdateIPs(ctxWithSignals, ppfmt, updateConfig, s)
 			hb.Ping(ctx, ppfmt, msg.HeartbeatMessage)
-			nt.Send(ctx, ppfmt, msg.NotifierMessage)
+			nt.Send(ctx, ppfmt, msg.Notification())
 		}
 
 		if ctxWithSignals.Err() != nil {
@@ -179,13 +178,8 @@ func realMain() int {
 			)
 			stopUpdating(ctx, ppfmt, lifecycleConfig, updateConfig, hb, nt, s)
 			hb.Ping(ctx, ppfmt, heartbeat.NewMessagef(false, "No scheduled updates"))
-			nt.Send(ctx, ppfmt,
-				notifier.NewMessagef(
-					"Cloudflare DDNS stopped because no updates are scheduled in the near future. "+
-						"Consider changing the value of UPDATE_CRON (%s).",
-					cron.DescribeSchedule(lifecycleConfig.UpdateCron),
-				),
-			)
+			nt.Send(ctx, ppfmt, schedulingFailureNotification(
+				cron.DescribeSchedule(lifecycleConfig.UpdateCron)))
 			ppfmt.Infof(pp.EmojiBye, "Bye!")
 			return 1
 		}
@@ -199,7 +193,7 @@ func realMain() int {
 			stopUpdating(ctx, ppfmt, lifecycleConfig, updateConfig, hb, nt, s)
 			hb.Exit(ctx, ppfmt, "Stopped")
 			if lifecycleConfig.UpdateCron != nil {
-				nt.Send(ctx, ppfmt, notifier.NewMessagef("Cloudflare DDNS has stopped."))
+				nt.Send(ctx, ppfmt, shutdownNotification())
 			}
 			ppfmt.Infof(pp.EmojiBye, "Bye!")
 			return 0

--- a/cmd/ddns/ddns_test.go
+++ b/cmd/ddns/ddns_test.go
@@ -195,9 +195,10 @@ func TestStopUpdatingDeleteOnStop(t *testing.T) {
 		},
 	)
 	mockNotifier.EXPECT().Send(gomock.Any(), ppfmt, gomock.Any()).DoAndReturn(
-		func(_ context.Context, _ pp.PP, msg notifier.Message) bool {
-			require.Contains(t, msg.Format(), "Deleted A records for example.org.")
-			require.Contains(t, msg.Format(), "Cleaned WAF list(s) acc/office.")
+		func(_ context.Context, _ pp.PP, notification notifier.Notification) bool {
+			require.Equal(t, notifier.KindCleanup, notification.Kind)
+			require.Contains(t, notification.Format(), "Deleted A records for example.org")
+			require.Contains(t, notification.Format(), "Cleaned WAF list(s) acc/office")
 			return true
 		},
 	)

--- a/cmd/ddns/notification.go
+++ b/cmd/ddns/notification.go
@@ -1,0 +1,23 @@
+package main
+
+import "github.com/favonia/cloudflare-ddns/internal/notifier"
+
+func startupFailureNotification() notifier.Notification {
+	return notifier.NewNotificationf(notifier.KindStartupFailure,
+		"Cloudflare DDNS was misconfigured and could not start. Please check the logs for details.")
+}
+
+func startupNotification() notifier.Notification {
+	return notifier.NewNotificationf(notifier.KindStartup, "Cloudflare DDNS has started.")
+}
+
+func schedulingFailureNotification(schedule string) notifier.Notification {
+	return notifier.NewNotificationf(notifier.KindSchedulingFailure,
+		"Cloudflare DDNS stopped because no updates are scheduled in the near future. "+
+			"Consider changing the value of UPDATE_CRON (%s).",
+		schedule)
+}
+
+func shutdownNotification() notifier.Notification {
+	return notifier.NewNotificationf(notifier.KindShutdown, "Cloudflare DDNS has stopped.")
+}

--- a/cmd/ddns/notification.go
+++ b/cmd/ddns/notification.go
@@ -11,6 +11,8 @@ func startupNotification() notifier.Notification {
 	return notifier.NewNotificationf(notifier.KindStartup, "Cloudflare DDNS has started.")
 }
 
+// schedulingFailureNotification adds the given schedule to the message.
+// The schedule is the original UPDATE_CRON string.
 func schedulingFailureNotification(schedule string) notifier.Notification {
 	return notifier.NewNotificationf(notifier.KindSchedulingFailure,
 		"Cloudflare DDNS stopped because no updates are scheduled in the near future. "+

--- a/cmd/ddns/notification_test.go
+++ b/cmd/ddns/notification_test.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/favonia/cloudflare-ddns/internal/notifier"
+)
+
+func TestLifecycleNotifications(t *testing.T) {
+	t.Parallel()
+
+	for name, tc := range map[string]struct {
+		build       func() notifier.Notification
+		wantKind    notifier.Kind
+		wantPayload string
+	}{
+		"startup failure": {
+			startupFailureNotification,
+			notifier.KindStartupFailure,
+			"Cloudflare DDNS was misconfigured and could not start. Please check the logs for details.",
+		},
+		"startup": {
+			startupNotification,
+			notifier.KindStartup,
+			"Cloudflare DDNS has started.",
+		},
+		"scheduling failure": {
+			func() notifier.Notification { return schedulingFailureNotification("@every 5m") },
+			notifier.KindSchedulingFailure,
+			"Cloudflare DDNS stopped because no updates are scheduled in the near future. " +
+				"Consider changing the value of UPDATE_CRON (@every 5m).",
+		},
+		"shutdown": {
+			shutdownNotification,
+			notifier.KindShutdown,
+			"Cloudflare DDNS has stopped.",
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			got := tc.build()
+			require.Equal(t, tc.wantKind, got.Kind)
+			require.Equal(t, tc.wantPayload, got.Format())
+		})
+	}
+}

--- a/internal/heartbeat/healthchecks.go
+++ b/internal/heartbeat/healthchecks.go
@@ -156,6 +156,9 @@ the variable user-facing wording for the request:
 This keeps the contract explicit while avoiding repeated string literals at
 each call site.
 
+The endpoint identifies the ping purpose and the POST body carries its details,
+so the success log does not repeat a semantic summary of the message.
+
 Code and body for UUID API:
 
   - 200

--- a/internal/heartbeat/healthchecks.go
+++ b/internal/heartbeat/healthchecks.go
@@ -150,7 +150,7 @@ The caller is responsible for choosing a [healthchecksPingSpec], which defines
 the variable user-facing wording for the request:
 
   - location is the endpoint label shown in error messages.
-  - descriptionWithArticle is used in messages like "Successfully sent ... to Healthchecks".
+  - descriptionWithArticle is used in messages like "Sent ... to Healthchecks".
   - descriptionWithoutArticle is used in messages like "The ... to Healthchecks returned an unexpected response".
 
 This keeps the contract explicit while avoiding repeated string literals at
@@ -224,6 +224,6 @@ func (h Healthchecks) ping(ctx context.Context, ppfmt pp.PP, spec healthchecksPi
 		return false
 	}
 
-	ppfmt.Infof(pp.EmojiPing, "Successfully sent %s to Healthchecks", spec.descriptionWithArticle)
+	ppfmt.Infof(pp.EmojiPing, "Sent %s to Healthchecks", spec.descriptionWithArticle)
 	return true
 }

--- a/internal/heartbeat/healthchecks_test.go
+++ b/internal/heartbeat/healthchecks_test.go
@@ -122,7 +122,7 @@ func TestHealthchecksEndPoints(t *testing.T) {
 			func(m *mocks.MockPP) {
 				gomock.InOrder(
 					m.EXPECT().Noticef(pp.EmojiUserWarning, "The Healthchecks URL (redacted) uses HTTP; please consider using HTTPS"),
-					m.EXPECT().Infof(pp.EmojiPing, "Successfully sent %s to Healthchecks", "a ping"),
+					m.EXPECT().Infof(pp.EmojiPing, "Sent %s to Healthchecks", "a ping"),
 				)
 			},
 		},
@@ -168,7 +168,7 @@ func TestHealthchecksEndPoints(t *testing.T) {
 			func(m *mocks.MockPP) {
 				gomock.InOrder(
 					m.EXPECT().Noticef(pp.EmojiUserWarning, "The Healthchecks URL (redacted) uses HTTP; please consider using HTTPS"),
-					m.EXPECT().Infof(pp.EmojiPing, "Successfully sent %s to Healthchecks", "a failure ping"),
+					m.EXPECT().Infof(pp.EmojiPing, "Sent %s to Healthchecks", "a failure ping"),
 				)
 			},
 		},
@@ -183,7 +183,7 @@ func TestHealthchecksEndPoints(t *testing.T) {
 			func(m *mocks.MockPP) {
 				gomock.InOrder(
 					m.EXPECT().Noticef(pp.EmojiUserWarning, "The Healthchecks URL (redacted) uses HTTP; please consider using HTTPS"),
-					m.EXPECT().Infof(pp.EmojiPing, "Successfully sent %s to Healthchecks", "a start ping"),
+					m.EXPECT().Infof(pp.EmojiPing, "Sent %s to Healthchecks", "a start ping"),
 				)
 			},
 		},
@@ -198,7 +198,7 @@ func TestHealthchecksEndPoints(t *testing.T) {
 			func(m *mocks.MockPP) {
 				gomock.InOrder(
 					m.EXPECT().Noticef(pp.EmojiUserWarning, "The Healthchecks URL (redacted) uses HTTP; please consider using HTTPS"),
-					m.EXPECT().Infof(pp.EmojiPing, "Successfully sent %s to Healthchecks", "an exit ping"),
+					m.EXPECT().Infof(pp.EmojiPing, "Sent %s to Healthchecks", "an exit ping"),
 				)
 			},
 		},
@@ -213,7 +213,7 @@ func TestHealthchecksEndPoints(t *testing.T) {
 			func(m *mocks.MockPP) {
 				gomock.InOrder(
 					m.EXPECT().Noticef(pp.EmojiUserWarning, "The Healthchecks URL (redacted) uses HTTP; please consider using HTTPS"),
-					m.EXPECT().Infof(pp.EmojiPing, "Successfully sent %s to Healthchecks", "a log ping"),
+					m.EXPECT().Infof(pp.EmojiPing, "Sent %s to Healthchecks", "a log ping"),
 				)
 			},
 		},
@@ -228,7 +228,7 @@ func TestHealthchecksEndPoints(t *testing.T) {
 			func(m *mocks.MockPP) {
 				gomock.InOrder(
 					m.EXPECT().Noticef(pp.EmojiUserWarning, "The Healthchecks URL (redacted) uses HTTP; please consider using HTTPS"),
-					m.EXPECT().Infof(pp.EmojiPing, "Successfully sent %s to Healthchecks", "a failure ping"),
+					m.EXPECT().Infof(pp.EmojiPing, "Sent %s to Healthchecks", "a failure ping"),
 				)
 			},
 		},

--- a/internal/mocks/mock_notifier.go
+++ b/internal/mocks/mock_notifier.go
@@ -79,17 +79,17 @@ func (c *MockNotifierDescribeCall) DoAndReturn(f func(func(string, string) bool)
 }
 
 // Send mocks base method.
-func (m *MockNotifier) Send(ctx context.Context, ppfmt pp.PP, msg notifier.Message) bool {
+func (m *MockNotifier) Send(ctx context.Context, ppfmt pp.PP, notification notifier.Notification) bool {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Send", ctx, ppfmt, msg)
+	ret := m.ctrl.Call(m, "Send", ctx, ppfmt, notification)
 	ret0, _ := ret[0].(bool)
 	return ret0
 }
 
 // Send indicates an expected call of Send.
-func (mr *MockNotifierMockRecorder) Send(ctx, ppfmt, msg any) *MockNotifierSendCall {
+func (mr *MockNotifierMockRecorder) Send(ctx, ppfmt, notification any) *MockNotifierSendCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Send", reflect.TypeOf((*MockNotifier)(nil).Send), ctx, ppfmt, msg)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Send", reflect.TypeOf((*MockNotifier)(nil).Send), ctx, ppfmt, notification)
 	return &MockNotifierSendCall{Call: call}
 }
 
@@ -105,13 +105,13 @@ func (c *MockNotifierSendCall) Return(arg0 bool) *MockNotifierSendCall {
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockNotifierSendCall) Do(f func(context.Context, pp.PP, notifier.Message) bool) *MockNotifierSendCall {
+func (c *MockNotifierSendCall) Do(f func(context.Context, pp.PP, notifier.Notification) bool) *MockNotifierSendCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockNotifierSendCall) DoAndReturn(f func(context.Context, pp.PP, notifier.Message) bool) *MockNotifierSendCall {
+func (c *MockNotifierSendCall) DoAndReturn(f func(context.Context, pp.PP, notifier.Notification) bool) *MockNotifierSendCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/internal/notifier/base.go
+++ b/internal/notifier/base.go
@@ -14,6 +14,6 @@ type Notifier interface {
 	// Describe a notifier in a human-readable format by calling callback with service names and params.
 	Describe(yield func(name, params string) bool)
 
-	// Send out a message.
-	Send(ctx context.Context, ppfmt pp.PP, msg Message) bool
+	// Send out a notification.
+	Send(ctx context.Context, ppfmt pp.PP, notification Notification) bool
 }

--- a/internal/notifier/composite.go
+++ b/internal/notifier/composite.go
@@ -39,10 +39,10 @@ func (ns Composed) Describe(yield func(name string, params string) bool) {
 }
 
 // Send calls [Notifier.Send] for each notifier in the group.
-func (ns Composed) Send(ctx context.Context, ppfmt pp.PP, msg Message) bool {
+func (ns Composed) Send(ctx context.Context, ppfmt pp.PP, notification Notification) bool {
 	allOK := true
 	for _, n := range ns {
-		childOK := n.Send(ctx, ppfmt, msg)
+		childOK := n.Send(ctx, ppfmt, notification)
 		allOK = allOK && childOK
 	}
 	return allOK

--- a/internal/notifier/composite_test.go
+++ b/internal/notifier/composite_test.go
@@ -47,12 +47,13 @@ func TestComposedSend(t *testing.T) {
 	t.Parallel()
 
 	for name, tc := range map[string]struct {
-		ss []string
+		kind notifier.Kind
+		ss   []string
 	}{
-		"nil":   {nil},
-		"empty": {[]string{}},
-		"one":   {[]string{"hi"}},
-		"two":   {[]string{"hi", "hey"}},
+		"nil":   {notifier.KindUpdate, nil},
+		"empty": {notifier.KindUpdateFailure, []string{}},
+		"one":   {notifier.KindCleanup, []string{"hi"}},
+		"two":   {notifier.KindCleanupFailure, []string{"hi", "hey"}},
 	} {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -61,15 +62,15 @@ func TestComposedSend(t *testing.T) {
 			mockCtrl := gomock.NewController(t)
 			mockPP := mocks.NewMockPP(mockCtrl)
 
-			msg := notifier.Message(tc.ss)
+			notification := notifier.NewNotification(tc.kind, notifier.Message(tc.ss))
 
 			for range 5 {
 				n := mocks.NewMockNotifier(mockCtrl)
-				n.EXPECT().Send(context.Background(), mockPP, msg).Return(true)
+				n.EXPECT().Send(context.Background(), mockPP, notification).Return(true)
 				ns = append(ns, n)
 			}
 
-			ok := notifier.NewComposed(ns...).Send(context.Background(), mockPP, msg)
+			ok := notifier.NewComposed(ns...).Send(context.Background(), mockPP, notification)
 			require.True(t, ok)
 		})
 	}
@@ -82,13 +83,13 @@ func TestComposedSendContinuesAfterFailure(t *testing.T) {
 	mockPP := mocks.NewMockPP(mockCtrl)
 	first := mocks.NewMockNotifier(mockCtrl)
 	second := mocks.NewMockNotifier(mockCtrl)
-	message := notifier.NewMessagef("notification")
+	notification := notifier.NewNotification(notifier.KindUpdate, notifier.NewMessagef("notification"))
 
 	gomock.InOrder(
-		first.EXPECT().Send(context.Background(), mockPP, message).Return(false),
-		second.EXPECT().Send(context.Background(), mockPP, message).Return(true),
+		first.EXPECT().Send(context.Background(), mockPP, notification).Return(false),
+		second.EXPECT().Send(context.Background(), mockPP, notification).Return(true),
 	)
 
-	ok := notifier.NewComposed(first, second).Send(context.Background(), mockPP, message)
+	ok := notifier.NewComposed(first, second).Send(context.Background(), mockPP, notification)
 	require.False(t, ok)
 }

--- a/internal/notifier/notification.go
+++ b/internal/notifier/notification.go
@@ -1,0 +1,66 @@
+package notifier
+
+import "github.com/favonia/cloudflare-ddns/internal/pp"
+
+// Kind identifies the purpose of a notification.
+type Kind string
+
+// Notification kinds.
+const (
+	KindStartup           Kind = "startup"
+	KindStartupFailure    Kind = "startup failure"
+	KindUpdate            Kind = "update"
+	KindUpdateFailure     Kind = "update failure"
+	KindSchedulingFailure Kind = "scheduling failure"
+	KindCleanup           Kind = "cleanup"
+	KindCleanupFailure    Kind = "cleanup failure"
+	KindShutdown          Kind = "shutdown"
+)
+
+// Notification is a message with metadata describing its purpose.
+type Notification struct {
+	Kind    Kind
+	Message Message
+}
+
+// NewNotification creates a notification.
+func NewNotification(kind Kind, message Message) Notification {
+	return Notification{Kind: kind, Message: message}
+}
+
+// NewNotificationf creates a notification with a formatted message.
+func NewNotificationf(kind Kind, format string, args ...any) Notification {
+	return NewNotification(kind, NewMessagef(format, args...))
+}
+
+// Format formats the notification message.
+func (n Notification) Format() string { return n.Message.Format() }
+
+// IsEmpty reports whether the notification message is empty.
+func (n Notification) IsEmpty() bool { return n.Message.IsEmpty() }
+
+func (n Notification) description(ppfmt pp.PP) string {
+	switch n.Kind {
+	case KindStartup:
+		return "a startup notification"
+	case KindStartupFailure:
+		return "a startup failure notification"
+	case KindUpdate:
+		return "an update notification"
+	case KindUpdateFailure:
+		return "an update failure notification"
+	case KindSchedulingFailure:
+		return "a scheduling failure notification"
+	case KindCleanup:
+		return "a cleanup notification"
+	case KindCleanupFailure:
+		return "a cleanup failure notification"
+	case KindShutdown:
+		return "a shutdown notification"
+	default:
+		ppfmt.Noticef(pp.EmojiImpossible,
+			"Unknown notification type %q; this should not happen. Please report it at %s",
+			n.Kind, pp.IssueReportingURL)
+		return "a notification"
+	}
+}

--- a/internal/notifier/notification.go
+++ b/internal/notifier/notification.go
@@ -2,7 +2,8 @@ package notifier
 
 import "github.com/favonia/cloudflare-ddns/internal/pp"
 
-// Kind identifies the purpose of a notification.
+// Kind identifies the purpose assigned at an event-producing boundary, so
+// transports never need to infer it from the formatted message.
 type Kind string
 
 // Notification kinds.

--- a/internal/notifier/notification_internal_test.go
+++ b/internal/notifier/notification_internal_test.go
@@ -1,0 +1,59 @@
+package notifier
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/favonia/cloudflare-ddns/internal/pp"
+)
+
+func TestNotificationDescription(t *testing.T) {
+	t.Parallel()
+
+	for name, tc := range map[string]struct {
+		kind Kind
+		want string
+	}{
+		"startup":            {KindStartup, "a startup notification"},
+		"startup failure":    {KindStartupFailure, "a startup failure notification"},
+		"update":             {KindUpdate, "an update notification"},
+		"update failure":     {KindUpdateFailure, "an update failure notification"},
+		"scheduling failure": {KindSchedulingFailure, "a scheduling failure notification"},
+		"cleanup":            {KindCleanup, "a cleanup notification"},
+		"cleanup failure":    {KindCleanupFailure, "a cleanup failure notification"},
+		"shutdown":           {KindShutdown, "a shutdown notification"},
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			notification := NewNotification(tc.kind, NewMessage())
+			require.Equal(t, tc.want, notification.description(pp.NewSilent()))
+		})
+	}
+}
+
+func TestUnknownNotificationDescription(t *testing.T) {
+	t.Parallel()
+
+	for name, tc := range map[string]struct {
+		kind Kind
+		want string
+	}{
+		"unexpected": {Kind("unexpected"), "\"unexpected\""},
+		"empty":      {Kind(""), "\"\""},
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			var output strings.Builder
+			notification := NewNotification(tc.kind, NewMessage())
+			got := notification.description(pp.NewDefault(&output))
+
+			require.Equal(t, "a notification", got)
+			require.Equal(t,
+				"🤯 Unknown notification type "+tc.want+"; this should not happen. "+
+					"Please report it at "+pp.IssueReportingURL+"\n",
+				output.String())
+		})
+	}
+}

--- a/internal/notifier/shoutrrr.go
+++ b/internal/notifier/shoutrrr.go
@@ -91,13 +91,14 @@ func (s Shoutrrr) Describe(yield func(string, string) bool) {
 	}
 }
 
-// Send sents the message msg.
-func (s Shoutrrr) Send(_ context.Context, ppfmt pp.PP, msg Message) bool {
-	if msg.IsEmpty() {
+// Send sends the notification.
+func (s Shoutrrr) Send(_ context.Context, ppfmt pp.PP, notification Notification) bool {
+	if notification.IsEmpty() {
 		return true
 	}
 
-	errs := s.Router.Send(msg.Format(), &types.Params{})
+	description := notification.description(ppfmt)
+	errs := s.Router.Send(notification.Format(), &types.Params{})
 	allOK := true
 	for _, err := range errs {
 		if err != nil {
@@ -107,7 +108,8 @@ func (s Shoutrrr) Send(_ context.Context, ppfmt pp.PP, msg Message) bool {
 	}
 	if allOK {
 		ppfmt.Infof(pp.EmojiNotify,
-			"Notified %s via Shoutrrr",
+			"Sent %s to %s via Shoutrrr",
+			description,
 			pp.EnglishJoinOrEmptyLabel(s.ServiceDescriptions, "(none)"))
 	}
 	return allOK

--- a/internal/notifier/shoutrrr.go
+++ b/internal/notifier/shoutrrr.go
@@ -107,6 +107,8 @@ func (s Shoutrrr) Send(_ context.Context, ppfmt pp.PP, notification Notification
 		}
 	}
 	if allOK {
+		// Keep the configured transport visible, especially when a service
+		// description such as "Generic" would be ambiguous in an isolated log.
 		ppfmt.Infof(pp.EmojiNotify,
 			"Sent %s to %s via Shoutrrr",
 			description,

--- a/internal/notifier/shoutrrr_test.go
+++ b/internal/notifier/shoutrrr_test.go
@@ -85,23 +85,50 @@ func TestShoutrrrSend(t *testing.T) {
 		path          string
 		pinged        int
 		service       func(serverURL string) string
-		message       notifier.Message
+		notification  notifier.Notification
 		ok            bool
 		prepareMockPP func(*mocks.MockPP)
 	}{
 		"success": {
 			"/greeting", 1,
 			func(serverURL string) string { return "generic+" + serverURL + "/greeting" },
-			notifier.NewMessagef("hello"),
+			notifier.NewNotificationf(notifier.KindStartup, "hello"),
 			true,
 			func(m *mocks.MockPP) {
-				m.EXPECT().Infof(pp.EmojiNotify, "Notified %s via Shoutrrr", "Generic")
+				m.EXPECT().Infof(
+					pp.EmojiNotify,
+					"Sent %s to %s via Shoutrrr",
+					"a startup notification",
+					"Generic",
+				)
+			},
+		},
+		"invalid kind": {
+			"/greeting", 1,
+			func(serverURL string) string { return "generic+" + serverURL + "/greeting" },
+			notifier.NewNotificationf(notifier.Kind("unexpected"), "hello"),
+			true,
+			func(m *mocks.MockPP) {
+				gomock.InOrder(
+					m.EXPECT().Noticef(
+						pp.EmojiImpossible,
+						"Unknown notification type %q; this should not happen. Please report it at %s",
+						notifier.Kind("unexpected"),
+						pp.IssueReportingURL,
+					),
+					m.EXPECT().Infof(
+						pp.EmojiNotify,
+						"Sent %s to %s via Shoutrrr",
+						"a notification",
+						"Generic",
+					),
+				)
 			},
 		},
 		"malformed url": {
 			"", 0,
 			func(_serverURL string) string { return "generic+https://0.0.0.0" },
-			notifier.NewMessagef("hello"),
+			notifier.NewNotificationf(notifier.KindUpdate, "hello"),
 			false,
 			func(m *mocks.MockPP) {
 				m.EXPECT().Noticef(pp.EmojiError, "Failed to send notifications via Shoutrrr: %v", gomock.Any())
@@ -110,7 +137,7 @@ func TestShoutrrrSend(t *testing.T) {
 		"empty": {
 			"/greeting", 0,
 			func(serverURL string) string { return "generic+" + serverURL + "/greeting" },
-			notifier.NewMessage(),
+			notifier.NewNotification(notifier.KindUpdate, notifier.NewMessage()),
 			true,
 			nil,
 		},
@@ -131,7 +158,7 @@ func TestShoutrrrSend(t *testing.T) {
 				}
 
 				if reqBody, err := io.ReadAll(r.Body); !assert.NoError(t, err) ||
-					!assert.Equal(t, tc.message.Format(), string(reqBody)) {
+					!assert.Equal(t, tc.notification.Format(), string(reqBody)) {
 					panic(http.ErrAbortHandler)
 				}
 
@@ -140,9 +167,39 @@ func TestShoutrrrSend(t *testing.T) {
 
 			s, ok := notifier.NewShoutrrr(mockPP, []string{tc.service(server.URL)})
 			require.True(t, ok)
-			ok = s.Send(context.Background(), mockPP, tc.message)
+			ok = s.Send(context.Background(), mockPP, tc.notification)
 			require.Equal(t, tc.ok, ok)
 			require.Equal(t, tc.pinged, pinged)
 		})
 	}
+}
+
+func TestShoutrrrSendMultipleServices(t *testing.T) {
+	t.Parallel()
+
+	notification := notifier.NewNotificationf(notifier.KindUpdate, "hello")
+	pinged := 0
+	server := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		if reqBody, err := io.ReadAll(r.Body); !assert.NoError(t, err) ||
+			!assert.Equal(t, notification.Format(), string(reqBody)) {
+			panic(http.ErrAbortHandler)
+		}
+		pinged++
+	}))
+	t.Cleanup(server.Close)
+
+	mockCtrl := gomock.NewController(t)
+	mockPP := mocks.NewMockPP(mockCtrl)
+	mockPP.EXPECT().Infof(
+		pp.EmojiNotify,
+		"Sent %s to %s via Shoutrrr",
+		"an update notification",
+		"Generic and Generic",
+	)
+
+	service := "generic+" + server.URL + "/greeting"
+	s, ok := notifier.NewShoutrrr(mockPP, []string{service, service})
+	require.True(t, ok)
+	require.True(t, s.Send(context.Background(), mockPP, notification))
+	require.Equal(t, 2, pinged)
 }

--- a/internal/updater/message.go
+++ b/internal/updater/message.go
@@ -12,6 +12,12 @@ import (
 type Message struct {
 	HeartbeatMessage heartbeat.Message
 	NotifierMessage  notifier.Message
+	NotificationKind notifier.Kind
+}
+
+// Notification returns the notifier-facing message with its classification.
+func (m Message) Notification() notifier.Notification {
+	return notifier.NewNotification(m.NotificationKind, m.NotifierMessage)
 }
 
 // newMessage creates a new, empty message.
@@ -19,6 +25,7 @@ func newMessage() Message {
 	return Message{
 		HeartbeatMessage: heartbeat.NewMessage(),
 		NotifierMessage:  notifier.NewMessage(),
+		NotificationKind: "",
 	}
 }
 
@@ -35,7 +42,17 @@ func mergeMessages(msgs ...Message) Message {
 	return Message{
 		HeartbeatMessage: heartbeat.MergeMessages(hms...),
 		NotifierMessage:  notifier.MergeMessages(nms...),
+		NotificationKind: "",
 	}
+}
+
+func classifyNotification(msg Message, successKind, failureKind notifier.Kind) Message {
+	if msg.HeartbeatMessage.OK {
+		msg.NotificationKind = successKind
+	} else {
+		msg.NotificationKind = failureKind
+	}
+	return msg
 }
 
 // appendNotifierFragmentf appends a notifier fragment while keeping the

--- a/internal/updater/message_records.go
+++ b/internal/updater/message_records.go
@@ -35,6 +35,7 @@ func generateDetectMessage(ipFamily ipnet.Family, ok bool) Message {
 			NotifierMessage: notifier.Message{
 				fmt.Sprintf("Failed to detect any %s addresses.", ipFamily.Describe()),
 			},
+			NotificationKind: "",
 		}
 	}
 }
@@ -49,6 +50,7 @@ func generateFilterAbortDetectMessage(ipFamily ipnet.Family) Message {
 		NotifierMessage: notifier.Message{
 			summary + ".",
 		},
+		NotificationKind: "",
 	}
 }
 
@@ -62,6 +64,7 @@ func generateIP6DerivationFailureMessage() Message {
 		NotifierMessage: notifier.Message{
 			message + ".",
 		},
+		NotificationKind: "",
 	}
 }
 
@@ -73,6 +76,7 @@ func generateMissingTargetSetsMessage(ipFamily ipnet.Family, domains []domain.Do
 		NotifierMessage: notifier.Message{
 			summary + " because of an internal error; check the logs for details.",
 		},
+		NotificationKind: "",
 	}
 }
 
@@ -227,11 +231,13 @@ func generateClearOrUpdateMessage(ipFamily ipnet.Family, ips []netip.Addr, s set
 		return Message{
 			HeartbeatMessage: generateClearHeartbeatMessage(ipFamily, s),
 			NotifierMessage:  generateClearNotifierMessage(ipFamily, s),
+			NotificationKind: "",
 		}
 	} else {
 		return Message{
 			HeartbeatMessage: generateUpdateHeartbeatMessage(ipFamily, ips, s),
 			NotifierMessage:  generateUpdateNotifierMessage(ipFamily, ips, s),
+			NotificationKind: "",
 		}
 	}
 }
@@ -300,5 +306,6 @@ func generateFinalDeleteMessage(ipFamily ipnet.Family, s setterResponses) Messag
 	return Message{
 		HeartbeatMessage: generateFinalDeleteHeartbeatMessage(ipFamily, s),
 		NotifierMessage:  generateFinalDeleteNotifierMessage(ipFamily, s),
+		NotificationKind: "",
 	}
 }

--- a/internal/updater/message_waf.go
+++ b/internal/updater/message_waf.go
@@ -79,6 +79,7 @@ func generateUpdateWAFListsMessage(s setterWAFListResponses) Message {
 	return Message{
 		HeartbeatMessage: generateUpdateWAFListsHeartbeatMessage(s),
 		NotifierMessage:  generateUpdateWAFListsNotifierMessage(s),
+		NotificationKind: "",
 	}
 }
 
@@ -139,5 +140,6 @@ func generateFinalClearWAFListsMessage(s setterWAFListResponses) Message {
 	return Message{
 		HeartbeatMessage: generateFinalClearWAFListsHeartbeatMessage(s),
 		NotifierMessage:  generateFinalClearWAFListsNotifierMessage(s),
+		NotificationKind: "",
 	}
 }

--- a/internal/updater/updater.go
+++ b/internal/updater/updater.go
@@ -14,6 +14,7 @@ import (
 	"github.com/favonia/cloudflare-ddns/internal/domain"
 	"github.com/favonia/cloudflare-ddns/internal/hostid6"
 	"github.com/favonia/cloudflare-ddns/internal/ipnet"
+	"github.com/favonia/cloudflare-ddns/internal/notifier"
 	"github.com/favonia/cloudflare-ddns/internal/pp"
 	"github.com/favonia/cloudflare-ddns/internal/provider"
 	"github.com/favonia/cloudflare-ddns/internal/setter"
@@ -405,7 +406,11 @@ func UpdateIPs(ctx context.Context, ppfmt pp.PP, c *config.UpdateConfig, s sette
 		msgs = append(msgs, setWAFLists(ctx, ppfmt, c, s, targetsForWAF))
 	}
 
-	return mergeMessages(msgs...)
+	return classifyNotification(
+		mergeMessages(msgs...),
+		notifier.KindUpdate,
+		notifier.KindUpdateFailure,
+	)
 }
 
 // FinalDeleteIPs removes all DNS records of managed domains.
@@ -421,5 +426,9 @@ func FinalDeleteIPs(ctx context.Context, ppfmt pp.PP, c *config.UpdateConfig, s 
 	// Clear WAF lists
 	msgs = append(msgs, finalClearWAFLists(ctx, ppfmt, c, s))
 
-	return mergeMessages(msgs...)
+	return classifyNotification(
+		mergeMessages(msgs...),
+		notifier.KindCleanup,
+		notifier.KindCleanupFailure,
+	)
 }

--- a/internal/updater/updater_internal_test.go
+++ b/internal/updater/updater_internal_test.go
@@ -20,6 +20,36 @@ import (
 	"github.com/favonia/cloudflare-ddns/internal/setter"
 )
 
+func TestClassifyNotification(t *testing.T) {
+	t.Parallel()
+
+	for name, tc := range map[string]struct {
+		ok       bool
+		wantKind notifier.Kind
+	}{
+		"success": {true, notifier.KindUpdate},
+		"failure": {false, notifier.KindUpdateFailure},
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			msg := Message{
+				HeartbeatMessage: heartbeat.NewMessagef(tc.ok, "heartbeat"),
+				NotifierMessage:  notifier.NewMessagef("notification"),
+				NotificationKind: "",
+			}
+			got := classifyNotification(
+				msg,
+				notifier.KindUpdate,
+				notifier.KindUpdateFailure,
+			)
+			require.Equal(t, tc.wantKind, got.NotificationKind)
+			require.Equal(t,
+				notifier.NewNotification(tc.wantKind, msg.NotifierMessage),
+				got.Notification())
+		})
+	}
+}
+
 func TestSetIPsSkipsManagedDomainWithoutTargets(t *testing.T) {
 	t.Parallel()
 
@@ -58,5 +88,6 @@ func TestSetIPsSkipsManagedDomainWithoutTargets(t *testing.T) {
 			"Could not update A records for missing.example because of an internal error; check the logs for details.",
 			"Updated A records for present.example to 192.0.2.1.",
 		},
+		NotificationKind: "",
 	}, msg)
 }

--- a/internal/updater/updater_test.go
+++ b/internal/updater/updater_test.go
@@ -353,12 +353,17 @@ func TestUpdateIPsMultiple(t *testing.T) {
 			}
 
 			resp := updater.UpdateIPs(ctx, mockPP, conf, mockSetter)
+			wantKind := notifier.KindUpdateFailure
+			if tc.ok {
+				wantKind = notifier.KindUpdate
+			}
 			require.Equal(t, updater.Message{
 				HeartbeatMessage: heartbeat.Message{
 					OK:    tc.ok,
 					Lines: tc.monitorMessages,
 				},
-				NotifierMessage: notifier.Message(tc.notifierMessages),
+				NotifierMessage:  notifier.Message(tc.notifierMessages),
+				NotificationKind: wantKind,
 			}, resp)
 		})
 	}
@@ -456,12 +461,17 @@ func TestFinalDeleteIPsMultiple(t *testing.T) {
 				tc.prepareMocks(mockPP, mockSetter)
 			}
 			resp := updater.FinalDeleteIPs(ctx, mockPP, conf, mockSetter)
+			wantKind := notifier.KindCleanupFailure
+			if tc.ok {
+				wantKind = notifier.KindCleanup
+			}
 			require.Equal(t, updater.Message{
 				HeartbeatMessage: heartbeat.Message{
 					OK:    tc.ok,
 					Lines: tc.monitorMessages,
 				},
-				NotifierMessage: notifier.Message(tc.notifierMessages),
+				NotifierMessage:  notifier.Message(tc.notifierMessages),
+				NotificationKind: wantKind,
 			}, resp)
 		})
 	}
@@ -713,12 +723,17 @@ func TestUpdateIPs(t *testing.T) {
 			t.Parallel()
 
 			resp := runUpdateIPsScenario(t, domains, lists, tc.providerEnablers, tc.prepareMocks)
+			wantKind := notifier.KindUpdateFailure
+			if tc.ok {
+				wantKind = notifier.KindUpdate
+			}
 			require.Equal(t, updater.Message{
 				HeartbeatMessage: heartbeat.Message{
 					OK:    tc.ok,
 					Lines: tc.monitorMessages,
 				},
-				NotifierMessage: notifier.Message(tc.notifierMessages),
+				NotifierMessage:  notifier.Message(tc.notifierMessages),
+				NotificationKind: wantKind,
 			}, resp)
 		})
 	}
@@ -752,6 +767,7 @@ func TestUpdateIPsDetectionFilterPartial(t *testing.T) {
 	require.Equal(t, updater.Message{
 		HeartbeatMessage: heartbeat.Message{OK: true, Lines: []string{"Set A records for ip4.hello to 198.51.100.8"}},
 		NotifierMessage:  notifier.Message{"Updated A records for ip4.hello to 198.51.100.8."},
+		NotificationKind: notifier.KindUpdate,
 	}, resp)
 }
 
@@ -785,6 +801,7 @@ func TestUpdateIPsDetectionFilterReportsMultipleDropped(t *testing.T) {
 	require.Equal(t, updater.Message{
 		HeartbeatMessage: heartbeat.Message{OK: true, Lines: []string{"Set A records for ip4.hello to 198.51.100.8"}},
 		NotifierMessage:  notifier.Message{"Updated A records for ip4.hello to 198.51.100.8."},
+		NotificationKind: notifier.KindUpdate,
 	}, resp)
 }
 
@@ -813,6 +830,7 @@ func TestUpdateIPsDetectionFilterKeepingAllReportsFilteredDetection(t *testing.T
 	require.Equal(t, updater.Message{
 		HeartbeatMessage: heartbeat.Message{OK: true, Lines: []string{"Set A records for ip4.hello to 198.51.100.8"}},
 		NotifierMessage:  notifier.Message{"Updated A records for ip4.hello to 198.51.100.8."},
+		NotificationKind: notifier.KindUpdate,
 	}, resp)
 }
 
@@ -843,6 +861,7 @@ func TestUpdateIPsDetectionFilterKeepingAllReportsFilteredPluralDetection(t *tes
 	require.Equal(t, updater.Message{
 		HeartbeatMessage: heartbeat.Message{OK: true, Lines: []string{"Set A records for ip4.hello to 198.51.100.8, 198.51.100.9"}},
 		NotifierMessage:  notifier.Message{"Updated A records for ip4.hello to 198.51.100.8 and 198.51.100.9."},
+		NotificationKind: notifier.KindUpdate,
 	}, resp)
 }
 
@@ -893,6 +912,7 @@ func TestUpdateIPsDetectionFilterToNoneAbortsFamily(t *testing.T) {
 			"Updated AAAA records for ip6.hello to 2001:db8::8.",
 			"Updated WAF list(s) 12341234/list.",
 		},
+		NotificationKind: notifier.KindUpdateFailure,
 	}, resp)
 }
 
@@ -920,6 +940,7 @@ func TestUpdateIPsDetectionFilterDoesNotChangeExplicitClear(t *testing.T) {
 	require.Equal(t, updater.Message{
 		HeartbeatMessage: heartbeat.Message{OK: true, Lines: []string{"Cleared A records for ip4.hello"}},
 		NotifierMessage:  notifier.Message{"Cleared A records for ip4.hello."},
+		NotificationKind: notifier.KindUpdate,
 	}, resp)
 }
 
@@ -944,6 +965,7 @@ func TestUpdateIPsDetectionFilterDoesNotChangeProviderUnavailable(t *testing.T) 
 	require.Equal(t, updater.Message{
 		HeartbeatMessage: heartbeat.Message{OK: false, Lines: []string{"Failed to detect any IPv4 addresses"}},
 		NotifierMessage:  notifier.Message{"Failed to detect any IPv4 addresses."},
+		NotificationKind: notifier.KindUpdateFailure,
 	}, resp)
 }
 
@@ -988,6 +1010,7 @@ func TestUpdateIPsHostID6Preflight(t *testing.T) {
 		require.Equal(t, updater.Message{
 			HeartbeatMessage: heartbeat.Message{OK: true, Lines: nil},
 			NotifierMessage:  nil,
+			NotificationKind: notifier.KindUpdate,
 		}, resp)
 	})
 
@@ -1021,6 +1044,7 @@ func TestUpdateIPsHostID6Preflight(t *testing.T) {
 		require.Equal(t, updater.Message{
 			HeartbeatMessage: heartbeat.Message{OK: true, Lines: nil},
 			NotifierMessage:  nil,
+			NotificationKind: notifier.KindUpdate,
 		}, resp)
 	})
 
@@ -1059,6 +1083,7 @@ func TestUpdateIPsHostID6Preflight(t *testing.T) {
 				"Cleared AAAA records for alpha.example and beta.example.",
 				"Updated WAF list(s) 12341234/list.",
 			},
+			NotificationKind: notifier.KindUpdate,
 		}, resp)
 	})
 
@@ -1105,6 +1130,7 @@ func TestUpdateIPsHostID6Preflight(t *testing.T) {
 			NotifierMessage: notifier.Message{
 				"No AAAA records were changed because a hostid6 setting is incompatible with the detected IPv6 prefixes.",
 			},
+			NotificationKind: notifier.KindUpdateFailure,
 		}, resp)
 	})
 
@@ -1147,6 +1173,7 @@ func TestUpdateIPsHostID6Preflight(t *testing.T) {
 			NotifierMessage: notifier.Message{
 				"No AAAA records were changed because a hostid6 setting is incompatible with the detected IPv6 prefixes.",
 			},
+			NotificationKind: notifier.KindUpdateFailure,
 		}, resp)
 	})
 
@@ -1193,6 +1220,7 @@ func TestUpdateIPsHostID6Preflight(t *testing.T) {
 			NotifierMessage: notifier.Message{
 				"No AAAA records were changed because a hostid6 setting is incompatible with the detected IPv6 prefixes.",
 			},
+			NotificationKind: notifier.KindUpdateFailure,
 		}, resp)
 	})
 }
@@ -1288,12 +1316,17 @@ func TestUpdateIPsTimeouts(t *testing.T) {
 
 			synctest.Test(t, func(t *testing.T) {
 				resp := runUpdateIPsScenario(t, domains, lists, tc.providerEnablers, tc.prepareMocks)
+				wantKind := notifier.KindUpdateFailure
+				if tc.ok {
+					wantKind = notifier.KindUpdate
+				}
 				require.Equal(t, updater.Message{
 					HeartbeatMessage: heartbeat.Message{
 						OK:    tc.ok,
 						Lines: tc.monitorMessages,
 					},
-					NotifierMessage: notifier.Message(tc.notifierMessages),
+					NotifierMessage:  notifier.Message(tc.notifierMessages),
+					NotificationKind: wantKind,
 				}, resp)
 			})
 		})
@@ -1456,12 +1489,17 @@ func TestFinalDeleteIPs(t *testing.T) {
 			t.Parallel()
 
 			resp := runFinalDeleteIPsScenario(t, domains, lists, tc.providerEnablers, tc.prepareMocks)
+			wantKind := notifier.KindCleanupFailure
+			if tc.ok {
+				wantKind = notifier.KindCleanup
+			}
 			require.Equal(t, updater.Message{
 				HeartbeatMessage: heartbeat.Message{
 					OK:    tc.ok,
 					Lines: tc.monitorMessages,
 				},
-				NotifierMessage: notifier.Message(tc.notifierMessages),
+				NotifierMessage:  notifier.Message(tc.notifierMessages),
+				NotificationKind: wantKind,
 			}, resp)
 		})
 	}
@@ -1531,12 +1569,17 @@ func TestFinalDeleteIPsTimeouts(t *testing.T) {
 
 			synctest.Test(t, func(t *testing.T) {
 				resp := runFinalDeleteIPsScenario(t, domains, lists, tc.providerEnablers, tc.prepareMocks)
+				wantKind := notifier.KindCleanupFailure
+				if tc.ok {
+					wantKind = notifier.KindCleanup
+				}
 				require.Equal(t, updater.Message{
 					HeartbeatMessage: heartbeat.Message{
 						OK:    tc.ok,
 						Lines: tc.monitorMessages,
 					},
-					NotifierMessage: notifier.Message(tc.notifierMessages),
+					NotifierMessage:  notifier.Message(tc.notifierMessages),
+					NotificationKind: wantKind,
 				}, resp)
 			})
 		})


### PR DESCRIPTION
Make successful Shoutrrr logs identify the notification type, and shorten Healthchecks success logs from `Successfully sent ...` to `Sent ...`. Notification metadata is assigned at the command and updater boundaries, leaving remote payloads, delivery and error behavior, and quiet output unchanged. Closes #959.
