### PR TITLE
feat: publish Docker images to GHCR

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -24,6 +24,7 @@ jobs:
     permissions:
       id-token: write # for cosign keyless signing via GitHub OIDC
       contents: read
+      packages: write # for pushing images and signatures to GitHub Container Registry
     steps:
       - name: 🛡️ Harden Runner
         uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
@@ -49,6 +50,13 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: 🔑 Log in to GitHub Container Registry
+        uses: docker/login-action@abd2ef45e78c5afb21d64d4ca52ee8550d9572c7 # v4.5.1
+        if: ${{ github.event_name != 'pull_request' }}
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: 🏷️ Fetch git tags for `git describe`
         run: "git fetch --force --prune --unshallow --tags"
       - name: 📝 Run `git describe` and save its output
@@ -58,7 +66,9 @@ jobs:
         uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
         id: meta
         with:
-          images: ${{ github.repository }}
+          images: |
+            ${{ github.repository }}
+            ghcr.io/${{ github.repository }}
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}
@@ -82,12 +92,31 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           annotations: ${{ steps.meta.outputs.annotations }}
           provenance: "mode=max"
+      - name: 🔎 Verify minimal image mirrors
+        if: ${{ github.event_name != 'pull_request' }}
+        run: |
+          docker buildx imagetools inspect "docker.io/favonia/cloudflare-ddns@${STEPS_BUILD_OUTPUTS_DIGEST}"
+          docker buildx imagetools inspect "ghcr.io/favonia/cloudflare-ddns@${STEPS_BUILD_OUTPUTS_DIGEST}"
+        env:
+          STEPS_BUILD_OUTPUTS_DIGEST: ${{ steps.build.outputs.digest }}
       - name: ✍️ Install Cosign
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
       - name: ✍️ Sign the minimal Docker images
         if: ${{ github.event_name == 'release' }}
         run: |
-          cosign sign --recursive --yes "favonia/cloudflare-ddns@${STEPS_BUILD_OUTPUTS_DIGEST}"
+          cosign sign --recursive --yes \
+            "docker.io/favonia/cloudflare-ddns@${STEPS_BUILD_OUTPUTS_DIGEST}" \
+            "ghcr.io/favonia/cloudflare-ddns@${STEPS_BUILD_OUTPUTS_DIGEST}"
+        env:
+          STEPS_BUILD_OUTPUTS_DIGEST: ${{ steps.build.outputs.digest }}
+      - name: 🔎 Verify the signed minimal Docker images
+        if: ${{ github.event_name == 'release' }}
+        run: |
+          cosign verify \
+            --certificate-identity "https://github.com/${GITHUB_REPOSITORY}/.github/workflows/build.yaml@${GITHUB_REF}" \
+            --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' \
+            "docker.io/favonia/cloudflare-ddns@${STEPS_BUILD_OUTPUTS_DIGEST}" \
+            "ghcr.io/favonia/cloudflare-ddns@${STEPS_BUILD_OUTPUTS_DIGEST}"
         env:
           STEPS_BUILD_OUTPUTS_DIGEST: ${{ steps.build.outputs.digest }}
 
@@ -96,7 +125,9 @@ jobs:
         uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
         id: meta-alpine
         with:
-          images: ${{ github.repository }}
+          images: |
+            ${{ github.repository }}
+            ghcr.io/${{ github.repository }}
           tags: |
             type=edge,suffix=-alpine
           annotations: |
@@ -119,3 +150,10 @@ jobs:
           labels: ${{ steps.meta-alpine.outputs.labels }}
           annotations: ${{ steps.meta-alpine.outputs.annotations }}
           provenance: "mode=max"
+      - name: 🔎 Verify alpine image mirrors
+        if: ${{ github.event_name != 'pull_request' && github.event_name != 'release' }}
+        run: |
+          docker buildx imagetools inspect "docker.io/favonia/cloudflare-ddns@${STEPS_BUILD_ALPINE_OUTPUTS_DIGEST}"
+          docker buildx imagetools inspect "ghcr.io/favonia/cloudflare-ddns@${STEPS_BUILD_ALPINE_OUTPUTS_DIGEST}"
+        env:
+          STEPS_BUILD_ALPINE_OUTPUTS_DIGEST: ${{ steps.build-alpine.outputs.digest }}

--- a/README.markdown
+++ b/README.markdown
@@ -94,7 +94,7 @@ docker run \
   favonia/cloudflare-ddns:1
 ```
 
-The GHCR mirror at `ghcr.io/favonia/cloudflare-ddns` (unreleased) will use the same image tags as `favonia/cloudflare-ddns`.
+The GHCR mirror at `ghcr.io/favonia/cloudflare-ddns` (unreleased) uses the same image tags as `favonia/cloudflare-ddns`.
 
 ⚠️ `PROXIED=true` does not change the proxy statuses of existing records. See [DNS and WAF Fallback Values](#dns-and-waf-fallback-values).
 

--- a/README.markdown
+++ b/README.markdown
@@ -47,6 +47,8 @@ A feature-rich and robust Cloudflare DDNS updater with a small Docker image. It 
     --certificate-oidc-issuer https://token.actions.githubusercontent.com
   ```
 
+  The GHCR mirror (unreleased) can be verified with the same command by replacing the image reference with `ghcr.io/favonia/cloudflare-ddns:1`.
+
   This only proves that the Docker image is from this repository, assuming that no one hacks into GitHub or the repository. It does not prove that the code itself is secure.
 
   </details>
@@ -91,6 +93,8 @@ docker run \
   -e PROXIED=true \
   favonia/cloudflare-ddns:1
 ```
+
+The GHCR mirror at `ghcr.io/favonia/cloudflare-ddns` (unreleased) will use the same image tags and platforms.
 
 ⚠️ `PROXIED=true` does not change the proxy statuses of existing records. See [DNS and WAF Fallback Values](#dns-and-waf-fallback-values).
 

--- a/README.markdown
+++ b/README.markdown
@@ -94,7 +94,7 @@ docker run \
   favonia/cloudflare-ddns:1
 ```
 
-The GHCR mirror at `ghcr.io/favonia/cloudflare-ddns` (unreleased) will use the same image tags and platforms.
+The GHCR mirror at `ghcr.io/favonia/cloudflare-ddns` (unreleased) will use the same image tags.
 
 ⚠️ `PROXIED=true` does not change the proxy statuses of existing records. See [DNS and WAF Fallback Values](#dns-and-waf-fallback-values).
 

--- a/README.markdown
+++ b/README.markdown
@@ -47,7 +47,7 @@ A feature-rich and robust Cloudflare DDNS updater with a small Docker image. It 
     --certificate-oidc-issuer https://token.actions.githubusercontent.com
   ```
 
-  The GHCR mirror (unreleased) can be verified with the same command by replacing the image reference with `ghcr.io/favonia/cloudflare-ddns:1`.
+  The GHCR mirror (unreleased) can be verified with the same command by replacing the image reference `favonia/cloudflare-ddns:1` with `ghcr.io/favonia/cloudflare-ddns:1`.
 
   This only proves that the Docker image is from this repository, assuming that no one hacks into GitHub or the repository. It does not prove that the code itself is secure.
 
@@ -94,7 +94,7 @@ docker run \
   favonia/cloudflare-ddns:1
 ```
 
-The GHCR mirror at `ghcr.io/favonia/cloudflare-ddns` (unreleased) will use the same image tags.
+The GHCR mirror at `ghcr.io/favonia/cloudflare-ddns` (unreleased) will use the same image tags as `favonia/cloudflare-ddns`.
 
 ⚠️ `PROXIED=true` does not change the proxy statuses of existing records. See [DNS and WAF Fallback Values](#dns-and-waf-fallback-values).
 


### PR DESCRIPTION
Publish the existing minimal and Alpine images to GHCR alongside Docker Hub, using the same tags, platforms, and build outputs. This keeps the current build and multi-platform signing model separate from the Docker GitHub Builder investigation in #1218; non-PR pushes verify both registry mirrors by digest, and releases sign and verify both image locations. The publishing and signature paths cannot run in pull requests because those builds do not push images.

Closes #1247.