### PR TITLE
docs: refine maintenance guides

### DIFF
--- a/docs/designs/guides/go-lint-suppressions.markdown
+++ b/docs/designs/guides/go-lint-suppressions.markdown
@@ -22,6 +22,7 @@ Write suppressions in the local form `//nolint:<linter> // reason`.
 - Keep the scope on the smallest code site that needs the exception.
 - Suppress one linter unless the same site needs inseparable suppressions.
 - Give a concrete local reason when the exception is not already obvious from nearby code.
+- Do not add semantically empty or misleading code solely to silence a linter; when the code is correct by an invariant the linter cannot see, use a precise suppression with a reason.
 - Do not use bare `//nolint`, `//nolint:all`, or file-wide suppression as normal practice.
 
 ## Narrowest Durable Home

--- a/docs/designs/guides/readme-writing.markdown
+++ b/docs/designs/guides/readme-writing.markdown
@@ -43,8 +43,7 @@ This is the README's governing rule; every section below is a corollary of it. O
 
 ## Fixed README Markers
 
-Use this fixed marker set only when it sharpens a reader's decision, expectation, or reading order; do not add markers mechanically. Keep each marker stable in meaning across the README.
-This README uses the fixed marker set below.
+Use this fixed marker set only when it sharpens a reader's decision, expectation, or reading order; do not add markers mechanically. Keep each marker stable in meaning across the README. This README uses the fixed marker set below.
 
 | Marker                            | Stable meaning                                  | Use when                                                                                                                                                                                  | Do not use when                                                                                                                                        |
 | --------------------------------- | ----------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |


### PR DESCRIPTION
Document that precise lint suppressions are preferable to misleading workaround code, and normalize an ordinary prose paragraph in the README-writing guide. Intentional badge and Leg-label source layouts remain unchanged.