### PR TITLE
fixup: allow redirects in Cloudflare trace detection

### DIFF
--- a/internal/provider/protocol/cloudflare_trace.go
+++ b/internal/provider/protocol/cloudflare_trace.go
@@ -119,7 +119,7 @@ func attemptCloudflareTrace(
 	ipFamily ipnet.Family,
 	defaultPrefixLen int,
 ) traceAttemptResult {
-	parsedURL, err := url.Parse(traceURL)
+	_, err := url.Parse(traceURL)
 	if err != nil {
 		return traceAttemptResult{
 			status:   traceAttemptFailed,
@@ -138,7 +138,7 @@ func attemptCloudflareTrace(
 		method:        http.MethodGet,
 		maxReadLength: traceMaxReadLength,
 	}
-	body, err := c.getBodyOnce(ctx)
+	body, finalURL, err := c.getBodyWithoutRetry(ctx)
 	if err != nil {
 		if ctx.Err() != nil {
 			return traceAttemptResult{ //nolint:exhaustruct // Cancellation is not a definite failure.
@@ -160,12 +160,12 @@ func attemptCloudflareTrace(
 	fields := parseTraceBody(body)
 	var warnings []traceWarningKind
 
-	// Validate h: integrity check on the response source.
+	// Validate h against the final request host, which can change after redirects.
 	// A missing h is unexpected but tolerated; a mismatched h is a hard failure.
 	switch {
 	case fields.h == "":
 		warnings = append(warnings, traceWarningMissingH)
-	case fields.h != parsedURL.Host:
+	case fields.h != finalURL.Host:
 		return traceAttemptResult{
 			status:   traceAttemptFailed,
 			rawData:  NewUnavailableDetectionResult(),
@@ -173,7 +173,7 @@ func attemptCloudflareTrace(
 			failure: traceFailure{ //nolint:exhaustruct // This failure compares the observed and expected hosts.
 				kind:     traceFailureMismatchedH,
 				observed: fields.h,
-				expected: parsedURL.Host,
+				expected: finalURL.Host,
 			},
 		}
 	}

--- a/internal/provider/protocol/cloudflare_trace_internal_test.go
+++ b/internal/provider/protocol/cloudflare_trace_internal_test.go
@@ -60,6 +60,64 @@ func TestAttemptCloudflareTraceValid(t *testing.T) {
 	require.Equal(t, traceFailure{}, result.failure) //nolint:exhaustruct // The zero value means no failure.
 }
 
+// These cases catch redirect suppression, validation against the original host,
+// and accidentally accepting a mismatched h after a redirect.
+func TestAttemptCloudflareTraceRedirectHost(t *testing.T) {
+	t.Parallel()
+
+	for name, tc := range map[string]struct {
+		crossHost  bool
+		wrongHost  bool
+		wantStatus traceAttemptStatus
+	}{
+		"same-host":              {false, false, traceAttemptSucceeded},
+		"cross-host":             {true, false, traceAttemptSucceeded},
+		"original-host-rejected": {true, true, traceAttemptFailed},
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			var originalHost string
+			target := newTraceAttemptServer(t, ipnet.IP4, func(req *http.Request) string {
+				host := req.Host
+				if tc.wrongHost {
+					host = originalHost
+				}
+				return fmt.Sprintf("h=%s\nip=192.0.2.1\nwarp=off\n", host)
+			})
+			source := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+				if req.URL.Path == "/start" {
+					location := "/cdn-cgi/trace"
+					if tc.crossHost {
+						location = target.URL + location
+					}
+					http.Redirect(w, req, location, http.StatusFound)
+					return
+				}
+				w.Header().Set("Content-Type", "text/plain")
+				_, _ = fmt.Fprintf(w, "h=%s\nip=192.0.2.1\nwarp=off\n", originalHost)
+			}))
+			t.Cleanup(source.Close)
+			originalHost = source.Listener.Addr().String()
+
+			result := attemptCloudflareTrace(context.Background(), source.URL+"/start", ipnet.IP4, 24)
+
+			require.Equal(t, tc.wantStatus, result.status)
+			require.Empty(t, result.warnings)
+			if tc.wantStatus == traceAttemptSucceeded {
+				require.Equal(t, NewKnownDetectionResult([]ipnet.RawEntry{
+					ipnet.RawEntryFrom(netip.MustParseAddr("192.0.2.1"), 24),
+				}), result.rawData)
+			} else {
+				require.Equal(t, NewUnavailableDetectionResult(), result.rawData)
+				require.Equal(t, traceFailureMismatchedH, result.failure.kind)
+				expectedHost := target.Listener.Addr().String()
+				require.Equal(t, expectedHost, result.failure.expected)
+				require.Equal(t, originalHost, result.failure.observed)
+			}
+		})
+	}
+}
+
 func TestAttemptCloudflareTraceTransportFailure(t *testing.T) {
 	t.Parallel()
 

--- a/internal/provider/protocol/httpcore.go
+++ b/internal/provider/protocol/httpcore.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 
 	"github.com/hashicorp/go-retryablehttp"
 
@@ -61,34 +62,37 @@ func (h httpCore) getBodyWithRetryableClient(
 	return body, true
 }
 
-// getBodyOnce performs one application-level request and rejects redirects so
-// one hedged attempt cannot move beyond its configured endpoint. It clones the
-// shared client before changing its redirect policy, leaving other providers
-// unchanged.
-func (h httpCore) getBodyOnce(ctx context.Context) ([]byte, error) {
+// getBodyWithoutRetry currently serves only attemptCloudflareTrace, whose
+// hedging coordinator schedules alternative attempts. It uses the shared
+// IP-family client without adding retries or changing client policy; redirects
+// and transport-level retries can still send additional requests. The caller
+// must bound ctx and select a supported IP family.
+//
+// On success it returns the size-limited body and final request URL after any
+// redirects, with the response body closed. On failure both returned values are
+// nil. It does not reject HTTP status codes: Cloudflare Trace validates the body
+// and its h field against the final URL. Other callers must define their own
+// status and body validation before reusing this helper.
+func (h httpCore) getBodyWithoutRetry(ctx context.Context) ([]byte, *url.URL, error) {
 	req, err := http.NewRequestWithContext(ctx, h.method, h.url, h.requestBody)
 	if err != nil {
-		return nil, fmt.Errorf("failed to prepare request: %w", err)
+		return nil, nil, fmt.Errorf("failed to prepare request: %w", err)
 	}
 	for header, value := range h.additionalHeaders {
 		req.Header.Set(header, value)
 	}
 
-	client := *SharedSplitClient(h.ipFamily)
-	client.CheckRedirect = func(*http.Request, []*http.Request) error {
-		return http.ErrUseLastResponse
-	}
-	resp, err := client.Do(req)
+	resp, err := SharedSplitClient(h.ipFamily).Do(req)
 	if err != nil {
-		return nil, fmt.Errorf("request failed: %w", err)
+		return nil, nil, fmt.Errorf("request failed: %w", err)
 	}
 	defer resp.Body.Close()
 
 	body, err := h.readBody(resp.Body)
 	if err != nil {
-		return nil, fmt.Errorf("failed to read response: %w", err)
+		return nil, nil, fmt.Errorf("failed to read response: %w", err)
 	}
-	return body, nil
+	return body, resp.Request.URL, nil
 }
 
 func (h httpCore) readBody(reader io.Reader) ([]byte, error) {

--- a/internal/provider/protocol/httpcore_internal_test.go
+++ b/internal/provider/protocol/httpcore_internal_test.go
@@ -23,7 +23,7 @@ var (
 	errReadFailure      = errors.New("read failure")
 )
 
-func TestHTTPCoreGetBodyOnceDoesNotRetry(t *testing.T) {
+func TestHTTPCoreGetBodyWithoutRetryDoesNotRetry(t *testing.T) {
 	t.Parallel()
 
 	var requests atomic.Int64
@@ -38,18 +38,19 @@ func TestHTTPCoreGetBodyOnceDoesNotRetry(t *testing.T) {
 		url:      server.URL,
 		method:   http.MethodGet,
 	}
-	_, err := h.getBodyOnce(context.Background())
+	_, _, err := h.getBodyWithoutRetry(context.Background())
 
 	require.NoError(t, err)
 	require.EqualValues(t, 1, requests.Load())
 }
 
-func TestHTTPCoreGetBodyOnceDoesNotFollowRedirects(t *testing.T) {
+func TestHTTPCoreGetBodyWithoutRetryFollowsRedirects(t *testing.T) {
 	t.Parallel()
 
 	var sourceRequests atomic.Int64
 	var targetRequests atomic.Int64
-	target := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, "redirected body")
 		targetRequests.Add(1)
 	}))
 	t.Cleanup(target.Close)
@@ -65,14 +66,16 @@ func TestHTTPCoreGetBodyOnceDoesNotFollowRedirects(t *testing.T) {
 		url:      source.URL,
 		method:   http.MethodGet,
 	}
-	_, err := h.getBodyOnce(context.Background())
+	body, finalURL, err := h.getBodyWithoutRetry(context.Background())
 
 	require.NoError(t, err)
+	require.Equal(t, "redirected body", string(body))
+	require.Equal(t, target.URL, finalURL.String())
 	require.EqualValues(t, 1, sourceRequests.Load())
-	require.EqualValues(t, 0, targetRequests.Load())
+	require.EqualValues(t, 1, targetRequests.Load())
 }
 
-func TestHTTPCoreGetBodyOnceAppliesAdditionalHeaders(t *testing.T) {
+func TestHTTPCoreGetBodyWithoutRetryAppliesAdditionalHeaders(t *testing.T) {
 	t.Parallel()
 
 	const headerName = "X-Cloudflare-Trace-Test"
@@ -92,22 +95,22 @@ func TestHTTPCoreGetBodyOnceAppliesAdditionalHeaders(t *testing.T) {
 			headerName: headerValue,
 		},
 	}
-	body, err := h.getBodyOnce(context.Background())
+	body, _, err := h.getBodyWithoutRetry(context.Background())
 
-	// Mutation caught: omitting configured headers from the one-shot request path.
+	// Mutation caught: omitting configured headers from the request path without retries.
 	require.NoError(t, err)
 	require.Equal(t, []byte("response body"), body)
 	require.Equal(t, headerValue, (<-receivedHeaders).Get(headerName))
 }
 
-func TestHTTPCoreGetBodyOnceReportsRequestPreparationFailure(t *testing.T) {
+func TestHTTPCoreGetBodyWithoutRetryReportsRequestPreparationFailure(t *testing.T) {
 	t.Parallel()
 
 	h := httpCore{ //nolint:exhaustruct // The invalid method fails before transport setup matters.
 		url:    "http://example.com/",
 		method: "GET\n",
 	}
-	body, err := h.getBodyOnce(context.Background())
+	body, _, err := h.getBodyWithoutRetry(context.Background())
 
 	// Mutation caught: losing the request-preparation category while propagating constructor errors.
 	require.Nil(t, body)
@@ -129,13 +132,14 @@ type roundTripperFunc func(*http.Request) (*http.Response, error)
 
 func (f roundTripperFunc) RoundTrip(req *http.Request) (*http.Response, error) { return f(req) }
 
-func TestHTTPCoreGetBodyOnceClosesResponseBody(t *testing.T) { //nolint:paralleltest // Mutates sharedSplitClient.
+func TestHTTPCoreGetBodyWithoutRetryClosesResponseBody(t *testing.T) { //nolint:paralleltest // Mutates sharedSplitClient.
 	const testFamily ipnet.Family = 99
 	var closed atomic.Bool
 	sharedSplitClient[testFamily] = &http.Client{ //nolint:exhaustruct // Test client needs only its transport.
-		Transport: roundTripperFunc(func(*http.Request) (*http.Response, error) {
-			return &http.Response{ //nolint:exhaustruct // Test response needs only status and body.
+		Transport: roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+			return &http.Response{ //nolint:exhaustruct // Test response needs status, request, and body.
 				StatusCode: http.StatusOK,
+				Request:    req,
 				Body: trackingReadCloser{
 					Reader: strings.NewReader("response body"),
 					closed: &closed,
@@ -150,14 +154,14 @@ func TestHTTPCoreGetBodyOnceClosesResponseBody(t *testing.T) { //nolint:parallel
 		url:      "http://example.com/",
 		method:   http.MethodGet,
 	}
-	body, err := h.getBodyOnce(context.Background())
+	body, _, err := h.getBodyWithoutRetry(context.Background())
 
 	require.NoError(t, err)
 	require.Equal(t, []byte("response body"), body)
 	require.True(t, closed.Load())
 }
 
-func TestHTTPCoreGetBodyOnceReportsTransportFailure(t *testing.T) { //nolint:paralleltest // Mutates sharedSplitClient.
+func TestHTTPCoreGetBodyWithoutRetryReportsTransportFailure(t *testing.T) { //nolint:paralleltest // Mutates sharedSplitClient.
 	const testFamily ipnet.Family = 100
 	sharedSplitClient[testFamily] = &http.Client{ //nolint:exhaustruct // Test client needs only its transport.
 		Transport: roundTripperFunc(func(*http.Request) (*http.Response, error) {
@@ -171,15 +175,15 @@ func TestHTTPCoreGetBodyOnceReportsTransportFailure(t *testing.T) { //nolint:par
 		url:      "http://example.com/",
 		method:   http.MethodGet,
 	}
-	body, err := h.getBodyOnce(context.Background())
+	body, _, err := h.getBodyWithoutRetry(context.Background())
 
-	// Mutation caught: swallowing or misclassifying a one-shot transport failure.
+	// Mutation caught: swallowing or misclassifying a transport failure.
 	require.Nil(t, body)
 	require.ErrorIs(t, err, errTransportFailure)
 	require.ErrorContains(t, err, "request failed")
 }
 
-func TestHTTPCoreGetBodyOnceReportsReadFailureAndClosesBody(t *testing.T) { //nolint:paralleltest // Mutates sharedSplitClient.
+func TestHTTPCoreGetBodyWithoutRetryReportsReadFailureAndClosesBody(t *testing.T) { //nolint:paralleltest // Mutates sharedSplitClient.
 	const testFamily ipnet.Family = 101
 	var closed atomic.Bool
 	sharedSplitClient[testFamily] = &http.Client{ //nolint:exhaustruct // Test client needs only its transport.
@@ -200,7 +204,7 @@ func TestHTTPCoreGetBodyOnceReportsReadFailureAndClosesBody(t *testing.T) { //no
 		url:      "http://example.com/",
 		method:   http.MethodGet,
 	}
-	body, err := h.getBodyOnce(context.Background())
+	body, _, err := h.getBodyWithoutRetry(context.Background())
 
 	// Mutation caught: swallowing or misclassifying a read failure, or leaking its response body.
 	require.Nil(t, body)


### PR DESCRIPTION
Let Cloudflare Trace follow redirects to obtain a valid trace response instead of parsing the redirect response as trace data. Scheduling each endpoint once does not require limiting an attempt to one HTTP request; redirects remain subject to the existing detection deadline. Compare the response’s h field against the final request host so redirects across hosts work with the existing host validation.