### PR TITLE
fv: restore Lean verification CI with pinned elan

### DIFF
--- a/.github/workflows/lean-verify.yaml
+++ b/.github/workflows/lean-verify.yaml
@@ -16,6 +16,10 @@ on:
 permissions:
   contents: read
 
+env:
+  # renovate: datasource=github-releases depName=leanprover/elan
+  ELAN_VERSION: "v4.2.3"
+
 jobs:
   lean-verify:
     name: Lean Verify
@@ -35,21 +39,24 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: 🦦 Install Lean, build proofs and oracle, and reject any sorry
-        uses: leanprover/lean-action@38fbc41a8c28c4cbaec22d7f7de508ec2e7c0dd9 # v1.5.0
-        with:
-          lake-package-directory: "proofs"
-          build: "true"
-          # Warning and stray-IO hygiene: fail on any warning (incl. sorry/
-          # deprecations) or leftover `#eval`/`#print`/info output.
-          build-args: "--wfail --iofail"
-          test: "false"
-          lint: "false"
-          use-mathlib-cache: "false"
-          # Re-check every declaration with the independent nanoda kernel and
-          # reject any proof that depends on `sorryAx` (sorry/admit).
-          nanoda: "true"
-          nanoda-allow-sorry: "false"
+      - name: 🦦 Install Lean
+        run: |
+          curl --fail --location --show-error --silent \
+            --output "$RUNNER_TEMP/elan-init.tar.gz" \
+            "https://github.com/leanprover/elan/releases/download/${ELAN_VERSION}/elan-x86_64-unknown-linux-gnu.tar.gz"
+          tar --extract --gzip \
+            --file "$RUNNER_TEMP/elan-init.tar.gz" \
+            --directory "$RUNNER_TEMP"
+          "$RUNNER_TEMP/elan-init" \
+            -y \
+            --default-toolchain none \
+            --no-modify-path
+          echo "$HOME/.elan/bin" >> "$GITHUB_PATH"
+
+      - name: 🦦 Build proofs and oracle, and reject any sorry
+        working-directory: proofs
+        run: |
+          lake build --wfail --iofail
 
       - name: 🏗️ Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0

--- a/proofs/README.markdown
+++ b/proofs/README.markdown
@@ -13,10 +13,10 @@ The pinned toolchain version is in `proofs/lean-toolchain`. You need `elan`, `la
 ## Build and check the proofs
 
 ```sh
-cd proofs && lake build Hostid6
+cd proofs && lake build --wfail --iofail
 ```
 
-This type-checks every theorem; a `sorry` shows up as a build warning. CI enforces a no-`sorry` gate independently with the nanoda kernel (`nanoda-allow-sorry: false`), which rejects any proof depending on `sorryAx`, and with `lake build --wfail`.
+This builds every default target, including the `Hostid6` proofs and the `oracle` executable. CI uses `--wfail` to reject `sorry` and every other warning, and `--iofail` to reject unexpected informational output.
 
 ## Build and run the oracle
 
@@ -51,6 +51,6 @@ Changing `Derive` or any of its documented claims requires updating **all** of t
 Then verify:
 
 ```sh
-cd proofs && lake build Hostid6   # type-checks every theorem; warns on any sorry
+(cd proofs && lake build --wfail --iofail)
 HOSTID6_LEAN_ORACLE="$PWD/proofs/.lake/build/bin/oracle" go test -tags lean_oracle ./internal/hostid6/...
 ```


### PR DESCRIPTION
Replace `lean-action`, whose transitive cache actions violate the full-SHA policy, with a Renovate-managed elan installation. This drops the action's nanoda recheck while retaining the strict Lean build and Go differential test; Lean v4.31.0 and v4.32.1 both pass locally.
