### PR TITLE
ci: fix scheduled watches

### DIFF
--- a/scripts/github-actions/cloudflare-doc-watch/cases.go
+++ b/scripts/github-actions/cloudflare-doc-watch/cases.go
@@ -342,6 +342,7 @@ var allWatches = []config{
 		HistoryURL:     "https://github.com/cloudflare/cloudflare-docs/commits/production/src/content/docs/dns/zone-setups/reference/domain-status.mdx",
 		PageURL:        "https://developers.cloudflare.com/dns/zone-setups/reference/domain-status/index.md",
 		WatchedHeading: "# Zone status",
+		StopHeading:    "## On this page",
 		LineFilters: []string{
 			"^## ",
 		},
@@ -373,6 +374,7 @@ var allWatches = []config{
 		HistoryURL:     "https://github.com/cloudflare/cloudflare-docs/commits/production/src/content/docs/dns/zone-setups/reference/domain-status.mdx",
 		PageURL:        "https://developers.cloudflare.com/dns/zone-setups/reference/domain-status/index.md",
 		WatchedHeading: "# Zone status",
+		StopHeading:    "## On this page",
 		LineFilters: []string{
 			`^[A-Za-z][A-Za-z0-9_]*\[[^\]]+\]$`,
 		},

--- a/scripts/github-actions/cloudflare-doc-watch/main.go
+++ b/scripts/github-actions/cloudflare-doc-watch/main.go
@@ -32,6 +32,7 @@ type config struct {
 	HistoryURL         string
 	PageURL            string
 	WatchedHeading     string
+	StopHeading        string
 	LineFilters        []string
 	ExpectedLines      []string
 	WatchedSection     string
@@ -325,6 +326,9 @@ func checkTargets(cfg config) []string {
 		return targets
 	case cfg.WatchedHeading != "":
 		targets := []string{fmt.Sprintf("heading %q", cfg.WatchedHeading)}
+		if cfg.StopHeading != "" {
+			targets = append(targets, fmt.Sprintf("stop before heading %q", cfg.StopHeading))
+		}
 		for _, line := range cfg.ExpectedLines {
 			targets = append(targets, fmt.Sprintf("expected phrase %q", line))
 		}
@@ -408,7 +412,7 @@ func collectWatchItems(ctx context.Context, cfg config) ([]string, []string, err
 			actual := extractPlainTextLines(document)
 			return expected, actual, nil
 		}
-		actual, err := extractMarkdownSectionLines(document, cfg.WatchedHeading, cfg.LineFilters)
+		actual, err := extractMarkdownSectionLines(document, cfg.WatchedHeading, cfg.StopHeading, cfg.LineFilters)
 		return expected, actual, err
 	default:
 		document, err := fetchDocument(ctx, cfg.Repo, cfg.Ref, cfg.Path)
@@ -588,8 +592,8 @@ func normalizeMarkdownLine(value string) string {
 	return strings.TrimSpace(value)
 }
 
-func extractMarkdownSectionLines(document, watchedHeading string, lineFilters []string) ([]string, error) {
-	sectionLines, err := extractMarkdownSectionContent(document, watchedHeading)
+func extractMarkdownSectionLines(document, watchedHeading, stopHeading string, lineFilters []string) ([]string, error) {
+	sectionLines, err := extractMarkdownSectionContent(document, watchedHeading, stopHeading)
 	if err != nil {
 		return nil, err
 	}
@@ -626,7 +630,7 @@ func extractMarkdownSectionLines(document, watchedHeading string, lineFilters []
 	return filtered, nil
 }
 
-func extractMarkdownSectionContent(document, watchedHeading string) ([]string, error) {
+func extractMarkdownSectionContent(document, watchedHeading, stopHeading string) ([]string, error) {
 	lines := strings.Split(document, "\n")
 	headingIndex := -1
 	for index, line := range lines {
@@ -643,7 +647,7 @@ func extractMarkdownSectionContent(document, watchedHeading string) ([]string, e
 	sectionLines := make([]string, 0)
 	for _, line := range lines[headingIndex+1:] {
 		stripped := strings.TrimSpace(line)
-		if isHeadingAtOrAboveLevel(stripped, headingLevel) {
+		if (stopHeading != "" && stripped == stopHeading) || isHeadingAtOrAboveLevel(stripped, headingLevel) {
 			break
 		}
 		if stripped != "" {

--- a/scripts/github-actions/cloudflare-doc-watch/main_test.go
+++ b/scripts/github-actions/cloudflare-doc-watch/main_test.go
@@ -65,3 +65,40 @@ func TestExtractKeySetItemsRejectsNonObject(t *testing.T) {
 		t.Fatal("extractKeySetItems succeeded on a non-object base pointer")
 	}
 }
+
+func TestExtractMarkdownSectionLinesStopsAtConfiguredHeading(t *testing.T) {
+	t.Parallel()
+
+	document := `# Watched section
+
+## First item
+
+First details.
+
+## Second item
+
+Second details.
+
+## Stop here
+
+Outside the watched section.
+`
+	actual, err := extractMarkdownSectionLines(
+		document,
+		"# Watched section",
+		"## Stop here",
+		[]string{"^## "},
+	)
+	if err != nil {
+		t.Fatalf("extractMarkdownSectionLines returned error: %v", err)
+	}
+	want := []string{"## First item", "## Second item"}
+	if len(actual) != len(want) {
+		t.Fatalf("extractMarkdownSectionLines = %v, want %v", actual, want)
+	}
+	for index := range want {
+		if actual[index] != want[index] {
+			t.Fatalf("extractMarkdownSectionLines = %v, want %v", actual, want)
+		}
+	}
+}

--- a/scripts/github-actions/link-check/internal/external/config.go
+++ b/scripts/github-actions/link-check/internal/external/config.go
@@ -91,7 +91,8 @@ func defaultConfig() config {
 					// durable documentation targets, so probing them adds noise.
 					"https://one.one.one.one/cdn-cgi/trace",
 					"https://api.cloudflare.com/cdn-cgi/trace",
-					"https://api.cloudflare.com/client/v4/user/tokens/verify",
+					"https://api.cloudflare.com/client/v4/zones",
+					"https://api.cloudflare.com/client/v4/accounts/",
 					"https://token.actions.githubusercontent.com",
 					"https://cloudflare-dns.com/dns-query",
 					"https://api4.ipify.org",

--- a/scripts/github-actions/link-check/internal/external/run_test.go
+++ b/scripts/github-actions/link-check/internal/external/run_test.go
@@ -41,13 +41,35 @@ func TestCollectURLsKeepsSourceLocations(t *testing.T) {
 	}
 }
 
+func TestCollectURLsUsesDefaultOperationalEndpointExclusions(t *testing.T) {
+	root := t.TempDir()
+	testutil.WriteFile(t, root, "operational.go", strings.Join([]string{
+		`const zonesURL = "https://api.cloudflare.com/client/v4/zones"`,
+		`const wafListsURL = "https://api.cloudflare.com/client/v4/accounts/" + accountID + "/rules/lists"`,
+		`const docsURL = "https://developers.cloudflare.com/api/"`,
+	}, "\n"))
+
+	cfg := defaultConfig()
+	urls := collectURLs(
+		root,
+		[]string{"operational.go"},
+		cfg.Links.TargetURLs.IgnoreExact,
+		cfg.Links.TargetURLs.IgnorePatterns,
+	)
+
+	if len(urls) != 1 || urls[0].URL != "https://developers.cloudflare.com/api/" {
+		t.Fatalf("collected URLs = %#v, want only the durable documentation URL", urls)
+	}
+}
+
 func TestDefaultConfigIgnoresOperationalEndpoints(t *testing.T) {
 	cfg := defaultConfig()
 
 	want := []string{
 		"https://one.one.one.one/cdn-cgi/trace",
 		"https://api.cloudflare.com/cdn-cgi/trace",
-		"https://api.cloudflare.com/client/v4/user/tokens/verify",
+		"https://api.cloudflare.com/client/v4/zones",
+		"https://api.cloudflare.com/client/v4/accounts/",
 		"https://token.actions.githubusercontent.com",
 		"https://cloudflare-dns.com/dns-query",
 		"https://api4.ipify.org",


### PR DESCRIPTION
Update the external-link exclusions after the auth-error watch replaced the token-verification endpoint, so intentionally failing Cloudflare API probes are not treated as broken links. Add a configurable Markdown stop heading and configure the zone-status watches to stop before Cloudflare's generated `On this page` navigation while keeping catch-all filters for actual upstream additions. Verified with the root and both script-module test suites, module linters, and live targeted watches.
